### PR TITLE
feat(tests): Provide initial tests stage for Alliance Jobs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,22 @@
       "Seat\\Eveapi\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Seat\\Eveapi\\Tests\\": "tests/"
+    }
+  },
   "minimum-stability": "alpha",
   "prefer-stable": true,
   "require": {
     "php": ">=7.1",
     "laravel/framework": "5.5.*",
     "eveseat/eseye": "~1",
-    "eveseat/services": "~3",
     "doctrine/dbal": "^2.6"
+  },
+  "require-dev": {
+    "orchestra/testbench": "~3.5",
+    "orchestra/database": "~3.5"
   },
   "extra": {
     "laravel": {

--- a/src/Helpers/EseyeSetup.php
+++ b/src/Helpers/EseyeSetup.php
@@ -44,6 +44,9 @@ class EseyeSetup
         $config->logfile_location = config('eveapi.config.eseye_logfile');
         $config->file_cache_location = config('eveapi.config.eseye_cache');
         $config->logger_level = config('eveapi.config.eseye_loglevel');
+        $config->esi_scheme = env('ESI_SCHEME', 'https');
+        $config->esi_host = env('ESI_HOST', 'esi.evetech.net');
+        $config->esi_port = env('ESI_PORT', 443);
     }
 
     /**

--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -271,6 +271,36 @@ abstract class EsiBase implements ShouldQueue
     }
 
     /**
+     * Return the endpoint to which a Job is attached.
+     *
+     * @return string
+     */
+    public function getEndpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    /**
+     * Return the endpoint type to which a Job is attached.
+     *
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    /**
+     * Provide the endpoint version for which a job has been built.
+     *
+     * @return string
+     */
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    /**
      * Assign this job a tag so that Horizon can categorize and allow
      * for specific tags to be monitored.
      *

--- a/src/Models/Alliances/Alliance.php
+++ b/src/Models/Alliances/Alliance.php
@@ -47,4 +47,15 @@ class Alliance extends Model
      * @var string
      */
     protected $primaryKey = 'alliance_id';
+
+    /**
+     * @var array
+     */
+    protected $casts = [
+        'alliance_id' => 'integer',
+        'creator_id' => 'integer',
+        'creator_corporation_id' => 'integer',
+        'executor_corporation_id' => 'integer',
+        'faction_id' => 'integer',
+    ];
 }

--- a/tests/Assets/alliance.json
+++ b/tests/Assets/alliance.json
@@ -1,0 +1,12 @@
+{
+  "alliance_id":1,
+  "name": "C C P Alliance",
+  "creator_id": 12345,
+  "creator_corporation_id": 45678,
+  "ticker": "<C C P>",
+  "executor_corporation_id": 98356193,
+  "date_founded": "2016-06-26 21:00:00",
+  "faction_id": null,
+  "created_at": null,
+  "updated_at": null
+}

