### PR TITLE
fix duplicate entry error while inserting jump clones

### DIFF
--- a/src/Api/Character/Clones.php
+++ b/src/Api/Character/Clones.php
@@ -93,11 +93,16 @@ class Clones extends Base
             // Lets loop over the implants and create them
             foreach ($result->implants as $implant) {
 
-                CharacterSheetImplants::create([
-                    'characterID' => $character->characterID,
-                    'typeID'      => $implant->typeID,
-                    'typeName'    => $implant->typeName,
-                ]);
+                // avoid entry duplication if more than a worker is working on the same character
+                CharacterSheetJumpClone::updateOrCreate([
+                        'jumpCloneID' => $jump_clone->jumpCloneID,
+                    ],
+                    [
+                        'characterID' => $character->characterID,
+                        'typeID' => $jump_clone->typeID,
+                        'locationID' => $jump_clone->locationID,
+                        'cloneName' => $jump_clone->cloneName,
+                    ]);
 
             } // Foreach Implants
 


### PR DESCRIPTION
Probably because of multiple API keys for the same character being updated at the same time, an error (randomly) occurs while updating jump clones.

Possible fix for https://github.com/eveseat/seat/issues/220