### PR TITLE
fix(mail): Add missing cast definition on MailHeader

### DIFF
--- a/src/Models/Mail/MailHeader.php
+++ b/src/Models/Mail/MailHeader.php
@@ -99,6 +99,13 @@ class MailHeader extends Model
     protected $primaryKey = null;
 
     /**
+     * @var array
+     */
+    protected $casts = [
+        'labels' => 'array',
+    ];
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
     public function body()


### PR DESCRIPTION
Labels field had no cast whereas we're storing them as a json array. Initial fix introduced with
eveseat/eveapi#ace3516 result in exception due to that missing cast in the model.

Closes eveseat/seat#414