### PR TITLE
CharacterInfo API access mask compatability and legacy deprecation

### DIFF
--- a/src/Api/Eve/CharacterInfo.php
+++ b/src/Api/Eve/CharacterInfo.php
@@ -59,16 +59,17 @@ class CharacterInfo extends Base
             $this->_update_character_info($result);
 
         } else {
-            // Init access check used by Pheal
-            $access_check = new EveApiAccess();
-
             // Check if key does not have access to authenticated CharacterInfo
             try {
                 // use 'char' scope for check instead of 'eve' to test access
-                $access_check->check('char', 'CharacterInfo', $this->api_info->info->type, $this->api_info->info->accessMask);
+                (new EveApiAccess)->check(
+                    'char',
+                    'CharacterInfo',
+                    $this->api_info->info->type,
+                    $this->api_info->info->accessMask);
 
             // Downgrade to public api if access check failed
-            } catch (\Exception $ex) {
+            } catch (\Pheal\Exceptions\AccessException $ex) {
                 // Get pheal without API key.
                 // Maybe update the Seat\Eveapi\Api\Base class
                 // to give an option to override key_id and v_code handling

--- a/src/Api/Eve/CharacterInfo.php
+++ b/src/Api/Eve/CharacterInfo.php
@@ -24,6 +24,7 @@ namespace Seat\Eveapi\Api\Eve;
 use Seat\Eveapi\Api\Base;
 use Seat\Eveapi\Models\Eve\CharacterInfo as CharacterInfoModel;
 use Seat\Eveapi\Models\Eve\CharacterInfoEmploymentHistory;
+use Seat\Eveapi\Helpers\EveApiAccess;
 
 /**
  * Class CharacterInfo
@@ -58,6 +59,28 @@ class CharacterInfo extends Base
             $this->_update_character_info($result);
 
         } else {
+            // Init access check used by Pheal
+            $access_check = new EveApiAccess();
+
+            // Check if key does not have access to authenticated CharacterInfo
+            try {
+                // use 'char' scope for check instead of 'eve' to test access
+                $access_check->check('char', 'CharacterInfo', $this->api_info->info->type, $this->api_info->info->accessMask);
+
+            // Downgrade to public api if access check failed
+            } catch (\Exception $ex) {
+                // Get pheal without API key.
+                // Maybe update the Seat\Eveapi\Api\Base class
+                // to give an option to override key_id and v_code handling
+                $pheal = $this->pheal_instance->getPheal();
+
+                // Set access and scope
+                $pheal->setAccess(
+                    $this->api_info->info->type,
+                    $this->api_info->info->accessMask);
+
+                $pheal->scope = $this->scope;
+            }
 
             // Otherwise, update all of the character on the
             // ApiKey that we got as normal


### PR DESCRIPTION
**Issue Background**
`CharacterInfo` will return 3 different datasets depending on an access mask:

* No access mask/API Key provides public info
* Access mask `8388608` provides public info + skill training summary + ship
* Access mask `16777216` provides public info + skill training summary + ship + location + wallet balance

See Docs:
http://eveonline-third-party-documentation.readthedocs.io/en/latest/xmlapi/eve/eve_characterinfo.html 

`CharacterInfo` api updates are performed along with all other authenticated API calls. Since `CharacterInfo` is part of the `eve` scope access checks were not being performed against the `char` scope. API keys that did not have `CharacterInfo` access would generate the following EVE API error because authenticated api updates always send a keyID and vCode.

```
A connection exception occured to the API server. 403:Client error: `GET https://api.eveonline.com/eve/CharacterInfo.xml.aspx?characterID=93118464&keyID=XXXXXX&vCode=YYYYYYYYY` resulted in a `403 Forbidden` response:
<?xml version='1.0' encoding='UTF-8'?>
<eveapi version="2">
 <currentTime>2016-08-23 11:11:13</currentTime>
 <error (truncated...)
```

API Keys with access masks that did not have `CharacterInfo` access would not be able to be to update key data for characters resulting in exceptions when viewing the character sheet at `/character/view/sheet/<characterid>`

**Resolution**
During `CharacterInfo` API updates, an access check is made to see if the API call can be made with authenticated info. If the access check fails, the API call is downgraded to the public version.

**Legacy Update**
It was also discovered that legacy code was still contained in this class. In a previous version of SeAT this class was used to fetch public API data for characters. After consulting with @leonjza it was decided that this legacy support should be removed. If this functionality is needed in the future then support can be added again.