### PR TITLE
Fix for RefTypesModel->refTypeName not updating properly.

### DIFF
--- a/src/Api/Eve/RefTypes.php
+++ b/src/Api/Eve/RefTypes.php
@@ -43,15 +43,9 @@ class RefTypes extends Base
 
         foreach ($result->refTypes as $ref_type) {
 
-            $ref_type = RefTypesModel::firstOrCreate([
-                'refTypeID' => $ref_type->refTypeID,
-            ]);
-
-            $ref_type->fill([
-                'refTypeName' => $ref_type->refTypeName
-            ]);
-
-            $ref_type->save();
+            RefTypesModel::firstOrNew(['refTypeID' => $ref_type->refTypeID])
+                ->fill(['refTypeName' => $ref_type->refTypeName])
+                ->save();
         }
 
         return;


### PR DESCRIPTION
RefTypeNames were not being associated in the journal. It was determined that during EVE API updates the refTypeName was not being populated.

Testing was completed with new RefTypes and existing.