### PR TITLE
fix(jump clones): Display name of player structure

### DIFF
--- a/src/Models/Clones/CharacterJumpClone.php
+++ b/src/Models/Clones/CharacterJumpClone.php
@@ -24,6 +24,7 @@ namespace Seat\Eveapi\Models\Clones;
 
 use Illuminate\Database\Eloquent\Model;
 use Seat\Eveapi\Models\Sde\StaStation;
+use Seat\Eveapi\Models\Universe\UniverseStructure;
 use Seat\Eveapi\Traits\HasCompositePrimaryKey;
 
 /**
@@ -114,6 +115,6 @@ class CharacterJumpClone extends Model
         if ($this->location_type == 'station')
             return $this->belongsTo(StaStation::class, 'location_id', 'stationID');
 
-        return $this->belongsTo(StaStation::class, 'location_id', 'stationID');
+        return $this->belongsTo(UniverseStructure::class, 'location_id', 'structure_id');
     }
 }

--- a/src/Models/Sde/StaStation.php
+++ b/src/Models/Sde/StaStation.php
@@ -48,4 +48,35 @@ class StaStation extends Model
      */
     protected $primaryKey = 'stationID';
 
+    /**
+     * @return int
+     */
+    public function getStructureIdAttribute()
+    {
+        return $this->stationID;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSolarSystemIdAttribute()
+    {
+        return $this->solarSystemID;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTypeIdAttribute()
+    {
+        return $this->stationTypeID;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameAttribute()
+    {
+        return $this->stationName;
+    }
 }


### PR DESCRIPTION
Fix character jump clone model relation to target universe structure instead StaStation when
location_type field has a value of structure.

Closes eveseat/seat#397