### PR TITLE
Fix https://github.com/eveseat/seat/issues/346

### DIFF
--- a/src/Jobs/PlanetaryInteraction/Corporation/CustomsOfficeLocations.php
+++ b/src/Jobs/PlanetaryInteraction/Corporation/CustomsOfficeLocations.php
@@ -57,6 +57,11 @@ class CustomsOfficeLocations extends EsiBase
     /**
      * @var array
      */
+    protected $roles = ['Accountant'];
+
+    /**
+     * @var array
+     */
     protected $tags = ['corporation', 'customs_offices', 'locations'];
 
     /**


### PR DESCRIPTION
Of all the things, apparently viewing customs office locations requires the accountant role.
Fixes https://github.com/eveseat/seat/issues/346