### PR TITLE
fix(token management): Revoke access_token when it does not match with client

### DIFF
--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -222,8 +222,10 @@ abstract class EsiBase implements ShouldQueue
             // If the token can't login and we get an HTTP 400 together with
             // and error message stating that this is an invalid_token, remove
             // the token from SeAT.
-            if ($exception->getEsiResponse()->getErrorCode() == 400 &&
-                $exception->getEsiResponse()->error() == 'invalid_token: The refresh token is expired.') {
+            if ($exception->getEsiResponse()->getErrorCode() == 400 && in_array($exception->getEsiResponse()->error(), [
+                    'invalid_token: The refresh token is expired.',
+                    'invalid_token: The refresh token does not match the client specified.',
+                ])) {
 
                 // Remove the invalid token
                 $this->token->delete();


### PR DESCRIPTION
Currently, we're only revoking token which have expire. Sometime, user may have to change their
client app which will result to denied access using the previously recorded tokens.