### PR TITLE
fix(jobs): Fix required role for extraction job

### DIFF
--- a/src/Jobs/Industry/Corporation/Mining/Extractions.php
+++ b/src/Jobs/Industry/Corporation/Mining/Extractions.php
@@ -54,7 +54,7 @@ class Extractions extends EsiBase
     /**
      * @var array
      */
-    protected $roles = ['Structure_Manager'];
+    protected $roles = ['Station_Manager'];
 
     /**
      * @var array


### PR DESCRIPTION
Fix a typo which was checking if the character has `Structure_Manager` role whereas it should be
`Station_Manager`