### PR TITLE
fix(corporation tracking): fix last location column

### DIFF
--- a/src/Models/Corporation/CorporationMemberTracking.php
+++ b/src/Models/Corporation/CorporationMemberTracking.php
@@ -24,6 +24,9 @@ namespace Seat\Eveapi\Models\Corporation;
 
 use Illuminate\Database\Eloquent\Model;
 use Seat\Eveapi\Models\Sde\InvType;
+use Seat\Eveapi\Models\Sde\MapDenormalize;
+use Seat\Eveapi\Models\Sde\StaStation;
+use Seat\Eveapi\Models\Universe\UniverseStructure;
 use Seat\Eveapi\Traits\HasCompositePrimaryKey;
 use Seat\Web\Models\User;
 
@@ -203,5 +206,21 @@ class CorporationMemberTracking extends Model
     {
 
         return $this->belongsTo(User::class, 'character_id', 'id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function location()
+    {
+        // System range
+        if ($this->location_id >= 30000001 && $this->location_id <= 31002604)
+            return $this->belongsTo(MapDenormalize::class, 'location_id', 'itemID');
+
+        // Station range
+        if ($this->location_id >= 60000000 && $this->location_id <= 64000000)
+            return $this->belongsTo(StaStation::class, 'location_id', 'stationID');
+
+        return $this->belongsTo(UniverseStructure::class, 'location_id', 'structure_id');
     }
 }

--- a/src/Models/Sde/MapDenormalize.php
+++ b/src/Models/Sde/MapDenormalize.php
@@ -157,9 +157,47 @@ class MapDenormalize extends Model
         return $this->belongsTo(InvType::class, 'typeID', 'typeID');
     }
 
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
     public function sovereignty()
     {
 
         return $this->hasOne(SovereigntyMap::class, 'system_id', 'itemID');
+    }
+
+    /**
+     * @return int
+     */
+    public function getStructureIdAttribute()
+    {
+        return $this->structure_id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSolarSystemIdAttribute()
+    {
+        if (! is_null($this->solarSystemID))
+            return $this->solarSystemID;
+
+        return $this->itemID;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTypeIdAttribute()
+    {
+        return $this->typeID;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameAttribute()
+    {
+        return $this->itemName;
     }
 }

--- a/src/Models/Sde/StaStation.php
+++ b/src/Models/Sde/StaStation.php
@@ -48,4 +48,35 @@ class StaStation extends Model
      */
     protected $primaryKey = 'stationID';
 
+    /**
+     * @return int
+     */
+    public function getStructureIdAttribute()
+    {
+        return $this->stationID;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSolarSystemIdAttribute()
+    {
+        return $this->solarSystemID;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTypeIdAttribute()
+    {
+        return $this->stationTypeID;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNameAttribute()
+    {
+        return $this->stationName;
+    }
 }


### PR DESCRIPTION
Add missing relation between corporation member tracking to universe structure, station and map
tables.

Provide attributes based on universe structure in order to ensure parity between all three
data source.

Show resolved location name instead location ID and display "Unknown Location" if no match.

Closes eveseat/seat#374