### PR TITLE
avoid jump clone duplication

### DIFF
--- a/src/Api/Character/CharacterSheet.php
+++ b/src/Api/Character/CharacterSheet.php
@@ -133,13 +133,16 @@ class CharacterSheet extends Base
             // Lets loop over the clones for the character.
             foreach ($result->jumpClones as $jump_clone) {
 
-                CharacterSheetJumpClone::create([
-                    'characterID' => $character->characterID,
-                    'jumpCloneID' => $jump_clone->jumpCloneID,
-                    'typeID'      => $jump_clone->typeID,
-                    'locationID'  => $jump_clone->locationID,
-                    'cloneName'   => $jump_clone->cloneName
-                ]);
+                // avoid entry duplication if more than a worker is working on the same character
+                CharacterSheetJumpClone::updateOrCreate([
+                        'jumpCloneID' => $jump_clone->jumpCloneID
+                    ],
+                    [
+                        'characterID' => $character->characterID,
+                        'typeID' => $jump_clone->typeID,
+                        'locationID' => $jump_clone->locationID,
+                        'cloneName' => $jump_clone->cloneName
+                    ]);
 
             } // Foreach JumpClone
 


### PR DESCRIPTION
Since many worker can work on the same characterID (when multiple keys reference same character),
even if we delete all existing clone for a specific character, a constraint issue can occured.

In order to prevent this, replace the simple create statement by a create or update.