--- a/tests/ESI/EndpointsTest.php
+++ b/tests/ESI/EndpointsTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Seat\Eveapi\Tests\ESI;
+
+
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+use Seat\Eveapi\Jobs\EsiBase;
+use Symfony\Component\Finder\Finder;
+
+class EndpointsTest extends TestCase
+{
+
+    public function testEndpoints()
+    {
+        $client = new Client();
+        $request = $client->get('https://esi.evetech.net/latest/swagger.json');
+        $swagger = json_decode($request->getBody(), true);
+
+        $esi_jobs = $this->getAllFcqns(__DIR__ . '/../../src/Jobs');
+
+        foreach ($esi_jobs as $job) {
+            // init a new object
+            $object = new $job;
+
+            // ensure the object is inheriting EsiBase
+            if (!is_subclass_of($object, EsiBase::class))
+                continue;
+
+            print sprintf('Checking validity for [%s] %s@%s%s', $object->getMethod(), $object->getEndpoint(), $object->getVersion(), PHP_EOL);
+
+            // ensure the endpoint still exists
+            $this->assertTrue(
+                array_key_exists($object->getEndpoint(), $swagger['paths']),
+                sprintf('%s endpoint has been removed from ESI.', $object->getEndpoint()));
+
+            // ensure the method still exists for this endpoint
+            $this->assertTrue(
+                array_key_exists($object->getMethod(), $swagger['paths'][$object->getEndpoint()]),
+                sprintf('[%s] %s has been removed from ESI.', $object->getMethod(), $object->getEndpoint()));
+
+            // ensure the used version is not deprecated
+            $swagger_endpoint_versions = $swagger['paths'][$object->getEndpoint()][$object->getMethod()]['x-alternate-versions'];
+            $this->assertContains(
+                $object->getVersion(), $swagger_endpoint_versions,
+                sprintf('[%s] %s@%s is deprecated: %s are available',
+                    $object->getMethod(), $object->getEndpoint(), $object->getVersion(), implode(', ', $swagger_endpoint_versions)));
+
+            unset($object);
+        }
+    }
+
+    /**
+     * @param string $filename
+     * @return string
+     *
+     * @see https://gnugat.github.io/2014/11/26/find-all-available-fqcn.html
+     */
+    private function getFullNamespace(string $filename): string
+    {
+        $match = [];
+        $lines = file($filename);
+        $namespace_lines = preg_grep('/^namespace /', $lines);
+        preg_match('/^namespace (.*);\r\n$/', array_shift($namespace_lines), $match);
+
+        return array_pop($match);
+    }
+
+    /**
+     * @param string $filename
+     * @return string
+     *
+     * @see https://gnugat.github.io/2014/11/26/find-all-available-fqcn.html
+     */
+    private function getClassName(string $filename): string
+    {
+        $paths = explode(DIRECTORY_SEPARATOR, $filename);
+        $filename = array_pop($paths);
+        $name_with_extension = explode('.', $filename);
+
+        return array_shift($name_with_extension);
+    }
+
+    /**
+     * @param $path
+     * @return array
+     *
+     * @see https://gnugat.github.io/2014/11/26/find-all-available-fqcn.html
+     */
+    private function getFilenames($path): array
+    {
+        $filenames = [];
+        $finder = Finder::create()->files()->in($path)->name('*.php');
+
+        foreach ($finder as $file)
+            $filenames[] = $file->getRealPath();
+
+        return $filenames;
+    }
+
+    /**
+     * @param $path
+     * @return array
+     *
+     * @see https://gnugat.github.io/2014/11/26/find-all-available-fqcn.html
+     */
+    private function getAllFcqns($path): array
+    {
+        $fcqns = [];
+        $filenames = $this->getFilenames($path);
+
+        foreach ($filenames as $filename) {
+            $fcqns[] = $this->getFullNamespace($filename) . '\\' . $this->getClassName($filename);
+        }
+
+        return $fcqns;
+    }
+
+}

--- a/tests/Init/AbstractBaseTest.php
+++ b/tests/Init/AbstractBaseTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Seat\Eveapi\Tests\Init;
+
+use Orchestra\Testbench\TestCase;
+
+abstract class AbstractBaseTest extends TestCase
+{
+    /**
+     * 
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->artisan('migrate:fresh', [
+            '--database' => 'sqlite',
+            '--realpath' => realpath(__DIR__ . '/../../src/database/migrations'),
+        ]);
+    }
+
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', true);
+        $app['config']->set('database.default', 'sqlite');
+        $app['config']->set('database.connections.sqlite', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ]);
+    }
+
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     * @return array
+     */
+    protected function getPackageProviders($app)
+    {
+        return [
+            \Seat\Eveapi\EveapiServiceProvider::class,
+            \Orchestra\Database\ConsoleServiceProvider::class,
+        ];
+    }
+}

--- a/tests/Jobs/Alliances/InfoTest.php
+++ b/tests/Jobs/Alliances/InfoTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Seat\Eveapi\Tests\Jobs\Alliances;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Seat\Eveapi\Models\Alliances\Alliance;
+use Seat\Eveapi\Tests\Init\AbstractBaseTest;
+use Seat\Eveapi\Jobs\Alliances\Info;
+
+class InfoTest extends AbstractBaseTest
+{
+
+    /**
+     * @test
+     * @throws \Throwable
+     */
+    public function testHandle()
+    {
+        $asset = __DIR__ . "/../../Assets/alliance.json";
+
+        $alliance = new Alliance([
+            'alliance_id' => 1,
+        ]);
+
+        $info = new Info();
+        $info->setAlliance($alliance);
+        $info->handle();
+
+        $alliance = Alliance::find(1);
+
+        // reset timestamp fields in order to avoid invalid return
+        $alliance->setCreatedAt(null);
+        $alliance->setUpdatedAt(null);
+
+        $this->assertJsonStringEqualsJsonFile($asset, $alliance->toJson());
+    }
+}


### PR DESCRIPTION
Based on Eseye modification in order to allow Mock usage, this provide
initial UnitTesting for Alliance.

It's upgrading container setup in
order to use new environment variables introduced by eveseat/eseye#42
for the API scheme, host and port.

Casts have also been introduced in
Alliance model in order to be sure the model is rendering data properly
(due to SQlite driver implementation - bigint are returned as
string)

datetime fields are reset after the tested alliance is
retrieved from the database in order to avoid conflict with the static
oracle. The oracle has been built from response made by
https://github.com/antihax/mock-esi. The mock is built using
Swagger.json structure file and their included sample data.

BREAKING CHANGE: eveseat/eseye#42