### PR TITLE
Set Historical Prices for mined ore:

### DIFF
--- a/src/Jobs/Industry/Character/Mining.php
+++ b/src/Jobs/Industry/Character/Mining.php
@@ -118,9 +118,10 @@ class Mining extends EsiBase
                         'quantity' => $delta_quantity,
                     ]);
 
-                    $this->getHistoricalPrice($ledger_entry->type_id, $ledger_entry->date);
-
                 }
+
+                // Set Historical Price
+                $this->getHistoricalPrice($ledger_entry->type_id, $ledger_entry->date);
 
             });
 


### PR DESCRIPTION
with removing of eager-loading ore value in commits: https://github.com/eveseat/web/commit/794edd4e823bcdc4cc0d99dc05e6c11ea9e9c8e0#diff-22011822c62a614039762bc1627bbd3bL55 and https://github.com/eveseat/services/pull/68/files#diff-0a192c3f7ec8a7bcc3181ae3229a931bL55
the prices for already existing mining entries would never be set and
would result in 0 rows. Moving the setting out of the `if($delta_quantity != 0)`
clause sets/gets the historical price for the type on this day.