### PR TITLE
optimise dashboard query for top mail badge

### DIFF
--- a/src/database/migrations/2017_08_04_213800_add__sent_date_index_character_mail_messages_table.php
+++ b/src/database/migrations/2017_08_04_213800_add__sent_date_index_character_mail_messages_table.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSentDateIndexCharacterMailMessagesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('character_mail_messages', function (Blueprint $table) {
+
+            $table->index('sentDate');
+
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('character_mail_messages', function (Blueprint $table) {
+
+            $table->dropIndex('character_mail_messages_sentdate_index');
+
+        });
+    }
+}


### PR DESCRIPTION
optimise dashboard query for top mail badge by adding an index on sentDate.

This index will be massively used by the order by instruction.

This is used by eveseat/services#24