### PR TITLE
feat(mining): use ore materials to compute amount instead itself

### DIFF
--- a/src/Models/Industry/CharacterMining.php
+++ b/src/Models/Industry/CharacterMining.php
@@ -61,6 +61,18 @@ class CharacterMining extends Model
         if (is_null($this->type))
             return 0.0;
 
+        // in case the type is containing materials - attempt to retrieve their price
+        if ($this->type->materials->count() > 0)
+            return $this->quantity * $this->type->materials->sum(function ($material) {
+                if (is_null($material->type))
+                    return 0.0;
+
+                if (is_null($material->type->prices))
+                    return 0.0;
+
+                return $material->quantity * $material->type->prices->average_price;
+            });
+
         if (is_null($this->type->prices))
             return 0.0;
 

--- a/src/Models/Sde/InvType.php
+++ b/src/Models/Sde/InvType.php
@@ -157,6 +157,14 @@ class InvType extends Model
     }
 
     /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function materials()
+    {
+        return $this->hasMany(InvTypeMaterial::class, 'typeID', 'typeID');
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function group()

--- a/src/Models/Sde/InvTypeMaterial.php
+++ b/src/Models/Sde/InvTypeMaterial.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eveapi\Models\Sde;
+
+use Illuminate\Database\Eloquent\Model;
+use Seat\Eveapi\Traits\HasCompositePrimaryKey;
+use Seat\Eveapi\Traits\IsReadOnly;
+
+/**
+ * Class InvTypeMaterial.
+ * @package Seat\Eveapi\Models\Sde
+ */
+class InvTypeMaterial extends Model
+{
+    use IsReadOnly;
+    use HasCompositePrimaryKey;
+
+    /**
+     * @var string
+     */
+    protected $table = 'invTypeMaterials';
+
+    /**
+     * @var string
+     */
+    protected $primaryKey = ['typeID', 'materialTypeID'];
+
+    /**
+     * InvType related to the current material.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function type()
+    {
+
+        return $this->hasOne(InvType::class, 'typeID', 'materialTypeID');
+    }
+
+    /**
+     * InvType composed by the current material.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function compose()
+    {
+        return $this->belongsTo(InvType::class, 'typeID', 'typeID');
+    }
+}


### PR DESCRIPTION
Since moon ore is quite recent, provided orders prices average and adjusted are quite wrong. In
order to provide more accurate price, alter the amount formula to be based on materials.