### PR TITLE
feat(jobs): Reduce duplicated jobs

### DIFF
--- a/src/Jobs/AbstractCorporationJob.php
+++ b/src/Jobs/AbstractCorporationJob.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of SeAT
  *
- * Copyright (C) 2015, 2016, 2017, 2018  Leon Jacobs
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/Jobs/AbstractCorporationJob.php
+++ b/src/Jobs/AbstractCorporationJob.php
@@ -59,8 +59,6 @@ abstract class AbstractCorporationJob extends EsiBase
 
             $this->job();
         }, function () {
-            logger()->debug(sprintf('%s has been dropped (throttler) | tags: %s | owner: %s',
-                get_class($this), $this->getUniqueKey(), $this->getCharacterId()));
 
             return $this->delete();
         });

--- a/src/Jobs/AbstractCorporationJob.php
+++ b/src/Jobs/AbstractCorporationJob.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eveapi\Jobs;
+
+use Illuminate\Support\Facades\Redis;
+
+/**
+ * Class AbstractCorporationJob.
+ * @package Seat\Eveapi\Jobs
+ */
+abstract class AbstractCorporationJob extends EsiBase
+{
+    /**
+     * @var array
+     */
+    protected $tags = ['corporation'];
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     * @throws \Throwable
+     */
+    public function handle()
+    {
+        $unique_key = implode(':', array_merge($this->tags, [$this->getCorporationId()]));
+
+        Redis::throttle($unique_key)->allow(1)->every(600)->then(function () use ($unique_key) {
+            logger()->debug(sprintf('%s has been queued | tags: %s | owner: %s', get_class($this), $unique_key, $this->getCharacterId()));
+
+            if (! $this->preflighted()) return;
+
+            $this->job();
+        }, function () use ($unique_key) {
+            logger()->debug(sprintf('%s has been dropped (throttler) | tags: %s | owner: %s', get_class($this), $unique_key, $this->getCharacterId()));
+
+            return $this->delete();
+        });
+    }
+
+    /**
+     * Contains the job process.
+     *
+     * @return void
+     * @throws \Throwable
+     */
+    abstract protected function job(): void;
+}

--- a/src/Jobs/AbstractCorporationJob.php
+++ b/src/Jobs/AbstractCorporationJob.php
@@ -54,8 +54,6 @@ abstract class AbstractCorporationJob extends EsiBase
     public function handle()
     {
         Redis::throttle($this->getUniqueKey())->allow($this->max_concurrent_jobs)->every($this->throttle_seconds)->then(function () {
-            logger()->debug(sprintf('%s has been queued | tags: %s | owner: %s',
-                get_class($this), $this->getUniqueKey(), $this->getCharacterId()));
 
             if (! $this->preflighted()) return;
 
@@ -68,6 +66,10 @@ abstract class AbstractCorporationJob extends EsiBase
         });
     }
 
+    /**
+     * @return string
+     * @throws \Exception
+     */
     private function getUniqueKey(): string
     {
         return implode(':', array_merge($this->tags, [$this->getCorporationId()]));

--- a/src/Jobs/Assets/Corporation/Assets.php
+++ b/src/Jobs/Assets/Corporation/Assets.php
@@ -106,16 +106,16 @@ class Assets extends AbstractCorporationJob
                 $records = $chunk->map(function ($asset, $key) {
 
                     return [
-                        'item_id' => $asset->item_id,
+                        'item_id'        => $asset->item_id,
                         'corporation_id' => $this->getCorporationId(),
-                        'type_id' => $asset->type_id,
-                        'quantity' => $asset->quantity,
-                        'location_id' => $asset->location_id,
-                        'location_type' => $asset->location_type,
-                        'location_flag' => $asset->location_flag,
-                        'is_singleton' => $asset->is_singleton,
-                        'created_at' => carbon(),
-                        'updated_at' => carbon(),
+                        'type_id'        => $asset->type_id,
+                        'quantity'       => $asset->quantity,
+                        'location_id'    => $asset->location_id,
+                        'location_type'  => $asset->location_type,
+                        'location_flag'  => $asset->location_flag,
+                        'is_singleton'   => $asset->is_singleton,
+                        'created_at'     => carbon(),
+                        'updated_at'     => carbon(),
                     ];
                 });
 

--- a/src/Jobs/Assets/Corporation/Assets.php
+++ b/src/Jobs/Assets/Corporation/Assets.php
@@ -86,7 +86,7 @@ class Assets extends AbstractCorporationJob
     }
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Assets/Corporation/Assets.php
+++ b/src/Jobs/Assets/Corporation/Assets.php
@@ -97,7 +97,7 @@ class Assets extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             while (true) {
 
@@ -143,7 +143,7 @@ class Assets extends EsiBase
                 $this->known_assets->push(collect($assets)
                     ->pluck('item_id')->flatten()->all());
 
-                if (!$this->nextPage($assets->pages))
+                if (! $this->nextPage($assets->pages))
                     break;
             }
 

--- a/src/Jobs/Assets/Corporation/Locations.php
+++ b/src/Jobs/Assets/Corporation/Locations.php
@@ -84,7 +84,7 @@ class Locations extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             // all items which need to be singleton
 

--- a/src/Jobs/Assets/Corporation/Locations.php
+++ b/src/Jobs/Assets/Corporation/Locations.php
@@ -122,10 +122,10 @@ class Locations extends AbstractCorporationJob
 
                     // Update the assets location information
                     $asset_data->fill([
-                        'x' => $location->position->x,
-                        'y' => $location->position->y,
-                        'z' => $location->position->z,
-                        'map_id' => $normalized_location['map_id'],
+                        'x'        => $location->position->x,
+                        'y'        => $location->position->y,
+                        'z'        => $location->position->z,
+                        'map_id'   => $normalized_location['map_id'],
                         'map_name' => $normalized_location['map_name'],
                     ])->save();
                 });
@@ -168,10 +168,10 @@ class Locations extends AbstractCorporationJob
 
                     // Update the assets location information
                     $asset_data->fill([
-                        'x' => $location->position->x,
-                        'y' => $location->position->y,
-                        'z' => $location->position->z,
-                        'map_id' => $normalized_location['map_id'],
+                        'x'        => $location->position->x,
+                        'y'        => $location->position->y,
+                        'z'        => $location->position->z,
+                        'map_id'   => $normalized_location['map_id'],
                         'map_name' => $normalized_location['map_name'],
                     ])->save();
                 });

--- a/src/Jobs/Assets/Corporation/Locations.php
+++ b/src/Jobs/Assets/Corporation/Locations.php
@@ -73,7 +73,7 @@ class Locations extends AbstractCorporationJob
     protected $item_id_limit = 1000;
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Assets/Corporation/Locations.php
+++ b/src/Jobs/Assets/Corporation/Locations.php
@@ -22,8 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\Assets\Corporation;
 
-use Illuminate\Support\Facades\Redis;
-use Seat\Eveapi\Jobs\EsiBase;
+use Seat\Eveapi\Jobs\AbstractCorporationJob;
 use Seat\Eveapi\Models\Assets\CorporationAsset;
 use Seat\Eveapi\Traits\Utils;
 
@@ -31,7 +30,7 @@ use Seat\Eveapi\Traits\Utils;
  * Class Locations.
  * @package Seat\Eveapi\Jobs\Assets\Corporation
  */
-class Locations extends EsiBase
+class Locations extends AbstractCorporationJob
 {
     use Utils;
 
@@ -74,119 +73,108 @@ class Locations extends EsiBase
     protected $item_id_limit = 1000;
 
     /**
-     * Execute the job.
+     * Contains the job process.
      *
      * @return void
-     * @throws \Exception
+     * @throws \Throwable
      */
-    public function handle()
+    protected function job(): void
     {
+        // all items which need to be singleton
 
-        Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
+        // Get the assets for this character, chunked in a number of blocks
+        // that the endpoint will accept.
+        CorporationAsset::join('invTypes', 'type_id', '=', 'typeID')
+            ->join('invGroups', 'invGroups.groupID', '=', 'invTypes.groupID')
+            ->where('corporation_id', $this->getCorporationId())
+            ->where('is_singleton', true)// only singleton items may have a specific location
+            // it seems only items from that categories can have a specific location
+            // 2  : Celestial
+            // 6  : Ship
+            // 22 : Deployable
+            // 23 : Starbase
+            // 65 : Structure
+            ->whereIn('categoryID', [2, 6, 22, 23, 65])
+            ->select('item_id')
+            ->chunk($this->item_id_limit, function ($item_ids) {
 
-            if (! $this->preflighted()) return;
+                $this->request_body = $item_ids->pluck('item_id')->all();
 
-            // all items which need to be singleton
+                $locations = $this->retrieve([
+                    'corporation_id' => $this->getCorporationId(),
+                ]);
 
-            // Get the assets for this character, chunked in a number of blocks
-            // that the endpoint will accept.
-            CorporationAsset::join('invTypes', 'type_id', '=', 'typeID')
-                ->join('invGroups', 'invGroups.groupID', '=', 'invTypes.groupID')
-                ->where('corporation_id', $this->getCorporationId())
-                ->where('is_singleton', true)// only singleton items may have a specific location
-                // it seems only items from that categories can have a specific location
-                // 2  : Celestial
-                // 6  : Ship
-                // 22 : Deployable
-                // 23 : Starbase
-                // 65 : Structure
-                ->whereIn('categoryID', [2, 6, 22, 23, 65])
-                ->select('item_id')
-                ->chunk($this->item_id_limit, function ($item_ids) {
+                collect($locations)->each(function ($location) {
 
-                    $this->request_body = $item_ids->pluck('item_id')->all();
+                    // If we have a zero value for any of the coordinates,
+                    // continue to the next location as we can't calculate
+                    // anything
+                    if ($location->position->x === 0.0)
+                        return;
 
-                    $locations = $this->retrieve([
-                        'corporation_id' => $this->getCorporationId(),
-                    ]);
+                    $asset_data = CorporationAsset::where('corporation_id', $this->getCorporationId())
+                        ->where('item_id', $location->item_id)
+                        ->first();
 
-                    collect($locations)->each(function ($location) {
+                    $normalized_location = $this->find_nearest_celestial(
+                        $asset_data->location_id,
+                        $location->position->x, $location->position->y, $location->position->z);
 
-                        // If we have a zero value for any of the coordinates,
-                        // continue to the next location as we can't calculate
-                        // anything
-                        if ($location->position->x === 0.0)
-                            return;
-
-                        $asset_data = CorporationAsset::where('corporation_id', $this->getCorporationId())
-                            ->where('item_id', $location->item_id)
-                            ->first();
-
-                        $normalized_location = $this->find_nearest_celestial(
-                            $asset_data->location_id,
-                            $location->position->x, $location->position->y, $location->position->z);
-
-                        // Update the assets location information
-                        $asset_data->fill([
-                            'x' => $location->position->x,
-                            'y' => $location->position->y,
-                            'z' => $location->position->z,
-                            'map_id' => $normalized_location['map_id'],
-                            'map_name' => $normalized_location['map_name'],
-                        ])->save();
-                    });
+                    // Update the assets location information
+                    $asset_data->fill([
+                        'x' => $location->position->x,
+                        'y' => $location->position->y,
+                        'z' => $location->position->z,
+                        'map_id' => $normalized_location['map_id'],
+                        'map_name' => $normalized_location['map_name'],
+                    ])->save();
                 });
+            });
 
-            // items which may not be singleton
+        // items which may not be singleton
 
-            // Get the assets for this character, chunked in a number of blocks
-            // that the endpoint will accept.
-            CorporationAsset::join('invTypes', 'type_id', '=', 'typeID')
-                ->join('invGroups', 'invGroups.groupID', '=', 'invTypes.groupID')
-                ->where('corporation_id', $this->getCorporationId())
-                // it seems only items from that categories can have a specific location
-                // 46 : Orbitals
-                ->whereIn('categoryID', [46])
-                ->select('item_id')
-                ->chunk($this->item_id_limit, function ($item_ids) {
+        // Get the assets for this character, chunked in a number of blocks
+        // that the endpoint will accept.
+        CorporationAsset::join('invTypes', 'type_id', '=', 'typeID')
+            ->join('invGroups', 'invGroups.groupID', '=', 'invTypes.groupID')
+            ->where('corporation_id', $this->getCorporationId())
+            // it seems only items from that categories can have a specific location
+            // 46 : Orbitals
+            ->whereIn('categoryID', [46])
+            ->select('item_id')
+            ->chunk($this->item_id_limit, function ($item_ids) {
 
-                    $this->request_body = $item_ids->pluck('item_id')->all();
+                $this->request_body = $item_ids->pluck('item_id')->all();
 
-                    $locations = $this->retrieve([
-                        'corporation_id' => $this->getCorporationId(),
-                    ]);
+                $locations = $this->retrieve([
+                    'corporation_id' => $this->getCorporationId(),
+                ]);
 
-                    collect($locations)->each(function ($location) {
+                collect($locations)->each(function ($location) {
 
-                        // If we have a zero value for any of the coordinates,
-                        // continue to the next location as we can't calculate
-                        // anything
-                        if ($location->position->x === 0.0)
-                            return;
+                    // If we have a zero value for any of the coordinates,
+                    // continue to the next location as we can't calculate
+                    // anything
+                    if ($location->position->x === 0.0)
+                        return;
 
-                        $asset_data = CorporationAsset::where('corporation_id', $this->getCorporationId())
-                            ->where('item_id', $location->item_id)
-                            ->first();
+                    $asset_data = CorporationAsset::where('corporation_id', $this->getCorporationId())
+                        ->where('item_id', $location->item_id)
+                        ->first();
 
-                        $normalized_location = $this->find_nearest_celestial(
-                            $asset_data->location_id,
-                            $location->position->x, $location->position->y, $location->position->z);
+                    $normalized_location = $this->find_nearest_celestial(
+                        $asset_data->location_id,
+                        $location->position->x, $location->position->y, $location->position->z);
 
-                        // Update the assets location information
-                        $asset_data->fill([
-                            'x' => $location->position->x,
-                            'y' => $location->position->y,
-                            'z' => $location->position->z,
-                            'map_id' => $normalized_location['map_id'],
-                            'map_name' => $normalized_location['map_name'],
-                        ])->save();
-                    });
+                    // Update the assets location information
+                    $asset_data->fill([
+                        'x' => $location->position->x,
+                        'y' => $location->position->y,
+                        'z' => $location->position->z,
+                        'map_id' => $normalized_location['map_id'],
+                        'map_name' => $normalized_location['map_name'],
+                    ])->save();
                 });
-
-        }, function () {
-
-            return $this->delete();
-
-        });
+            });
     }
 }

--- a/src/Jobs/Assets/Corporation/Names.php
+++ b/src/Jobs/Assets/Corporation/Names.php
@@ -81,7 +81,7 @@ class Names extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             // Get the assets for this character, chunked in a number of blocks
             // that the endpoint will accept.

--- a/src/Jobs/Assets/Corporation/Names.php
+++ b/src/Jobs/Assets/Corporation/Names.php
@@ -70,7 +70,7 @@ class Names extends AbstractCorporationJob
     protected $item_id_limit = 1000;
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Bookmarks/Corporation/Bookmarks.php
+++ b/src/Jobs/Bookmarks/Corporation/Bookmarks.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\Bookmarks\Corporation;
 
+use Illuminate\Support\Facades\Redis;
 use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\Bookmarks\CorporationBookmark;
 use Seat\Eveapi\Models\RefreshToken;
@@ -93,53 +94,61 @@ class Bookmarks extends EsiBase
     public function handle()
     {
 
-        if (! $this->preflighted()) return;
+        Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-        while (true) {
+            if (!$this->preflighted()) return;
 
-            $bookmarks = $this->retrieve([
-                'corporation_id' => $this->getCorporationId(),
-            ]);
+            while (true) {
 
-            if ($bookmarks->isCachedLoad()) return;
-
-            collect($bookmarks)->each(function ($bookmark) {
-
-                $normalized_location = $this->find_nearest_celestial(
-                    $bookmark->location_id,
-                    $bookmark->position->x ?? 0.0,
-                    $bookmark->position->y ?? 0.0,
-                    $bookmark->position->z ?? 0.0);
-
-                CorporationBookmark::firstOrNew([
+                $bookmarks = $this->retrieve([
                     'corporation_id' => $this->getCorporationId(),
-                    'bookmark_id'    => $bookmark->bookmark_id,
-                ])->fill([
-                    'creator_id'  => $bookmark->creator_id,
-                    'folder_id'   => $bookmark->folder_id ?? null,
-                    'created'     => carbon($bookmark->created),
-                    'label'       => $bookmark->label,
-                    'notes'       => $bookmark->notes,
-                    'location_id' => $bookmark->location_id,
-                    'item_id'     => $bookmark->item->item_id ?? null,
-                    'type_id'     => $bookmark->item->type_id ?? null,
-                    'x'           => $bookmark->coordinates->x ?? null,
-                    'y'           => $bookmark->coordinates->y ?? null,
-                    'z'           => $bookmark->coordinates->z ?? null,
-                    'map_id'      => $normalized_location['map_id'],
-                    'map_name'    => $normalized_location['map_name'],
-                ])->save();
-            });
+                ]);
 
-            $this->known_bookmarks->push(collect($bookmarks)
-                ->pluck('bookmark_id')->flatten()->all());
+                if ($bookmarks->isCachedLoad()) return;
 
-            if (! $this->nextPage($bookmarks->pages))
-                break;
-        }
+                collect($bookmarks)->each(function ($bookmark) {
 
-        CorporationBookmark::where('corporation_id', $this->getCorporationId())
-            ->whereNotIn('bookmark_id', $this->known_bookmarks->flatten()->all())
-            ->delete();
+                    $normalized_location = $this->find_nearest_celestial(
+                        $bookmark->location_id,
+                        $bookmark->position->x ?? 0.0,
+                        $bookmark->position->y ?? 0.0,
+                        $bookmark->position->z ?? 0.0);
+
+                    CorporationBookmark::firstOrNew([
+                        'corporation_id' => $this->getCorporationId(),
+                        'bookmark_id' => $bookmark->bookmark_id,
+                    ])->fill([
+                        'creator_id' => $bookmark->creator_id,
+                        'folder_id' => $bookmark->folder_id ?? null,
+                        'created' => carbon($bookmark->created),
+                        'label' => $bookmark->label,
+                        'notes' => $bookmark->notes,
+                        'location_id' => $bookmark->location_id,
+                        'item_id' => $bookmark->item->item_id ?? null,
+                        'type_id' => $bookmark->item->type_id ?? null,
+                        'x' => $bookmark->coordinates->x ?? null,
+                        'y' => $bookmark->coordinates->y ?? null,
+                        'z' => $bookmark->coordinates->z ?? null,
+                        'map_id' => $normalized_location['map_id'],
+                        'map_name' => $normalized_location['map_name'],
+                    ])->save();
+                });
+
+                $this->known_bookmarks->push(collect($bookmarks)
+                    ->pluck('bookmark_id')->flatten()->all());
+
+                if (!$this->nextPage($bookmarks->pages))
+                    break;
+            }
+
+            CorporationBookmark::where('corporation_id', $this->getCorporationId())
+                ->whereNotIn('bookmark_id', $this->known_bookmarks->flatten()->all())
+                ->delete();
+
+        }, function () {
+
+            return $this->delete();
+
+        });
     }
 }

--- a/src/Jobs/Bookmarks/Corporation/Bookmarks.php
+++ b/src/Jobs/Bookmarks/Corporation/Bookmarks.php
@@ -96,7 +96,7 @@ class Bookmarks extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             while (true) {
 
@@ -137,7 +137,7 @@ class Bookmarks extends EsiBase
                 $this->known_bookmarks->push(collect($bookmarks)
                     ->pluck('bookmark_id')->flatten()->all());
 
-                if (!$this->nextPage($bookmarks->pages))
+                if (! $this->nextPage($bookmarks->pages))
                     break;
             }
 

--- a/src/Jobs/Bookmarks/Corporation/Bookmarks.php
+++ b/src/Jobs/Bookmarks/Corporation/Bookmarks.php
@@ -84,7 +84,7 @@ class Bookmarks extends AbstractCorporationJob
     }
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Bookmarks/Corporation/Bookmarks.php
+++ b/src/Jobs/Bookmarks/Corporation/Bookmarks.php
@@ -109,21 +109,21 @@ class Bookmarks extends AbstractCorporationJob
 
                 CorporationBookmark::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
-                    'bookmark_id' => $bookmark->bookmark_id,
+                    'bookmark_id'    => $bookmark->bookmark_id,
                 ])->fill([
-                    'creator_id' => $bookmark->creator_id,
-                    'folder_id' => $bookmark->folder_id ?? null,
-                    'created' => carbon($bookmark->created),
-                    'label' => $bookmark->label,
-                    'notes' => $bookmark->notes,
+                    'creator_id'  => $bookmark->creator_id,
+                    'folder_id'   => $bookmark->folder_id ?? null,
+                    'created'     => carbon($bookmark->created),
+                    'label'       => $bookmark->label,
+                    'notes'       => $bookmark->notes,
                     'location_id' => $bookmark->location_id,
-                    'item_id' => $bookmark->item->item_id ?? null,
-                    'type_id' => $bookmark->item->type_id ?? null,
-                    'x' => $bookmark->coordinates->x ?? null,
-                    'y' => $bookmark->coordinates->y ?? null,
-                    'z' => $bookmark->coordinates->z ?? null,
-                    'map_id' => $normalized_location['map_id'],
-                    'map_name' => $normalized_location['map_name'],
+                    'item_id'     => $bookmark->item->item_id ?? null,
+                    'type_id'     => $bookmark->item->type_id ?? null,
+                    'x'           => $bookmark->coordinates->x ?? null,
+                    'y'           => $bookmark->coordinates->y ?? null,
+                    'z'           => $bookmark->coordinates->z ?? null,
+                    'map_id'      => $normalized_location['map_id'],
+                    'map_name'    => $normalized_location['map_name'],
                 ])->save();
             });
 

--- a/src/Jobs/Bookmarks/Corporation/Folders.php
+++ b/src/Jobs/Bookmarks/Corporation/Folders.php
@@ -100,9 +100,9 @@ class Folders extends AbstractCorporationJob
 
                 CorporationBookmarkFolder::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
-                    'folder_id' => $folder->folder_id,
+                    'folder_id'      => $folder->folder_id,
                 ])->fill([
-                    'name' => $folder->name,
+                    'name'       => $folder->name,
                     'creator_id' => $folder->creator_id ?? null,
                 ])->save();
             });

--- a/src/Jobs/Bookmarks/Corporation/Folders.php
+++ b/src/Jobs/Bookmarks/Corporation/Folders.php
@@ -81,7 +81,7 @@ class Folders extends AbstractCorporationJob
     }
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Bookmarks/Corporation/Folders.php
+++ b/src/Jobs/Bookmarks/Corporation/Folders.php
@@ -92,7 +92,7 @@ class Folders extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             while (true) {
 
@@ -116,7 +116,7 @@ class Folders extends EsiBase
                 $this->known_folder_ids->push(collect($folders)
                     ->pluck('folder_id')->flatten()->all());
 
-                if (!$this->nextPage($folders->pages))
+                if (! $this->nextPage($folders->pages))
                     break;
             }
 

--- a/src/Jobs/Contacts/Corporation/Contacts.php
+++ b/src/Jobs/Contacts/Corporation/Contacts.php
@@ -100,12 +100,12 @@ class Contacts extends AbstractCorporationJob
 
                 CorporationContact::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
-                    'contact_id' => $contact->contact_id,
+                    'contact_id'     => $contact->contact_id,
                 ])->fill([
-                    'standing' => $contact->standing,
+                    'standing'     => $contact->standing,
                     'contact_type' => $contact->contact_type,
-                    'is_watched' => $contact->is_watched ?? false,
-                    'label_ids' => $contact->label_ids ?? null,
+                    'is_watched'   => $contact->is_watched ?? false,
+                    'label_ids'    => $contact->label_ids ?? null,
                 ])->save();
             });
 

--- a/src/Jobs/Contacts/Corporation/Contacts.php
+++ b/src/Jobs/Contacts/Corporation/Contacts.php
@@ -93,7 +93,7 @@ class Contacts extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             while (true) {
 
@@ -119,7 +119,7 @@ class Contacts extends EsiBase
                 $this->known_contact_ids->push(collect($contacts)
                     ->pluck('contact_id')->flatten()->all());
 
-                if (!$this->nextPage($contacts->pages))
+                if (! $this->nextPage($contacts->pages))
                     break;
             }
 

--- a/src/Jobs/Contacts/Corporation/Contacts.php
+++ b/src/Jobs/Contacts/Corporation/Contacts.php
@@ -81,7 +81,7 @@ class Contacts extends AbstractCorporationJob
     }
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Contacts/Corporation/Labels.php
+++ b/src/Jobs/Contacts/Corporation/Labels.php
@@ -57,7 +57,7 @@ class Labels extends AbstractCorporationJob
     protected $tags = ['corporation', 'contacts', 'labels'];
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Contacts/Corporation/Labels.php
+++ b/src/Jobs/Contacts/Corporation/Labels.php
@@ -69,7 +69,7 @@ class Labels extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $labels = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),

--- a/src/Jobs/Contacts/Corporation/Labels.php
+++ b/src/Jobs/Contacts/Corporation/Labels.php
@@ -74,7 +74,7 @@ class Labels extends AbstractCorporationJob
 
             CorporationContactLabel::firstOrNew([
                 'corporation_id' => $this->getCorporationId(),
-                'label_id' => $label->label_id,
+                'label_id'       => $label->label_id,
             ])->fill([
                 'label_name' => $label->label_name,
             ])->save();

--- a/src/Jobs/Contracts/Corporation/Bids.php
+++ b/src/Jobs/Contracts/Corporation/Bids.php
@@ -84,7 +84,7 @@ class Bids extends AbstractCorporationJob
 
                 $bids = $this->retrieve([
                     'corporation_id' => $this->getCorporationId(),
-                    'contract_id' => $contract_id,
+                    'contract_id'    => $contract_id,
                 ]);
 
                 if ($bids->isCachedLoad()) return;
@@ -95,9 +95,9 @@ class Bids extends AbstractCorporationJob
                         'bid_id' => $bid->bid_id,
                     ], [
                         'contract_id' => $contract_id,
-                        'bidder_id' => $bid->bidder_id,
-                        'date_bid' => carbon($bid->date_bid),
-                        'amount' => $bid->amount,
+                        'bidder_id'   => $bid->bidder_id,
+                        'date_bid'    => carbon($bid->date_bid),
+                        'amount'      => $bid->amount,
                     ]);
                 });
 

--- a/src/Jobs/Contracts/Corporation/Bids.php
+++ b/src/Jobs/Contracts/Corporation/Bids.php
@@ -74,7 +74,7 @@ class Bids extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $unfinished_auctions = CorporationContract::join('contract_details',
                 'corporation_contracts.contract_id', '=',
@@ -107,7 +107,7 @@ class Bids extends EsiBase
                         ]);
                     });
 
-                    if (!$this->nextPage($bids->pages))
+                    if (! $this->nextPage($bids->pages))
                         break;
                 }
 

--- a/src/Jobs/Contracts/Corporation/Bids.php
+++ b/src/Jobs/Contracts/Corporation/Bids.php
@@ -24,7 +24,6 @@ namespace Seat\Eveapi\Jobs\Contracts\Corporation;
 
 use Seat\Eseye\Exceptions\RequestFailedException;
 use Seat\Eveapi\Jobs\AbstractCorporationJob;
-use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\Contracts\ContractBid;
 use Seat\Eveapi\Models\Contracts\ContractDetail;
 use Seat\Eveapi\Models\Contracts\CorporationContract;
@@ -107,7 +106,7 @@ class Bids extends AbstractCorporationJob
 
                     if (! $this->nextPage($bids->pages))
                         break;
-                  
+
                 } catch (RequestFailedException $e) {
                     if (strtolower($e->getError()) == 'contract not found') {
                         ContractDetail::where('contract_id', $contract_id)

--- a/src/Jobs/Contracts/Corporation/Bids.php
+++ b/src/Jobs/Contracts/Corporation/Bids.php
@@ -63,7 +63,7 @@ class Bids extends AbstractCorporationJob
     protected $page = 1;
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Contracts/Corporation/Contracts.php
+++ b/src/Jobs/Contracts/Corporation/Contracts.php
@@ -84,35 +84,35 @@ class Contracts extends AbstractCorporationJob
                 ContractDetail::firstOrNew([
                     'contract_id' => $contract->contract_id,
                 ])->fill([
-                    'issuer_id' => $contract->issuer_id,
+                    'issuer_id'             => $contract->issuer_id,
                     'issuer_corporation_id' => $contract->issuer_corporation_id,
-                    'assignee_id' => $contract->assignee_id,
-                    'acceptor_id' => $contract->acceptor_id,
-                    'start_location_id' => $contract->start_location_id ?? null,
-                    'end_location_id' => $contract->end_location_id ?? null,
-                    'type' => $contract->type,
-                    'status' => $contract->status,
-                    'title' => $contract->title ?? null,
-                    'for_corporation' => $contract->for_corporation,
-                    'availability' => $contract->availability,
-                    'date_issued' => carbon($contract->date_issued),
-                    'date_expired' => carbon($contract->date_expired),
-                    'date_accepted' => isset($contract->date_accepted) ?
+                    'assignee_id'           => $contract->assignee_id,
+                    'acceptor_id'           => $contract->acceptor_id,
+                    'start_location_id'     => $contract->start_location_id ?? null,
+                    'end_location_id'       => $contract->end_location_id ?? null,
+                    'type'                  => $contract->type,
+                    'status'                => $contract->status,
+                    'title'                 => $contract->title ?? null,
+                    'for_corporation'       => $contract->for_corporation,
+                    'availability'          => $contract->availability,
+                    'date_issued'           => carbon($contract->date_issued),
+                    'date_expired'          => carbon($contract->date_expired),
+                    'date_accepted'         => isset($contract->date_accepted) ?
                         carbon($contract->date_accepted) : null,
-                    'days_to_complete' => $contract->days_to_complete ?? null,
-                    'date_completed' => isset($contract->date_completed) ?
+                    'days_to_complete'      => $contract->days_to_complete ?? null,
+                    'date_completed'        => isset($contract->date_completed) ?
                         carbon($contract->date_completed) : null,
-                    'price' => $contract->price ?? null,
-                    'reward' => $contract->reward ?? null,
-                    'collateral' => $contract->collateral ?? null,
-                    'buyout' => $contract->buyout ?? null,
-                    'volume' => $contract->volume ?? null,
+                    'price'                 => $contract->price ?? null,
+                    'reward'                => $contract->reward ?? null,
+                    'collateral'            => $contract->collateral ?? null,
+                    'buyout'                => $contract->buyout ?? null,
+                    'volume'                => $contract->volume ?? null,
                 ])->save();
 
                 // Ensure the character is associated to this contract
                 CorporationContract::firstOrCreate([
                     'corporation_id' => $this->getCorporationId(),
-                    'contract_id' => $contract->contract_id,
+                    'contract_id'    => $contract->contract_id,
                 ]);
             });
 

--- a/src/Jobs/Contracts/Corporation/Contracts.php
+++ b/src/Jobs/Contracts/Corporation/Contracts.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\Contracts\Corporation;
 
+use Illuminate\Support\Facades\Redis;
 use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\Contracts\ContractDetail;
 use Seat\Eveapi\Models\Contracts\CorporationContract;
@@ -72,56 +73,64 @@ class Contracts extends EsiBase
     public function handle()
     {
 
-        if (! $this->preflighted()) return;
+        Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-        while (true) {
+            if (!$this->preflighted()) return;
 
-            $contracts = $this->retrieve([
-                'corporation_id' => $this->getCorporationId(),
-            ]);
+            while (true) {
 
-            if ($contracts->isCachedLoad()) return;
-
-            collect($contracts)->each(function ($contract) {
-
-                // Update or create the contract details.
-                ContractDetail::firstOrNew([
-                    'contract_id' => $contract->contract_id,
-                ])->fill([
-                    'issuer_id'             => $contract->issuer_id,
-                    'issuer_corporation_id' => $contract->issuer_corporation_id,
-                    'assignee_id'           => $contract->assignee_id,
-                    'acceptor_id'           => $contract->acceptor_id,
-                    'start_location_id'     => $contract->start_location_id ?? null,
-                    'end_location_id'       => $contract->end_location_id ?? null,
-                    'type'                  => $contract->type,
-                    'status'                => $contract->status,
-                    'title'                 => $contract->title ?? null,
-                    'for_corporation'       => $contract->for_corporation,
-                    'availability'          => $contract->availability,
-                    'date_issued'           => carbon($contract->date_issued),
-                    'date_expired'          => carbon($contract->date_expired),
-                    'date_accepted'         => isset($contract->date_accepted) ?
-                        carbon($contract->date_accepted) : null,
-                    'days_to_complete'      => $contract->days_to_complete ?? null,
-                    'date_completed'        => isset($contract->date_completed) ?
-                        carbon($contract->date_completed) : null,
-                    'price'                 => $contract->price ?? null,
-                    'reward'                => $contract->reward ?? null,
-                    'collateral'            => $contract->collateral ?? null,
-                    'buyout'                => $contract->buyout ?? null,
-                    'volume'                => $contract->volume ?? null,
-                ])->save();
-
-                // Ensure the character is associated to this contract
-                CorporationContract::firstOrCreate([
+                $contracts = $this->retrieve([
                     'corporation_id' => $this->getCorporationId(),
-                    'contract_id'    => $contract->contract_id,
                 ]);
-            });
 
-            if (! $this->nextPage($contracts->pages))
-                break;
-        }
+                if ($contracts->isCachedLoad()) return;
+
+                collect($contracts)->each(function ($contract) {
+
+                    // Update or create the contract details.
+                    ContractDetail::firstOrNew([
+                        'contract_id' => $contract->contract_id,
+                    ])->fill([
+                        'issuer_id' => $contract->issuer_id,
+                        'issuer_corporation_id' => $contract->issuer_corporation_id,
+                        'assignee_id' => $contract->assignee_id,
+                        'acceptor_id' => $contract->acceptor_id,
+                        'start_location_id' => $contract->start_location_id ?? null,
+                        'end_location_id' => $contract->end_location_id ?? null,
+                        'type' => $contract->type,
+                        'status' => $contract->status,
+                        'title' => $contract->title ?? null,
+                        'for_corporation' => $contract->for_corporation,
+                        'availability' => $contract->availability,
+                        'date_issued' => carbon($contract->date_issued),
+                        'date_expired' => carbon($contract->date_expired),
+                        'date_accepted' => isset($contract->date_accepted) ?
+                            carbon($contract->date_accepted) : null,
+                        'days_to_complete' => $contract->days_to_complete ?? null,
+                        'date_completed' => isset($contract->date_completed) ?
+                            carbon($contract->date_completed) : null,
+                        'price' => $contract->price ?? null,
+                        'reward' => $contract->reward ?? null,
+                        'collateral' => $contract->collateral ?? null,
+                        'buyout' => $contract->buyout ?? null,
+                        'volume' => $contract->volume ?? null,
+                    ])->save();
+
+                    // Ensure the character is associated to this contract
+                    CorporationContract::firstOrCreate([
+                        'corporation_id' => $this->getCorporationId(),
+                        'contract_id' => $contract->contract_id,
+                    ]);
+                });
+
+                if (!$this->nextPage($contracts->pages))
+                    break;
+            }
+
+        }, function () {
+
+            return $this->delete();
+
+        });
     }
 }

--- a/src/Jobs/Contracts/Corporation/Contracts.php
+++ b/src/Jobs/Contracts/Corporation/Contracts.php
@@ -75,7 +75,7 @@ class Contracts extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             while (true) {
 
@@ -123,7 +123,7 @@ class Contracts extends EsiBase
                     ]);
                 });
 
-                if (!$this->nextPage($contracts->pages))
+                if (! $this->nextPage($contracts->pages))
                     break;
             }
 

--- a/src/Jobs/Contracts/Corporation/Contracts.php
+++ b/src/Jobs/Contracts/Corporation/Contracts.php
@@ -63,7 +63,7 @@ class Contracts extends AbstractCorporationJob
     protected $page = 1;
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Contracts/Corporation/Items.php
+++ b/src/Jobs/Contracts/Corporation/Items.php
@@ -153,7 +153,7 @@ class Items extends AbstractCorporationJob
 
             $items = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
-                'contract_id' => $contract_id,
+                'contract_id'    => $contract_id,
             ]);
 
             if ($items->isCachedLoad()) return;
@@ -161,13 +161,13 @@ class Items extends AbstractCorporationJob
             collect($items)->each(function ($item) use ($contract_id) {
 
                 ContractItem::upsert([
-                    'contract_id' => $contract_id,
-                    'record_id' => $item->record_id,
-                    'type_id' => $item->type_id,
-                    'quantity' => $item->quantity,
+                    'contract_id'  => $contract_id,
+                    'record_id'    => $item->record_id,
+                    'type_id'      => $item->type_id,
+                    'quantity'     => $item->quantity,
                     'raw_quantity' => $item->raw_quantity ?? null,
                     'is_singleton' => $item->is_singleton,
-                    'is_included' => $item->is_included,
+                    'is_included'  => $item->is_included,
                 ], [
                     'contract_id', 'record_id',
                 ]);

--- a/src/Jobs/Contracts/Corporation/Items.php
+++ b/src/Jobs/Contracts/Corporation/Items.php
@@ -24,7 +24,6 @@ namespace Seat\Eveapi\Jobs\Contracts\Corporation;
 
 use Seat\Eseye\Exceptions\RequestFailedException;
 use Seat\Eveapi\Jobs\AbstractCorporationJob;
-use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\Contracts\ContractDetail;
 use Seat\Eveapi\Models\Contracts\ContractItem;
 use Seat\Eveapi\Models\Contracts\CorporationContract;

--- a/src/Jobs/Contracts/Corporation/Items.php
+++ b/src/Jobs/Contracts/Corporation/Items.php
@@ -135,7 +135,7 @@ class Items extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $empty_contracts = CorporationContract::join('contract_details',
                 'corporation_contracts.contract_id', '=',

--- a/src/Jobs/Contracts/Corporation/Items.php
+++ b/src/Jobs/Contracts/Corporation/Items.php
@@ -124,7 +124,7 @@ class Items extends AbstractCorporationJob
     }
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Contracts/Corporation/Items.php
+++ b/src/Jobs/Contracts/Corporation/Items.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\Contracts\Corporation;
 
+use Illuminate\Support\Facades\Redis;
 use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\Contracts\ContractItem;
 use Seat\Eveapi\Models\Contracts\CorporationContract;
@@ -132,81 +133,89 @@ class Items extends EsiBase
     public function handle()
     {
 
-        if (! $this->preflighted()) return;
+        Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-        $empty_contracts = CorporationContract::join('contract_details',
-            'corporation_contracts.contract_id', '=',
-            'contract_details.contract_id')
-            ->where('corporation_id', $this->getCorporationId())
-            ->where('type', '<>', 'courier')
-            ->where('status', '<>', 'deleted')
-            ->where('volume', '>', 0)
-            ->whereNotIn('corporation_contracts.contract_id', function ($query) {
+            if (!$this->preflighted()) return;
 
-                $query->select('contract_id')
-                    ->distinct()
-                    ->from((new ContractItem)->getTable());
+            $empty_contracts = CorporationContract::join('contract_details',
+                'corporation_contracts.contract_id', '=',
+                'contract_details.contract_id')
+                ->where('corporation_id', $this->getCorporationId())
+                ->where('type', '<>', 'courier')
+                ->where('status', '<>', 'deleted')
+                ->where('volume', '>', 0)
+                ->whereNotIn('corporation_contracts.contract_id', function ($query) {
 
-            })
-            ->pluck('corporation_contracts.contract_id');
+                    $query->select('contract_id')
+                        ->distinct()
+                        ->from((new ContractItem)->getTable());
 
-        $empty_contracts->each(function ($contract_id) {
+                })
+                ->pluck('corporation_contracts.contract_id');
 
-            $this->iteration_count++;
+            $empty_contracts->each(function ($contract_id) {
 
-            $items = $this->retrieve([
-                'corporation_id' => $this->getCorporationId(),
-                'contract_id'    => $contract_id,
-            ]);
+                $this->iteration_count++;
 
-            if ($items->isCachedLoad()) return;
-
-            collect($items)->each(function ($item) use ($contract_id) {
-
-                ContractItem::upsert([
-                    'contract_id'  => $contract_id,
-                    'record_id'    => $item->record_id,
-                    'type_id'      => $item->type_id,
-                    'quantity'     => $item->quantity,
-                    'raw_quantity' => $item->raw_quantity ?? null,
-                    'is_singleton' => $item->is_singleton,
-                    'is_included'  => $item->is_included,
-                ], [
-                    'contract_id', 'record_id',
+                $items = $this->retrieve([
+                    'corporation_id' => $this->getCorporationId(),
+                    'contract_id' => $contract_id,
                 ]);
+
+                if ($items->isCachedLoad()) return;
+
+                collect($items)->each(function ($item) use ($contract_id) {
+
+                    ContractItem::upsert([
+                        'contract_id' => $contract_id,
+                        'record_id' => $item->record_id,
+                        'type_id' => $item->type_id,
+                        'quantity' => $item->quantity,
+                        'raw_quantity' => $item->raw_quantity ?? null,
+                        'is_singleton' => $item->is_singleton,
+                        'is_included' => $item->is_included,
+                    ], [
+                        'contract_id', 'record_id',
+                    ]);
+                });
+
+                // Check if we should be stopping this job all together.
+                // The next time a job is queued it will just continue
+                // where it left off.
+                if ($this->job_start_time->copy()->addSeconds($this->max_job_runtime) < carbon('now'))
+                    return false;
+
+                // Check if we should be sleeping. This should be true if we
+                // have made 20 requests in the last 10 seconds.
+                // If the time we started, plus 10 seconds is more than the current
+                // time, wait for the remainder of the time.
+                if ($this->iteration_count >= $this->max_cycle_requests &&
+                    $this->cycle_start_time->copy()->addSeconds($this->cycle_duration) < carbon('now')) {
+
+                    $wait_duration = $this->cycle_start_time->copy()->addSeconds($this->cycle_duration)
+                        ->diffInSeconds(carbon('now'));
+
+                    sleep($wait_duration);
+
+                    // Reset the cycle start time as well as the iteration count.
+                    $this->cycle_start_time = carbon('now');
+                    $this->iteration_count = 0;
+                }
+
+                // Check if we should just reset the iteration & cycle count as a result of
+                // us not using the full 20 requests in a 10 second window.
+                if ($this->cycle_start_time->copy()->addSeconds($this->cycle_duration) < carbon('now')) {
+
+                    $this->cycle_start_time = carbon('now');
+                    $this->iteration_count = 0;
+
+                }
             });
 
-            // Check if we should be stopping this job all together.
-            // The next time a job is queued it will just continue
-            // where it left off.
-            if ($this->job_start_time->copy()->addSeconds($this->max_job_runtime) < carbon('now'))
-                return false;
+        }, function () {
 
-            // Check if we should be sleeping. This should be true if we
-            // have made 20 requests in the last 10 seconds.
-            // If the time we started, plus 10 seconds is more than the current
-            // time, wait for the remainder of the time.
-            if ($this->iteration_count >= $this->max_cycle_requests &&
-                $this->cycle_start_time->copy()->addSeconds($this->cycle_duration) < carbon('now')) {
+            return $this->delete();
 
-                $wait_duration = $this->cycle_start_time->copy()->addSeconds($this->cycle_duration)
-                    ->diffInSeconds(carbon('now'));
-
-                sleep($wait_duration);
-
-                // Reset the cycle start time as well as the iteration count.
-                $this->cycle_start_time = carbon('now');
-                $this->iteration_count = 0;
-            }
-
-            // Check if we should just reset the iteration & cycle count as a result of
-            // us not using the full 20 requests in a 10 second window.
-            if ($this->cycle_start_time->copy()->addSeconds($this->cycle_duration) < carbon('now')) {
-
-                $this->cycle_start_time = carbon('now');
-                $this->iteration_count = 0;
-
-            }
         });
     }
 }

--- a/src/Jobs/Corporation/AllianceHistory.php
+++ b/src/Jobs/Corporation/AllianceHistory.php
@@ -52,7 +52,7 @@ class AllianceHistory extends AbstractCorporationJob
     protected $tags = ['corporation', 'alliance_history'];
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/AllianceHistory.php
+++ b/src/Jobs/Corporation/AllianceHistory.php
@@ -62,7 +62,7 @@ class AllianceHistory extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $history = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),

--- a/src/Jobs/Corporation/AllianceHistory.php
+++ b/src/Jobs/Corporation/AllianceHistory.php
@@ -69,11 +69,11 @@ class AllianceHistory extends AbstractCorporationJob
 
             CorporationAllianceHistory::firstOrNew([
                 'corporation_id' => $this->getCorporationId(),
-                'record_id' => $alliance->record_id,
+                'record_id'      => $alliance->record_id,
             ])->fill([
-                'start_date' => carbon($alliance->start_date),
+                'start_date'  => carbon($alliance->start_date),
                 'alliance_id' => $alliance->alliance_id ?? null,
-                'is_deleted' => $alliance->is_deleted ?? false,
+                'is_deleted'  => $alliance->is_deleted ?? false,
             ])->save();
 
         });

--- a/src/Jobs/Corporation/Blueprints.php
+++ b/src/Jobs/Corporation/Blueprints.php
@@ -87,7 +87,7 @@ class Blueprints extends AbstractCorporationJob
     }
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/Blueprints.php
+++ b/src/Jobs/Corporation/Blueprints.php
@@ -106,17 +106,17 @@ class Blueprints extends AbstractCorporationJob
 
                 $records = $chunk->map(function ($blueprint, $key) {
                     return [
-                        'corporation_id' => $this->getCorporationId(),
-                        'item_id' => $blueprint->item_id,
-                        'type_id' => $blueprint->type_id,
-                        'location_id' => $blueprint->location_id,
-                        'location_flag' => $blueprint->location_flag,
-                        'quantity' => $blueprint->quantity,
-                        'time_efficiency' => $blueprint->time_efficiency,
+                        'corporation_id'      => $this->getCorporationId(),
+                        'item_id'             => $blueprint->item_id,
+                        'type_id'             => $blueprint->type_id,
+                        'location_id'         => $blueprint->location_id,
+                        'location_flag'       => $blueprint->location_flag,
+                        'quantity'            => $blueprint->quantity,
+                        'time_efficiency'     => $blueprint->time_efficiency,
                         'material_efficiency' => $blueprint->material_efficiency,
-                        'runs' => $blueprint->runs,
-                        'created_at' => carbon(),
-                        'updated_at' => carbon(),
+                        'runs'                => $blueprint->runs,
+                        'created_at'          => carbon(),
+                        'updated_at'          => carbon(),
                     ];
                 });
 

--- a/src/Jobs/Corporation/Blueprints.php
+++ b/src/Jobs/Corporation/Blueprints.php
@@ -98,7 +98,7 @@ class Blueprints extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             while (true) {
 
@@ -144,7 +144,7 @@ class Blueprints extends EsiBase
                 $this->known_blueprints->push(collect($blueprints)
                     ->pluck('item_id')->flatten()->all());
 
-                if (!$this->nextPage($blueprints->pages))
+                if (! $this->nextPage($blueprints->pages))
                     break;
 
             }

--- a/src/Jobs/Corporation/ContainerLogs.php
+++ b/src/Jobs/Corporation/ContainerLogs.php
@@ -86,17 +86,17 @@ class ContainerLogs extends AbstractCorporationJob
 
                 CorporationContainerLog::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
-                    'container_id' => $log->container_id,
-                    'logged_at' => carbon($log->logged_at),
+                    'container_id'   => $log->container_id,
+                    'logged_at'      => carbon($log->logged_at),
                 ])->fill([
-                    'container_type_id' => $log->container_type_id,
-                    'character_id' => $log->character_id,
-                    'location_id' => $log->location_id,
-                    'action' => $log->action,
-                    'location_flag' => $log->location_flag,
-                    'password_type' => $log->password_type ?? null,
-                    'type_id' => $log->type_id ?? null,
-                    'quantity' => $log->quantity ?? null,
+                    'container_type_id'  => $log->container_type_id,
+                    'character_id'       => $log->character_id,
+                    'location_id'        => $log->location_id,
+                    'action'             => $log->action,
+                    'location_flag'      => $log->location_flag,
+                    'password_type'      => $log->password_type ?? null,
+                    'type_id'            => $log->type_id ?? null,
+                    'quantity'           => $log->quantity ?? null,
                     'old_config_bitmask' => $log->old_config_bitmask ?? null,
                     'new_config_bitmask' => $log->new_config_bitmask ?? null,
                 ])->save();

--- a/src/Jobs/Corporation/ContainerLogs.php
+++ b/src/Jobs/Corporation/ContainerLogs.php
@@ -78,7 +78,7 @@ class ContainerLogs extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             while (true) {
 
@@ -109,7 +109,7 @@ class ContainerLogs extends EsiBase
 
                 });
 
-                if (!$this->nextPage($logs->pages))
+                if (! $this->nextPage($logs->pages))
                     break;
             }
 

--- a/src/Jobs/Corporation/ContainerLogs.php
+++ b/src/Jobs/Corporation/ContainerLogs.php
@@ -67,7 +67,7 @@ class ContainerLogs extends AbstractCorporationJob
     protected $page = 1;
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/Divisions.php
+++ b/src/Jobs/Corporation/Divisions.php
@@ -62,7 +62,7 @@ class Divisions extends AbstractCorporationJob
     protected $tags = ['corporation', 'divisions'];
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/Divisions.php
+++ b/src/Jobs/Corporation/Divisions.php
@@ -73,7 +73,7 @@ class Divisions extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $divisions = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),

--- a/src/Jobs/Corporation/Divisions.php
+++ b/src/Jobs/Corporation/Divisions.php
@@ -81,8 +81,8 @@ class Divisions extends AbstractCorporationJob
 
                 CorporationDivision::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
-                    'type' => 'hangar',
-                    'division' => $hangar->division,
+                    'type'           => 'hangar',
+                    'division'       => $hangar->division,
                 ])->fill([
                     'name' => $hangar->name ?? null,
                 ])->save();
@@ -94,8 +94,8 @@ class Divisions extends AbstractCorporationJob
 
                 CorporationDivision::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
-                    'type' => 'wallet',
-                    'division' => $wallet->division,
+                    'type'           => 'wallet',
+                    'division'       => $wallet->division,
                 ])->fill([
                     'name' => $wallet->name ?? null,
                 ])->save();

--- a/src/Jobs/Corporation/Facilities.php
+++ b/src/Jobs/Corporation/Facilities.php
@@ -73,7 +73,7 @@ class Facilities extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $facilities = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),

--- a/src/Jobs/Corporation/Facilities.php
+++ b/src/Jobs/Corporation/Facilities.php
@@ -79,9 +79,9 @@ class Facilities extends AbstractCorporationJob
 
             CorporationFacility::firstOrNew([
                 'corporation_id' => $this->getCorporationId(),
-                'facility_id' => $facility->facility_id,
+                'facility_id'    => $facility->facility_id,
             ])->fill([
-                'type_id' => $facility->type_id,
+                'type_id'   => $facility->type_id,
                 'system_id' => $facility->system_id,
             ])->save();
         });

--- a/src/Jobs/Corporation/Facilities.php
+++ b/src/Jobs/Corporation/Facilities.php
@@ -62,7 +62,7 @@ class Facilities extends AbstractCorporationJob
     protected $tags = ['corporation', 'facilities'];
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/Info.php
+++ b/src/Jobs/Corporation/Info.php
@@ -68,20 +68,20 @@ class Info extends AbstractCorporationJob
         CorporationInfo::firstOrNew([
             'corporation_id' => $this->getCorporationId(),
         ])->fill([
-            'name' => $corporation->name,
-            'ticker' => $corporation->ticker,
-            'member_count' => $corporation->member_count,
-            'ceo_id' => $corporation->ceo_id,
-            'alliance_id' => $corporation->alliance_id ?? null,
-            'description' => $corporation->description ?? null,
-            'tax_rate' => $corporation->tax_rate,
-            'date_founded' => property_exists($corporation, 'date_founded') ?
+            'name'            => $corporation->name,
+            'ticker'          => $corporation->ticker,
+            'member_count'    => $corporation->member_count,
+            'ceo_id'          => $corporation->ceo_id,
+            'alliance_id'     => $corporation->alliance_id ?? null,
+            'description'     => $corporation->description ?? null,
+            'tax_rate'        => $corporation->tax_rate,
+            'date_founded'    => property_exists($corporation, 'date_founded') ?
                 carbon($corporation->date_founded) : null,
-            'creator_id' => $corporation->creator_id,
-            'url' => $corporation->url ?? null,
-            'faction_id' => $corporation->faction_id ?? null,
+            'creator_id'      => $corporation->creator_id,
+            'url'             => $corporation->url ?? null,
+            'faction_id'      => $corporation->faction_id ?? null,
             'home_station_id' => $corporation->home_station_id ?? null,
-            'shares' => $corporation->shares ?? null,
+            'shares'          => $corporation->shares ?? null,
         ])->save();
     }
 }

--- a/src/Jobs/Corporation/Info.php
+++ b/src/Jobs/Corporation/Info.php
@@ -63,7 +63,7 @@ class Info extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $corporation = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),

--- a/src/Jobs/Corporation/Info.php
+++ b/src/Jobs/Corporation/Info.php
@@ -22,15 +22,14 @@
 
 namespace Seat\Eveapi\Jobs\Corporation;
 
-use Illuminate\Support\Facades\Redis;
-use Seat\Eveapi\Jobs\EsiBase;
+use Seat\Eveapi\Jobs\AbstractCorporationJob;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
 
 /**
  * Class Info.
  * @package Seat\Eveapi\Jobs\Corporation
  */
-class Info extends EsiBase
+class Info extends AbstractCorporationJob
 {
     /**
      * @var string
@@ -53,47 +52,36 @@ class Info extends EsiBase
     protected $tags = ['corporation', 'info'];
 
     /**
-     * Execute the job.
+     * Contains the job process.
      *
      * @return void
      * @throws \Throwable
      */
-    public function handle()
+    protected function job(): void
     {
+        $corporation = $this->retrieve([
+            'corporation_id' => $this->getCorporationId(),
+        ]);
 
-        Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
+        if ($corporation->isCachedLoad()) return;
 
-            if (! $this->preflighted()) return;
-
-            $corporation = $this->retrieve([
-                'corporation_id' => $this->getCorporationId(),
-            ]);
-
-            if ($corporation->isCachedLoad()) return;
-
-            CorporationInfo::firstOrNew([
-                'corporation_id' => $this->getCorporationId(),
-            ])->fill([
-                'name' => $corporation->name,
-                'ticker' => $corporation->ticker,
-                'member_count' => $corporation->member_count,
-                'ceo_id' => $corporation->ceo_id,
-                'alliance_id' => $corporation->alliance_id ?? null,
-                'description' => $corporation->description ?? null,
-                'tax_rate' => $corporation->tax_rate,
-                'date_founded' => property_exists($corporation, 'date_founded') ?
-                    carbon($corporation->date_founded) : null,
-                'creator_id' => $corporation->creator_id,
-                'url' => $corporation->url ?? null,
-                'faction_id' => $corporation->faction_id ?? null,
-                'home_station_id' => $corporation->home_station_id ?? null,
-                'shares' => $corporation->shares ?? null,
-            ])->save();
-
-        }, function () {
-
-            return $this->delete();
-
-        });
+        CorporationInfo::firstOrNew([
+            'corporation_id' => $this->getCorporationId(),
+        ])->fill([
+            'name' => $corporation->name,
+            'ticker' => $corporation->ticker,
+            'member_count' => $corporation->member_count,
+            'ceo_id' => $corporation->ceo_id,
+            'alliance_id' => $corporation->alliance_id ?? null,
+            'description' => $corporation->description ?? null,
+            'tax_rate' => $corporation->tax_rate,
+            'date_founded' => property_exists($corporation, 'date_founded') ?
+                carbon($corporation->date_founded) : null,
+            'creator_id' => $corporation->creator_id,
+            'url' => $corporation->url ?? null,
+            'faction_id' => $corporation->faction_id ?? null,
+            'home_station_id' => $corporation->home_station_id ?? null,
+            'shares' => $corporation->shares ?? null,
+        ])->save();
     }
 }

--- a/src/Jobs/Corporation/Info.php
+++ b/src/Jobs/Corporation/Info.php
@@ -52,7 +52,7 @@ class Info extends AbstractCorporationJob
     protected $tags = ['corporation', 'info'];
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/IssuedMedals.php
+++ b/src/Jobs/Corporation/IssuedMedals.php
@@ -86,11 +86,11 @@ class IssuedMedals extends AbstractCorporationJob
 
                 CorporationIssuedMedal::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
-                    'medal_id' => $medal->medal_id,
-                    'character_id' => $medal->character_id,
+                    'medal_id'       => $medal->medal_id,
+                    'character_id'   => $medal->character_id,
                 ])->fill([
-                    'reason' => $medal->reason,
-                    'status' => $medal->status,
+                    'reason'    => $medal->reason,
+                    'status'    => $medal->status,
                     'issuer_id' => $medal->issuer_id,
                     'issued_at' => carbon($medal->issued_at),
                 ])->save();

--- a/src/Jobs/Corporation/IssuedMedals.php
+++ b/src/Jobs/Corporation/IssuedMedals.php
@@ -22,7 +22,6 @@
 
 namespace Seat\Eveapi\Jobs\Corporation;
 
-use function foo\func;
 use Illuminate\Support\Facades\Redis;
 use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\Corporation\CorporationIssuedMedal;
@@ -79,7 +78,7 @@ class IssuedMedals extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             while (true) {
 
@@ -104,7 +103,7 @@ class IssuedMedals extends EsiBase
 
                 });
 
-                if (!$this->nextPage($medals->pages))
+                if (! $this->nextPage($medals->pages))
                     break;
             }
 

--- a/src/Jobs/Corporation/IssuedMedals.php
+++ b/src/Jobs/Corporation/IssuedMedals.php
@@ -67,7 +67,7 @@ class IssuedMedals extends AbstractCorporationJob
     protected $page = 1;
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/Medals.php
+++ b/src/Jobs/Corporation/Medals.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\Corporation;
 
+use Illuminate\Support\Facades\Redis;
 use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\Corporation\CorporationMedal;
 
@@ -73,32 +74,40 @@ class Medals extends EsiBase
     public function handle()
     {
 
-        if (! $this->preflighted()) return;
+        Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-        while (true) {
+            if (!$this->preflighted()) return;
 
-            $medals = $this->retrieve([
-                'corporation_id' => $this->getCorporationId(),
-            ]);
+            while (true) {
 
-            if ($medals->isCachedLoad()) return;
-
-            collect($medals)->each(function ($medal) {
-
-                CorporationMedal::firstOrNew([
+                $medals = $this->retrieve([
                     'corporation_id' => $this->getCorporationId(),
-                    'medal_id'       => $medal->medal_id,
-                ])->fill([
-                    'title'       => $medal->title,
-                    'description' => $medal->description,
-                    'creator_id'  => $medal->creator_id,
-                    'created_at'  => carbon($medal->created_at),
-                ])->save();
+                ]);
 
-            });
+                if ($medals->isCachedLoad()) return;
 
-            if (! $this->nextPage($medals->pages))
-                break;
-        }
+                collect($medals)->each(function ($medal) {
+
+                    CorporationMedal::firstOrNew([
+                        'corporation_id' => $this->getCorporationId(),
+                        'medal_id' => $medal->medal_id,
+                    ])->fill([
+                        'title' => $medal->title,
+                        'description' => $medal->description,
+                        'creator_id' => $medal->creator_id,
+                        'created_at' => carbon($medal->created_at),
+                    ])->save();
+
+                });
+
+                if (!$this->nextPage($medals->pages))
+                    break;
+            }
+
+        }, function () {
+
+            return $this->delete();
+
+        });
     }
 }

--- a/src/Jobs/Corporation/Medals.php
+++ b/src/Jobs/Corporation/Medals.php
@@ -65,7 +65,7 @@ class Medals extends AbstractCorporationJob
     protected $page = 1;
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/Medals.php
+++ b/src/Jobs/Corporation/Medals.php
@@ -84,12 +84,12 @@ class Medals extends AbstractCorporationJob
 
                 CorporationMedal::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
-                    'medal_id' => $medal->medal_id,
+                    'medal_id'       => $medal->medal_id,
                 ])->fill([
-                    'title' => $medal->title,
+                    'title'       => $medal->title,
                     'description' => $medal->description,
-                    'creator_id' => $medal->creator_id,
-                    'created_at' => carbon($medal->created_at),
+                    'creator_id'  => $medal->creator_id,
+                    'created_at'  => carbon($medal->created_at),
                 ])->save();
 
             });

--- a/src/Jobs/Corporation/Medals.php
+++ b/src/Jobs/Corporation/Medals.php
@@ -76,7 +76,7 @@ class Medals extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             while (true) {
 
@@ -100,7 +100,7 @@ class Medals extends EsiBase
 
                 });
 
-                if (!$this->nextPage($medals->pages))
+                if (! $this->nextPage($medals->pages))
                     break;
             }
 

--- a/src/Jobs/Corporation/MemberTracking.php
+++ b/src/Jobs/Corporation/MemberTracking.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\Corporation;
 
+use Illuminate\Support\Facades\Redis;
 use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\Corporation\CorporationMemberTracking;
 
@@ -69,34 +70,42 @@ class MemberTracking extends EsiBase
     public function handle()
     {
 
-        if (! $this->preflighted()) return;
+        Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-        $members = $this->retrieve([
-            'corporation_id' => $this->getCorporationId(),
-        ]);
+            if (!$this->preflighted()) return;
 
-        if ($members->isCachedLoad()) return;
-
-        collect($members)->each(function ($member) {
-
-            CorporationMemberTracking::firstOrNew([
+            $members = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
-                'character_id'   => $member->character_id,
-            ])->fill([
-                'start_date'   => property_exists($member, 'start_date') ?
-                    carbon($member->start_date) : null,
-                'base_id'      => $member->base_id ?? null,
-                'logon_date'   => property_exists($member, 'logon_date') ?
-                    carbon($member->logon_date) : null,
-                'logoff_date'  => property_exists($member, 'logoff_date') ?
-                    carbon($member->logoff_date) : null,
-                'location_id'  => $member->location_id ?? null,
-                'ship_type_id' => $member->ship_type_id ?? null,
-            ])->save();
-        });
+            ]);
 
-        CorporationMemberTracking::where('corporation_id', $this->getCorporationId())
-            ->whereNotIn('character_id', collect($members)->pluck('character_id')->all())
-            ->delete();
+            if ($members->isCachedLoad()) return;
+
+            collect($members)->each(function ($member) {
+
+                CorporationMemberTracking::firstOrNew([
+                    'corporation_id' => $this->getCorporationId(),
+                    'character_id' => $member->character_id,
+                ])->fill([
+                    'start_date' => property_exists($member, 'start_date') ?
+                        carbon($member->start_date) : null,
+                    'base_id' => $member->base_id ?? null,
+                    'logon_date' => property_exists($member, 'logon_date') ?
+                        carbon($member->logon_date) : null,
+                    'logoff_date' => property_exists($member, 'logoff_date') ?
+                        carbon($member->logoff_date) : null,
+                    'location_id' => $member->location_id ?? null,
+                    'ship_type_id' => $member->ship_type_id ?? null,
+                ])->save();
+            });
+
+            CorporationMemberTracking::where('corporation_id', $this->getCorporationId())
+                ->whereNotIn('character_id', collect($members)->pluck('character_id')->all())
+                ->delete();
+
+        }, function () {
+
+            return $this->delete();
+
+        });
     }
 }

--- a/src/Jobs/Corporation/MemberTracking.php
+++ b/src/Jobs/Corporation/MemberTracking.php
@@ -62,7 +62,7 @@ class MemberTracking extends AbstractCorporationJob
     protected $tags = ['corporation', 'member_tracking'];
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/MemberTracking.php
+++ b/src/Jobs/Corporation/MemberTracking.php
@@ -72,7 +72,7 @@ class MemberTracking extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $members = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),

--- a/src/Jobs/Corporation/MemberTracking.php
+++ b/src/Jobs/Corporation/MemberTracking.php
@@ -79,16 +79,16 @@ class MemberTracking extends AbstractCorporationJob
 
             CorporationMemberTracking::firstOrNew([
                 'corporation_id' => $this->getCorporationId(),
-                'character_id' => $member->character_id,
+                'character_id'   => $member->character_id,
             ])->fill([
-                'start_date' => property_exists($member, 'start_date') ?
+                'start_date'   => property_exists($member, 'start_date') ?
                     carbon($member->start_date) : null,
-                'base_id' => $member->base_id ?? null,
-                'logon_date' => property_exists($member, 'logon_date') ?
+                'base_id'      => $member->base_id ?? null,
+                'logon_date'   => property_exists($member, 'logon_date') ?
                     carbon($member->logon_date) : null,
-                'logoff_date' => property_exists($member, 'logoff_date') ?
+                'logoff_date'  => property_exists($member, 'logoff_date') ?
                     carbon($member->logoff_date) : null,
-                'location_id' => $member->location_id ?? null,
+                'location_id'  => $member->location_id ?? null,
                 'ship_type_id' => $member->ship_type_id ?? null,
             ])->save();
         });

--- a/src/Jobs/Corporation/Members.php
+++ b/src/Jobs/Corporation/Members.php
@@ -74,7 +74,7 @@ class Members extends AbstractCorporationJob
 
             CorporationMember::firstOrNew([
                 'corporation_id' => $this->getCorporationId(),
-                'character_id' => $member_id,
+                'character_id'   => $member_id,
             ])->save();
 
         });

--- a/src/Jobs/Corporation/Members.php
+++ b/src/Jobs/Corporation/Members.php
@@ -57,7 +57,7 @@ class Members extends AbstractCorporationJob
     protected $tags = ['corporation', 'members'];
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/Members.php
+++ b/src/Jobs/Corporation/Members.php
@@ -68,7 +68,7 @@ class Members extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $members = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),

--- a/src/Jobs/Corporation/MembersLimit.php
+++ b/src/Jobs/Corporation/MembersLimit.php
@@ -62,7 +62,7 @@ class MembersLimit extends AbstractCorporationJob
     protected $tags = ['corporation', 'members', 'limit'];
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/MembersLimit.php
+++ b/src/Jobs/Corporation/MembersLimit.php
@@ -73,7 +73,7 @@ class MembersLimit extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $limit = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
@@ -81,7 +81,7 @@ class MembersLimit extends EsiBase
 
             if ($limit->isCachedLoad()) return;
 
-            if (!property_exists($limit, 'scalar'))
+            if (! property_exists($limit, 'scalar'))
                 return;
 
             CorporationMemberLimits::firstOrNew([

--- a/src/Jobs/Corporation/MembersTitles.php
+++ b/src/Jobs/Corporation/MembersTitles.php
@@ -87,8 +87,8 @@ class MembersTitles extends AbstractCorporationJob
 
                 CorporationMemberTitle::firstOrCreate([
                     'corporation_id' => $this->getCorporationId(),
-                    'character_id' => $member->character_id,
-                    'title_id' => $title,
+                    'character_id'   => $member->character_id,
+                    'title_id'       => $title,
                 ]);
             });
         });

--- a/src/Jobs/Corporation/MembersTitles.php
+++ b/src/Jobs/Corporation/MembersTitles.php
@@ -62,7 +62,7 @@ class MembersTitles extends AbstractCorporationJob
     protected $tags = ['corporation', 'member_titles'];
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/MembersTitles.php
+++ b/src/Jobs/Corporation/MembersTitles.php
@@ -72,7 +72,7 @@ class MembersTitles extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $member_titles = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),

--- a/src/Jobs/Corporation/RoleHistories.php
+++ b/src/Jobs/Corporation/RoleHistories.php
@@ -77,7 +77,7 @@ class RoleHistories extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             while (true) {
 
@@ -121,7 +121,7 @@ class RoleHistories extends EsiBase
 
                 });
 
-                if (!$this->nextPage($roles->pages))
+                if (! $this->nextPage($roles->pages))
                     break;
             }
 

--- a/src/Jobs/Corporation/RoleHistories.php
+++ b/src/Jobs/Corporation/RoleHistories.php
@@ -67,7 +67,7 @@ class RoleHistories extends AbstractCorporationJob
     protected $page = 1;
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/RoleHistories.php
+++ b/src/Jobs/Corporation/RoleHistories.php
@@ -88,11 +88,11 @@ class RoleHistories extends AbstractCorporationJob
 
                     CorporationRoleHistory::firstOrNew([
                         'corporation_id' => $this->getCorporationId(),
-                        'character_id' => $role->character_id,
-                        'changed_at' => carbon($role->changed_at),
-                        'role_type' => $role->role_type,
-                        'state' => 'old',
-                        'role' => $role_id,
+                        'character_id'   => $role->character_id,
+                        'changed_at'     => carbon($role->changed_at),
+                        'role_type'      => $role->role_type,
+                        'state'          => 'old',
+                        'role'           => $role_id,
                     ])->fill([
                         'issuer_id' => $role->issuer_id,
                     ])->save();
@@ -103,11 +103,11 @@ class RoleHistories extends AbstractCorporationJob
 
                     CorporationRoleHistory::firstOrNew([
                         'corporation_id' => $this->getCorporationId(),
-                        'character_id' => $role->character_id,
-                        'changed_at' => carbon($role->changed_at),
-                        'role_type' => $role->role_type,
-                        'state' => 'new',
-                        'role' => $role_id,
+                        'character_id'   => $role->character_id,
+                        'changed_at'     => carbon($role->changed_at),
+                        'role_type'      => $role->role_type,
+                        'state'          => 'new',
+                        'role'           => $role_id,
                     ])->fill([
                         'issuer_id' => $role->issuer_id,
                     ])->save();

--- a/src/Jobs/Corporation/Roles.php
+++ b/src/Jobs/Corporation/Roles.php
@@ -86,7 +86,7 @@ class Roles extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $roles = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
@@ -98,7 +98,7 @@ class Roles extends EsiBase
 
                 collect($this->types)->each(function ($type) use ($role) {
 
-                    if (!property_exists($role, $type))
+                    if (! property_exists($role, $type))
                         return;
 
                     collect($role->{$type})->each(function ($name) use ($role, $type) {

--- a/src/Jobs/Corporation/Roles.php
+++ b/src/Jobs/Corporation/Roles.php
@@ -76,7 +76,7 @@ class Roles extends AbstractCorporationJob
     ];
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/Roles.php
+++ b/src/Jobs/Corporation/Roles.php
@@ -100,9 +100,9 @@ class Roles extends AbstractCorporationJob
 
                     CorporationRole::firstOrCreate([
                         'corporation_id' => $this->getCorporationId(),
-                        'character_id' => $role->character_id,
-                        'type' => $type,
-                        'role' => $name,
+                        'character_id'   => $role->character_id,
+                        'type'           => $type,
+                        'role'           => $name,
                     ]);
 
                 });

--- a/src/Jobs/Corporation/Shareholders.php
+++ b/src/Jobs/Corporation/Shareholders.php
@@ -96,7 +96,7 @@ class Shareholders extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             while (true) {
 
@@ -121,7 +121,7 @@ class Shareholders extends EsiBase
                 $this->known_shareholders->push(collect($shareholders)
                     ->pluck(['shareholder_type', 'shareholder_id'])->flatten()->all());
 
-                if (!$this->nextPage($shareholders->pages))
+                if (! $this->nextPage($shareholders->pages))
                     break;
             }
 

--- a/src/Jobs/Corporation/Shareholders.php
+++ b/src/Jobs/Corporation/Shareholders.php
@@ -86,7 +86,7 @@ class Shareholders extends AbstractCorporationJob
     }
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/Shareholders.php
+++ b/src/Jobs/Corporation/Shareholders.php
@@ -104,9 +104,9 @@ class Shareholders extends AbstractCorporationJob
             collect($shareholders)->each(function ($shareholder) {
 
                 CorporationShareholder::firstOrNew([
-                    'corporation_id' => $this->getCorporationId(),
+                    'corporation_id'   => $this->getCorporationId(),
                     'shareholder_type' => $shareholder->shareholder_type,
-                    'shareholder_id' => $shareholder->shareholder_id,
+                    'shareholder_id'   => $shareholder->shareholder_id,
                 ])->fill([
                     'share_count' => $shareholder->share_count,
                 ])->save();

--- a/src/Jobs/Corporation/Standings.php
+++ b/src/Jobs/Corporation/Standings.php
@@ -62,7 +62,7 @@ class Standings extends AbstractCorporationJob
     protected $page = 1;
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/Standings.php
+++ b/src/Jobs/Corporation/Standings.php
@@ -82,11 +82,11 @@ class Standings extends AbstractCorporationJob
                 $records = $chunk->map(function ($standing, $key) {
                     return [
                         'corporation_id' => $this->getCorporationId(),
-                        'from_type' => $standing->from_type,
-                        'from_id' => $standing->from_id,
-                        'standing' => $standing->standing,
-                        'created_at' => carbon(),
-                        'updated_at' => carbon(),
+                        'from_type'      => $standing->from_type,
+                        'from_id'        => $standing->from_id,
+                        'standing'       => $standing->standing,
+                        'created_at'     => carbon(),
+                        'updated_at'     => carbon(),
                     ];
                 });
 

--- a/src/Jobs/Corporation/Standings.php
+++ b/src/Jobs/Corporation/Standings.php
@@ -72,7 +72,7 @@ class Standings extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             while (true) {
 
@@ -104,7 +104,7 @@ class Standings extends EsiBase
                     ]);
                 });
 
-                if (!$this->nextPage($standings->pages))
+                if (! $this->nextPage($standings->pages))
                     break;
             }
 

--- a/src/Jobs/Corporation/StarbaseDetails.php
+++ b/src/Jobs/Corporation/StarbaseDetails.php
@@ -83,7 +83,7 @@ class StarbaseDetails extends AbstractCorporationJob
     }
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/StarbaseDetails.php
+++ b/src/Jobs/Corporation/StarbaseDetails.php
@@ -99,26 +99,26 @@ class StarbaseDetails extends AbstractCorporationJob
 
                 $detail = $this->retrieve([
                     'corporation_id' => $this->getCorporationId(),
-                    'starbase_id' => $starbase->starbase_id,
+                    'starbase_id'    => $starbase->starbase_id,
                 ]);
 
                 CorporationStarbaseDetail::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
-                    'starbase_id' => $starbase->starbase_id,
+                    'starbase_id'    => $starbase->starbase_id,
                 ])->fill([
-                    'fuel_bay_view' => $detail->fuel_bay_view,
-                    'fuel_bay_take' => $detail->fuel_bay_take,
-                    'anchor' => $detail->anchor,
-                    'unanchor' => $detail->unanchor,
-                    'online' => $detail->online,
-                    'offline' => $detail->offline,
-                    'allow_corporation_members' => $detail->allow_corporation_members,
-                    'allow_alliance_members' => $detail->allow_alliance_members,
-                    'use_alliance_standings' => $detail->use_alliance_standings,
-                    'attack_standing_threshold' => $detail->attack_standing_threshold ?? null,
-                    'attack_security_status_threshold' => $detail->attack_security_status_threshold ?? null,
+                    'fuel_bay_view'                            => $detail->fuel_bay_view,
+                    'fuel_bay_take'                            => $detail->fuel_bay_take,
+                    'anchor'                                   => $detail->anchor,
+                    'unanchor'                                 => $detail->unanchor,
+                    'online'                                   => $detail->online,
+                    'offline'                                  => $detail->offline,
+                    'allow_corporation_members'                => $detail->allow_corporation_members,
+                    'allow_alliance_members'                   => $detail->allow_alliance_members,
+                    'use_alliance_standings'                   => $detail->use_alliance_standings,
+                    'attack_standing_threshold'                => $detail->attack_standing_threshold ?? null,
+                    'attack_security_status_threshold'         => $detail->attack_security_status_threshold ?? null,
                     'attack_if_other_security_status_dropping' => $detail->attack_if_other_security_status_dropping,
-                    'attack_if_at_war' => $detail->attack_if_at_war,
+                    'attack_if_at_war'                         => $detail->attack_if_at_war,
                 ])->save();
 
                 if (property_exists($detail, 'fuels'))
@@ -127,8 +127,8 @@ class StarbaseDetails extends AbstractCorporationJob
 
                         CorporationStarbaseFuel::firstOrNew([
                             'corporation_id' => $this->getCorporationId(),
-                            'starbase_id' => $starbase->starbase_id,
-                            'type_id' => $fuel->type_id,
+                            'starbase_id'    => $starbase->starbase_id,
+                            'type_id'        => $fuel->type_id,
                         ])->fill([
                             'quantity' => $fuel->quantity,
                         ])->save();

--- a/src/Jobs/Corporation/StarbaseDetails.php
+++ b/src/Jobs/Corporation/StarbaseDetails.php
@@ -93,7 +93,7 @@ class StarbaseDetails extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             CorporationStarbase::where('corporation_id', $this->getCorporationId())
                 ->get()->each(function ($starbase) {

--- a/src/Jobs/Corporation/Starbases.php
+++ b/src/Jobs/Corporation/Starbases.php
@@ -105,17 +105,17 @@ class Starbases extends AbstractCorporationJob
 
                 CorporationStarbase::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
-                    'starbase_id' => $starbase->starbase_id,
+                    'starbase_id'    => $starbase->starbase_id,
                 ])->fill([
-                    'moon_id' => $starbase->moon_id ?? null,
-                    'onlined_since' => property_exists($starbase, 'onlined_since') ?
+                    'moon_id'          => $starbase->moon_id ?? null,
+                    'onlined_since'    => property_exists($starbase, 'onlined_since') ?
                         carbon($starbase->onlined_since) : null,
                     'reinforced_until' => property_exists($starbase, 'reinforced_until') ?
                         carbon($starbase->reinforced_until) : null,
-                    'state' => $starbase->state ?? null,
-                    'type_id' => $starbase->type_id,
-                    'system_id' => $starbase->system_id,
-                    'unanchor_at' => property_exists($starbase, 'unanchor_at') ?
+                    'state'            => $starbase->state ?? null,
+                    'type_id'          => $starbase->type_id,
+                    'system_id'        => $starbase->system_id,
+                    'unanchor_at'      => property_exists($starbase, 'unanchor_at') ?
                         carbon($starbase->unanchor_at) : null,
                 ])->save();
 

--- a/src/Jobs/Corporation/Starbases.php
+++ b/src/Jobs/Corporation/Starbases.php
@@ -96,7 +96,7 @@ class Starbases extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             while (true) {
 
@@ -128,7 +128,7 @@ class Starbases extends EsiBase
 
                 });
 
-                if (!$this->nextPage($starbases->pages))
+                if (! $this->nextPage($starbases->pages))
                     break;
             }
 

--- a/src/Jobs/Corporation/Starbases.php
+++ b/src/Jobs/Corporation/Starbases.php
@@ -86,7 +86,7 @@ class Starbases extends AbstractCorporationJob
     }
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/Structures.php
+++ b/src/Jobs/Corporation/Structures.php
@@ -22,8 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\Corporation;
 
-use Illuminate\Support\Facades\Redis;
-use Seat\Eveapi\Jobs\EsiBase;
+use Seat\Eveapi\Jobs\AbstractCorporationJob;
 use Seat\Eveapi\Models\Corporation\CorporationStructure;
 use Seat\Eveapi\Models\Corporation\CorporationStructureService;
 use Seat\Eveapi\Models\RefreshToken;
@@ -33,7 +32,7 @@ use Seat\Eveapi\Models\Universe\UniverseStructure;
  * Class Structures.
  * @package Seat\Eveapi\Jobs\Corporation
  */
-class Structures extends EsiBase
+class Structures extends AbstractCorporationJob
 {
     /**
      * @var string
@@ -89,117 +88,107 @@ class Structures extends EsiBase
     }
 
     /**
-     * Execute the job.
+     * Contains the job process.
      *
+     * @return void
      * @throws \Throwable
      */
-    public function handle()
+    protected function job(): void
     {
+        while (true) {
 
-        Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
+            $structures = $this->retrieve([
+                'corporation_id' => $this->getCorporationId(),
+            ]);
 
-            if (! $this->preflighted()) return;
+            if ($structures->isCachedLoad()) return;
 
-            while (true) {
+            collect($structures)->each(function ($structure) {
 
-                $structures = $this->retrieve([
-                    'corporation_id' => $this->getCorporationId(),
+                // Ensure that we have an entry for this structure_id in the
+                // UniverseStructures model. We set the name to unknown for now
+                // but this will update when that models updater runs.
+                $model = UniverseStructure::firstOrNew([
+                    'structure_id' => $structure->structure_id,
+                ])->fill([
+                    'solar_system_id' => $structure->system_id,
+                    'type_id' => $structure->type_id,
+                    'name' => 'Unknown Structure',
+                    'x' => 0.0,
+                    'y' => 0.0,
+                    'z' => 0.0,
                 ]);
 
-                if ($structures->isCachedLoad()) return;
+                // Persist the structure only if it doesn't already exists
+                if (! $model->exists) $model->save();
 
-                collect($structures)->each(function ($structure) {
+                CorporationStructure::firstOrNew([
+                    'corporation_id' => $structure->corporation_id,
+                    'structure_id' => $structure->structure_id,
+                ])->fill([
+                    'type_id' => $structure->type_id,
+                    'system_id' => $structure->system_id,
+                    'profile_id' => $structure->profile_id,
+                    'fuel_expires' => property_exists($structure, 'fuel_expires') ?
+                        carbon($structure->fuel_expires) : null,
+                    'state_timer_start' => property_exists($structure, 'state_timer_start') ?
+                        carbon($structure->state_timer_start) : null,
+                    'state_timer_end' => property_exists($structure, 'state_timer_end') ?
+                        carbon($structure->state_timer_end) : null,
+                    'unanchors_at' => property_exists($structure, 'unanchors_at') ?
+                        carbon($structure->unanchors_at) : null,
+                    'state' => $structure->state,
+                    'reinforce_weekday' => $structure->reinforce_weekday,
+                    'reinforce_hour' => $structure->reinforce_hour,
+                    'next_reinforce_weekday' => $structure->next_reinforce_weekday ?? null,
+                    'next_reinforce_hour' => $structure->next_reinforce_hour ?? null,
+                    'next_reinforce_apply' => property_exists($structure, 'next_reinforce_apply') ?
+                        carbon($structure->next_reinforce_apply) : null,
+                ])->save();
 
-                    // Ensure that we have an entry for this structure_id in the
-                    // UniverseStructures model. We set the name to unknown for now
-                    // but this will update when that models updater runs.
-                    $model = UniverseStructure::firstOrNew([
-                        'structure_id' => $structure->structure_id,
-                    ])->fill([
-                        'solar_system_id' => $structure->system_id,
-                        'type_id' => $structure->type_id,
-                        'name' => 'Unknown Structure',
-                        'x' => 0.0,
-                        'y' => 0.0,
-                        'z' => 0.0,
-                    ]);
+                if (property_exists($structure, 'services')) {
 
-                    // Persist the structure only if it doesn't already exists
-                    if (! $model->exists) $model->save();
+                    collect($structure->services)->each(function ($service) use ($structure) {
 
-                    CorporationStructure::firstOrNew([
-                        'corporation_id' => $structure->corporation_id,
-                        'structure_id' => $structure->structure_id,
-                    ])->fill([
-                        'type_id' => $structure->type_id,
-                        'system_id' => $structure->system_id,
-                        'profile_id' => $structure->profile_id,
-                        'fuel_expires' => property_exists($structure, 'fuel_expires') ?
-                            carbon($structure->fuel_expires) : null,
-                        'state_timer_start' => property_exists($structure, 'state_timer_start') ?
-                            carbon($structure->state_timer_start) : null,
-                        'state_timer_end' => property_exists($structure, 'state_timer_end') ?
-                            carbon($structure->state_timer_end) : null,
-                        'unanchors_at' => property_exists($structure, 'unanchors_at') ?
-                            carbon($structure->unanchors_at) : null,
-                        'state' => $structure->state,
-                        'reinforce_weekday' => $structure->reinforce_weekday,
-                        'reinforce_hour' => $structure->reinforce_hour,
-                        'next_reinforce_weekday' => $structure->next_reinforce_weekday ?? null,
-                        'next_reinforce_hour' => $structure->next_reinforce_hour ?? null,
-                        'next_reinforce_apply' => property_exists($structure, 'next_reinforce_apply') ?
-                            carbon($structure->next_reinforce_apply) : null,
-                    ])->save();
+                        CorporationStructureService::firstOrNew([
+                            'corporation_id' => $structure->corporation_id,
+                            'structure_id' => $structure->structure_id,
+                            'name' => $service->name,
+                        ])->fill([
+                            'state' => $service->state,
+                        ])->save();
+                    });
 
-                    if (property_exists($structure, 'services')) {
+                    // Cleanup Services that may no longer be applicable to this structure.
+                    CorporationStructureService::where('corporation_id', $structure->corporation_id)
+                        ->where('structure_id', $structure->structure_id)
+                        ->whereNotIn('name', collect($structure->services)
+                            ->pluck('name')->flatten()->all())
+                        ->delete();
 
-                        collect($structure->services)->each(function ($service) use ($structure) {
+                } else {
 
-                            CorporationStructureService::firstOrNew([
-                                'corporation_id' => $structure->corporation_id,
-                                'structure_id' => $structure->structure_id,
-                                'name' => $service->name,
-                            ])->fill([
-                                'state' => $service->state,
-                            ])->save();
-                        });
+                    // If no services are defined on this structure, remove all of the
+                    // ones we might have in the database.
+                    CorporationStructureService::where('corporation_id', $structure->corporation_id)
+                        ->where('structure_id', $structure->structure_id)
+                        ->delete();
+                }
 
-                        // Cleanup Services that may no longer be applicable to this structure.
-                        CorporationStructureService::where('corporation_id', $structure->corporation_id)
-                            ->where('structure_id', $structure->structure_id)
-                            ->whereNotIn('name', collect($structure->services)
-                                ->pluck('name')->flatten()->all())
-                            ->delete();
+                $this->known_structures->push($structure->structure_id);
+            });
 
-                    } else {
+            if (! $this->nextPage($structures->pages))
+                break;
+        }
 
-                        // If no services are defined on this structure, remove all of the
-                        // ones we might have in the database.
-                        CorporationStructureService::where('corporation_id', $structure->corporation_id)
-                            ->where('structure_id', $structure->structure_id)
-                            ->delete();
-                    }
+        // Cleanup services and structures that were not in the response.
+        CorporationStructureService::where('corporation_id', $this->getCorporationId())
+            ->whereNotIn('structure_id', $this->known_structures->flatten()->all())
+            ->delete();
 
-                    $this->known_structures->push($structure->structure_id);
-                });
-
-                if (! $this->nextPage($structures->pages))
-                    break;
-            }
-
-            // Cleanup services and structures that were not in the response.
-            CorporationStructureService::where('corporation_id', $this->getCorporationId())
-                ->whereNotIn('structure_id', $this->known_structures->flatten()->all())
-                ->delete();
-
-            CorporationStructure::where('corporation_id', $this->getCorporationId())
-                ->whereNotIn('structure_id', $this->known_structures->flatten()->all())
-                ->delete();
-
-        }, function () {
-
-            return $this->delete();
-
-        });
+        CorporationStructure::where('corporation_id', $this->getCorporationId())
+            ->whereNotIn('structure_id', $this->known_structures->flatten()->all())
+            ->delete();
     }
 }

--- a/src/Jobs/Corporation/Structures.php
+++ b/src/Jobs/Corporation/Structures.php
@@ -88,7 +88,7 @@ class Structures extends AbstractCorporationJob
     }
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/Structures.php
+++ b/src/Jobs/Corporation/Structures.php
@@ -112,11 +112,11 @@ class Structures extends AbstractCorporationJob
                     'structure_id' => $structure->structure_id,
                 ])->fill([
                     'solar_system_id' => $structure->system_id,
-                    'type_id' => $structure->type_id,
-                    'name' => 'Unknown Structure',
-                    'x' => 0.0,
-                    'y' => 0.0,
-                    'z' => 0.0,
+                    'type_id'         => $structure->type_id,
+                    'name'            => 'Unknown Structure',
+                    'x'               => 0.0,
+                    'y'               => 0.0,
+                    'z'               => 0.0,
                 ]);
 
                 // Persist the structure only if it doesn't already exists
@@ -124,25 +124,25 @@ class Structures extends AbstractCorporationJob
 
                 CorporationStructure::firstOrNew([
                     'corporation_id' => $structure->corporation_id,
-                    'structure_id' => $structure->structure_id,
+                    'structure_id'   => $structure->structure_id,
                 ])->fill([
-                    'type_id' => $structure->type_id,
-                    'system_id' => $structure->system_id,
-                    'profile_id' => $structure->profile_id,
-                    'fuel_expires' => property_exists($structure, 'fuel_expires') ?
+                    'type_id'                => $structure->type_id,
+                    'system_id'              => $structure->system_id,
+                    'profile_id'             => $structure->profile_id,
+                    'fuel_expires'           => property_exists($structure, 'fuel_expires') ?
                         carbon($structure->fuel_expires) : null,
-                    'state_timer_start' => property_exists($structure, 'state_timer_start') ?
+                    'state_timer_start'      => property_exists($structure, 'state_timer_start') ?
                         carbon($structure->state_timer_start) : null,
-                    'state_timer_end' => property_exists($structure, 'state_timer_end') ?
+                    'state_timer_end'        => property_exists($structure, 'state_timer_end') ?
                         carbon($structure->state_timer_end) : null,
-                    'unanchors_at' => property_exists($structure, 'unanchors_at') ?
+                    'unanchors_at'           => property_exists($structure, 'unanchors_at') ?
                         carbon($structure->unanchors_at) : null,
-                    'state' => $structure->state,
-                    'reinforce_weekday' => $structure->reinforce_weekday,
-                    'reinforce_hour' => $structure->reinforce_hour,
+                    'state'                  => $structure->state,
+                    'reinforce_weekday'      => $structure->reinforce_weekday,
+                    'reinforce_hour'         => $structure->reinforce_hour,
                     'next_reinforce_weekday' => $structure->next_reinforce_weekday ?? null,
-                    'next_reinforce_hour' => $structure->next_reinforce_hour ?? null,
-                    'next_reinforce_apply' => property_exists($structure, 'next_reinforce_apply') ?
+                    'next_reinforce_hour'    => $structure->next_reinforce_hour ?? null,
+                    'next_reinforce_apply'   => property_exists($structure, 'next_reinforce_apply') ?
                         carbon($structure->next_reinforce_apply) : null,
                 ])->save();
 
@@ -152,8 +152,8 @@ class Structures extends AbstractCorporationJob
 
                         CorporationStructureService::firstOrNew([
                             'corporation_id' => $structure->corporation_id,
-                            'structure_id' => $structure->structure_id,
-                            'name' => $service->name,
+                            'structure_id'   => $structure->structure_id,
+                            'name'           => $service->name,
                         ])->fill([
                             'state' => $service->state,
                         ])->save();

--- a/src/Jobs/Corporation/Structures.php
+++ b/src/Jobs/Corporation/Structures.php
@@ -98,7 +98,7 @@ class Structures extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             while (true) {
 
@@ -125,7 +125,7 @@ class Structures extends EsiBase
                     ]);
 
                     // Persist the structure only if it doesn't already exists
-                    if (!$model->exists) $model->save();
+                    if (! $model->exists) $model->save();
 
                     CorporationStructure::firstOrNew([
                         'corporation_id' => $structure->corporation_id,
@@ -183,7 +183,7 @@ class Structures extends EsiBase
                     $this->known_structures->push($structure->structure_id);
                 });
 
-                if (!$this->nextPage($structures->pages))
+                if (! $this->nextPage($structures->pages))
                     break;
             }
 

--- a/src/Jobs/Corporation/Structures.php
+++ b/src/Jobs/Corporation/Structures.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\Corporation;
 
+use Illuminate\Support\Facades\Redis;
 use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\Corporation\CorporationStructure;
 use Seat\Eveapi\Models\Corporation\CorporationStructureService;
@@ -95,102 +96,110 @@ class Structures extends EsiBase
     public function handle()
     {
 
-        if (! $this->preflighted()) return;
+        Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-        while (true) {
+            if (!$this->preflighted()) return;
 
-            $structures = $this->retrieve([
-                'corporation_id' => $this->getCorporationId(),
-            ]);
+            while (true) {
 
-            if ($structures->isCachedLoad()) return;
-
-            collect($structures)->each(function ($structure) {
-
-                // Ensure that we have an entry for this structure_id in the
-                // UniverseStructures model. We set the name to unknown for now
-                // but this will update when that models updater runs.
-                $model = UniverseStructure::firstOrNew([
-                    'structure_id' => $structure->structure_id,
-                ])->fill([
-                    'solar_system_id' => $structure->system_id,
-                    'type_id'         => $structure->type_id,
-                    'name'            => 'Unknown Structure',
-                    'x'               => 0.0,
-                    'y'               => 0.0,
-                    'z'               => 0.0,
+                $structures = $this->retrieve([
+                    'corporation_id' => $this->getCorporationId(),
                 ]);
 
-                // Persist the structure only if it doesn't already exists
-                if (! $model->exists) $model->save();
+                if ($structures->isCachedLoad()) return;
 
-                CorporationStructure::firstOrNew([
-                    'corporation_id' => $structure->corporation_id,
-                    'structure_id'   => $structure->structure_id,
-                ])->fill([
-                    'type_id'                => $structure->type_id,
-                    'system_id'              => $structure->system_id,
-                    'profile_id'             => $structure->profile_id,
-                    'fuel_expires'           => property_exists($structure, 'fuel_expires') ?
-                        carbon($structure->fuel_expires) : null,
-                    'state_timer_start'      => property_exists($structure, 'state_timer_start') ?
-                        carbon($structure->state_timer_start) : null,
-                    'state_timer_end'        => property_exists($structure, 'state_timer_end') ?
-                        carbon($structure->state_timer_end) : null,
-                    'unanchors_at'           => property_exists($structure, 'unanchors_at') ?
-                        carbon($structure->unanchors_at) : null,
-                    'state'                  => $structure->state,
-                    'reinforce_weekday'      => $structure->reinforce_weekday,
-                    'reinforce_hour'         => $structure->reinforce_hour,
-                    'next_reinforce_weekday' => $structure->next_reinforce_weekday ?? null,
-                    'next_reinforce_hour'    => $structure->next_reinforce_hour ?? null,
-                    'next_reinforce_apply'   => property_exists($structure, 'next_reinforce_apply') ?
-                        carbon($structure->next_reinforce_apply) : null,
-                ])->save();
+                collect($structures)->each(function ($structure) {
 
-                if (property_exists($structure, 'services')) {
+                    // Ensure that we have an entry for this structure_id in the
+                    // UniverseStructures model. We set the name to unknown for now
+                    // but this will update when that models updater runs.
+                    $model = UniverseStructure::firstOrNew([
+                        'structure_id' => $structure->structure_id,
+                    ])->fill([
+                        'solar_system_id' => $structure->system_id,
+                        'type_id' => $structure->type_id,
+                        'name' => 'Unknown Structure',
+                        'x' => 0.0,
+                        'y' => 0.0,
+                        'z' => 0.0,
+                    ]);
 
-                    collect($structure->services)->each(function ($service) use ($structure) {
+                    // Persist the structure only if it doesn't already exists
+                    if (!$model->exists) $model->save();
 
-                        CorporationStructureService::firstOrNew([
-                            'corporation_id' => $structure->corporation_id,
-                            'structure_id'   => $structure->structure_id,
-                            'name'           => $service->name,
-                        ])->fill([
-                            'state' => $service->state,
-                        ])->save();
-                    });
+                    CorporationStructure::firstOrNew([
+                        'corporation_id' => $structure->corporation_id,
+                        'structure_id' => $structure->structure_id,
+                    ])->fill([
+                        'type_id' => $structure->type_id,
+                        'system_id' => $structure->system_id,
+                        'profile_id' => $structure->profile_id,
+                        'fuel_expires' => property_exists($structure, 'fuel_expires') ?
+                            carbon($structure->fuel_expires) : null,
+                        'state_timer_start' => property_exists($structure, 'state_timer_start') ?
+                            carbon($structure->state_timer_start) : null,
+                        'state_timer_end' => property_exists($structure, 'state_timer_end') ?
+                            carbon($structure->state_timer_end) : null,
+                        'unanchors_at' => property_exists($structure, 'unanchors_at') ?
+                            carbon($structure->unanchors_at) : null,
+                        'state' => $structure->state,
+                        'reinforce_weekday' => $structure->reinforce_weekday,
+                        'reinforce_hour' => $structure->reinforce_hour,
+                        'next_reinforce_weekday' => $structure->next_reinforce_weekday ?? null,
+                        'next_reinforce_hour' => $structure->next_reinforce_hour ?? null,
+                        'next_reinforce_apply' => property_exists($structure, 'next_reinforce_apply') ?
+                            carbon($structure->next_reinforce_apply) : null,
+                    ])->save();
 
-                    // Cleanup Services that may no longer be applicable to this structure.
-                    CorporationStructureService::where('corporation_id', $structure->corporation_id)
-                        ->where('structure_id', $structure->structure_id)
-                        ->whereNotIn('name', collect($structure->services)
-                            ->pluck('name')->flatten()->all())
-                        ->delete();
+                    if (property_exists($structure, 'services')) {
 
-                } else {
+                        collect($structure->services)->each(function ($service) use ($structure) {
 
-                    // If no services are defined on this structure, remove all of the
-                    // ones we might have in the database.
-                    CorporationStructureService::where('corporation_id', $structure->corporation_id)
-                        ->where('structure_id', $structure->structure_id)
-                        ->delete();
-                }
+                            CorporationStructureService::firstOrNew([
+                                'corporation_id' => $structure->corporation_id,
+                                'structure_id' => $structure->structure_id,
+                                'name' => $service->name,
+                            ])->fill([
+                                'state' => $service->state,
+                            ])->save();
+                        });
 
-                $this->known_structures->push($structure->structure_id);
-            });
+                        // Cleanup Services that may no longer be applicable to this structure.
+                        CorporationStructureService::where('corporation_id', $structure->corporation_id)
+                            ->where('structure_id', $structure->structure_id)
+                            ->whereNotIn('name', collect($structure->services)
+                                ->pluck('name')->flatten()->all())
+                            ->delete();
 
-            if (! $this->nextPage($structures->pages))
-                break;
-        }
+                    } else {
 
-        // Cleanup services and structures that were not in the response.
-        CorporationStructureService::where('corporation_id', $this->getCorporationId())
-            ->whereNotIn('structure_id', $this->known_structures->flatten()->all())
-            ->delete();
+                        // If no services are defined on this structure, remove all of the
+                        // ones we might have in the database.
+                        CorporationStructureService::where('corporation_id', $structure->corporation_id)
+                            ->where('structure_id', $structure->structure_id)
+                            ->delete();
+                    }
 
-        CorporationStructure::where('corporation_id', $this->getCorporationId())
-            ->whereNotIn('structure_id', $this->known_structures->flatten()->all())
-            ->delete();
+                    $this->known_structures->push($structure->structure_id);
+                });
+
+                if (!$this->nextPage($structures->pages))
+                    break;
+            }
+
+            // Cleanup services and structures that were not in the response.
+            CorporationStructureService::where('corporation_id', $this->getCorporationId())
+                ->whereNotIn('structure_id', $this->known_structures->flatten()->all())
+                ->delete();
+
+            CorporationStructure::where('corporation_id', $this->getCorporationId())
+                ->whereNotIn('structure_id', $this->known_structures->flatten()->all())
+                ->delete();
+
+        }, function () {
+
+            return $this->delete();
+
+        });
     }
 }

--- a/src/Jobs/Corporation/Titles.php
+++ b/src/Jobs/Corporation/Titles.php
@@ -96,7 +96,7 @@ class Titles extends AbstractCorporationJob
     }
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Corporation/Titles.php
+++ b/src/Jobs/Corporation/Titles.php
@@ -113,7 +113,7 @@ class Titles extends AbstractCorporationJob
 
             CorporationTitle::firstOrNew([
                 'corporation_id' => $this->getCorporationId(),
-                'title_id' => $title->title_id,
+                'title_id'       => $title->title_id,
             ])->fill([
                 'name' => $title->name ?? sprintf('Untitled %d', (int) sqrt($title->title_id - 1)),
             ])->save();
@@ -127,9 +127,9 @@ class Titles extends AbstractCorporationJob
 
                     CorporationTitleRole::firstOrCreate([
                         'corporation_id' => $this->getCorporationId(),
-                        'title_id' => $title->title_id,
-                        'type' => $type,
-                        'role' => $name,
+                        'title_id'       => $title->title_id,
+                        'type'           => $type,
+                        'role'           => $name,
                     ]);
                 });
 

--- a/src/Jobs/Corporation/Titles.php
+++ b/src/Jobs/Corporation/Titles.php
@@ -106,7 +106,7 @@ class Titles extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $titles = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
@@ -120,12 +120,12 @@ class Titles extends EsiBase
                     'corporation_id' => $this->getCorporationId(),
                     'title_id' => $title->title_id,
                 ])->fill([
-                    'name' => $title->name ?? sprintf('Untitled %d', (int)sqrt($title->title_id - 1)),
+                    'name' => $title->name ?? sprintf('Untitled %d', (int) sqrt($title->title_id - 1)),
                 ])->save();
 
                 collect($this->types)->each(function ($type) use ($title) {
 
-                    if (!property_exists($title, $type))
+                    if (! property_exists($title, $type))
                         return;
 
                     collect($title->{$type})->each(function ($name) use ($title, $type) {

--- a/src/Jobs/Industry/Corporation/Jobs.php
+++ b/src/Jobs/Industry/Corporation/Jobs.php
@@ -93,31 +93,31 @@ class Jobs extends AbstractCorporationJob
 
                 CorporationIndustryJob::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
-                    'job_id' => $job->job_id,
+                    'job_id'         => $job->job_id,
                 ])->fill([
-                    'installer_id' => $job->installer_id,
-                    'facility_id' => $job->facility_id,
-                    'location_id' => $job->location_id,
-                    'activity_id' => $job->activity_id,
-                    'blueprint_id' => $job->blueprint_id,
-                    'blueprint_type_id' => $job->blueprint_type_id,
-                    'blueprint_location_id' => $job->blueprint_location_id,
-                    'output_location_id' => $job->output_location_id,
-                    'runs' => $job->runs,
-                    'cost' => $job->cost ?? null,
-                    'licensed_runs' => $job->licensed_runs ?? null,
-                    'probability' => $job->probability ?? null,
-                    'product_type_id' => $job->product_type_id ?? null,
-                    'status' => $job->status,
-                    'duration' => $job->duration,
-                    'start_date' => carbon($job->start_date),
-                    'end_date' => carbon($job->end_date),
-                    'pause_date' => property_exists($job, 'pause_date') ?
+                    'installer_id'           => $job->installer_id,
+                    'facility_id'            => $job->facility_id,
+                    'location_id'            => $job->location_id,
+                    'activity_id'            => $job->activity_id,
+                    'blueprint_id'           => $job->blueprint_id,
+                    'blueprint_type_id'      => $job->blueprint_type_id,
+                    'blueprint_location_id'  => $job->blueprint_location_id,
+                    'output_location_id'     => $job->output_location_id,
+                    'runs'                   => $job->runs,
+                    'cost'                   => $job->cost ?? null,
+                    'licensed_runs'          => $job->licensed_runs ?? null,
+                    'probability'            => $job->probability ?? null,
+                    'product_type_id'        => $job->product_type_id ?? null,
+                    'status'                 => $job->status,
+                    'duration'               => $job->duration,
+                    'start_date'             => carbon($job->start_date),
+                    'end_date'               => carbon($job->end_date),
+                    'pause_date'             => property_exists($job, 'pause_date') ?
                         carbon($job->pause_date) : null,
-                    'completed_date' => property_exists($job, 'completed_date') ?
+                    'completed_date'         => property_exists($job, 'completed_date') ?
                         carbon($job->completed_date) : null,
                     'completed_character_id' => $job->completed_character_id ?? null,
-                    'successful_runs' => $job->successful_runs ?? null,
+                    'successful_runs'        => $job->successful_runs ?? null,
                 ])->save();
             });
 

--- a/src/Jobs/Industry/Corporation/Jobs.php
+++ b/src/Jobs/Industry/Corporation/Jobs.php
@@ -22,15 +22,14 @@
 
 namespace Seat\Eveapi\Jobs\Industry\Corporation;
 
-use Illuminate\Support\Facades\Redis;
-use Seat\Eveapi\Jobs\EsiBase;
+use Seat\Eveapi\Jobs\AbstractCorporationJob;
 use Seat\Eveapi\Models\Industry\CorporationIndustryJob;
 
 /**
  * Class Jobs.
  * @package Seat\Eveapi\Jobs\Industry\Corporation
  */
-class Jobs extends EsiBase
+class Jobs extends AbstractCorporationJob
 {
     /**
      * @var string
@@ -75,65 +74,55 @@ class Jobs extends EsiBase
     protected $page = 1;
 
     /**
-     * Execute the job.
+     * Contains the job process.
      *
+     * @return void
      * @throws \Throwable
      */
-    public function handle()
+    protected function job(): void
     {
+        while (true) {
 
-        Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
+            $industry_jobs = $this->retrieve([
+                'corporation_id' => $this->getCorporationId(),
+            ]);
 
-            if (! $this->preflighted()) return;
+            if ($industry_jobs->isCachedLoad()) return;
 
-            while (true) {
+            collect($industry_jobs)->each(function ($job) {
 
-                $industry_jobs = $this->retrieve([
+                CorporationIndustryJob::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
-                ]);
+                    'job_id' => $job->job_id,
+                ])->fill([
+                    'installer_id' => $job->installer_id,
+                    'facility_id' => $job->facility_id,
+                    'location_id' => $job->location_id,
+                    'activity_id' => $job->activity_id,
+                    'blueprint_id' => $job->blueprint_id,
+                    'blueprint_type_id' => $job->blueprint_type_id,
+                    'blueprint_location_id' => $job->blueprint_location_id,
+                    'output_location_id' => $job->output_location_id,
+                    'runs' => $job->runs,
+                    'cost' => $job->cost ?? null,
+                    'licensed_runs' => $job->licensed_runs ?? null,
+                    'probability' => $job->probability ?? null,
+                    'product_type_id' => $job->product_type_id ?? null,
+                    'status' => $job->status,
+                    'duration' => $job->duration,
+                    'start_date' => carbon($job->start_date),
+                    'end_date' => carbon($job->end_date),
+                    'pause_date' => property_exists($job, 'pause_date') ?
+                        carbon($job->pause_date) : null,
+                    'completed_date' => property_exists($job, 'completed_date') ?
+                        carbon($job->completed_date) : null,
+                    'completed_character_id' => $job->completed_character_id ?? null,
+                    'successful_runs' => $job->successful_runs ?? null,
+                ])->save();
+            });
 
-                if ($industry_jobs->isCachedLoad()) return;
-
-                collect($industry_jobs)->each(function ($job) {
-
-                    CorporationIndustryJob::firstOrNew([
-                        'corporation_id' => $this->getCorporationId(),
-                        'job_id' => $job->job_id,
-                    ])->fill([
-                        'installer_id' => $job->installer_id,
-                        'facility_id' => $job->facility_id,
-                        'location_id' => $job->location_id,
-                        'activity_id' => $job->activity_id,
-                        'blueprint_id' => $job->blueprint_id,
-                        'blueprint_type_id' => $job->blueprint_type_id,
-                        'blueprint_location_id' => $job->blueprint_location_id,
-                        'output_location_id' => $job->output_location_id,
-                        'runs' => $job->runs,
-                        'cost' => $job->cost ?? null,
-                        'licensed_runs' => $job->licensed_runs ?? null,
-                        'probability' => $job->probability ?? null,
-                        'product_type_id' => $job->product_type_id ?? null,
-                        'status' => $job->status,
-                        'duration' => $job->duration,
-                        'start_date' => carbon($job->start_date),
-                        'end_date' => carbon($job->end_date),
-                        'pause_date' => property_exists($job, 'pause_date') ?
-                            carbon($job->pause_date) : null,
-                        'completed_date' => property_exists($job, 'completed_date') ?
-                            carbon($job->completed_date) : null,
-                        'completed_character_id' => $job->completed_character_id ?? null,
-                        'successful_runs' => $job->successful_runs ?? null,
-                    ])->save();
-                });
-
-                if (! $this->nextPage($industry_jobs->pages))
-                    return;
-            }
-
-        }, function () {
-
-            return $this->delete();
-
-        });
+            if (! $this->nextPage($industry_jobs->pages))
+                return;
+        }
     }
 }

--- a/src/Jobs/Industry/Corporation/Jobs.php
+++ b/src/Jobs/Industry/Corporation/Jobs.php
@@ -74,7 +74,7 @@ class Jobs extends AbstractCorporationJob
     protected $page = 1;
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Industry/Corporation/Jobs.php
+++ b/src/Jobs/Industry/Corporation/Jobs.php
@@ -84,7 +84,7 @@ class Jobs extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             while (true) {
 
@@ -126,7 +126,7 @@ class Jobs extends EsiBase
                     ])->save();
                 });
 
-                if (!$this->nextPage($industry_jobs->pages))
+                if (! $this->nextPage($industry_jobs->pages))
                     return;
             }
 

--- a/src/Jobs/Industry/Corporation/Mining/Extractions.php
+++ b/src/Jobs/Industry/Corporation/Mining/Extractions.php
@@ -62,7 +62,7 @@ class Extractions extends AbstractCorporationJob
     protected $tags = ['corporation', 'mining', 'extractions'];
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Industry/Corporation/Mining/Extractions.php
+++ b/src/Jobs/Industry/Corporation/Mining/Extractions.php
@@ -72,7 +72,7 @@ class Extractions extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $mining_extractions = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),

--- a/src/Jobs/Industry/Corporation/Mining/Extractions.php
+++ b/src/Jobs/Industry/Corporation/Mining/Extractions.php
@@ -79,12 +79,12 @@ class Extractions extends AbstractCorporationJob
 
             CorporationIndustryMiningExtraction::firstOrNew([
                 'corporation_id' => $this->getCorporationId(),
-                'structure_id' => $extraction->structure_id,
+                'structure_id'   => $extraction->structure_id,
             ])->fill([
                 'extraction_start_time' => carbon($extraction->extraction_start_time),
-                'moon_id' => $extraction->moon_id,
-                'chunk_arrival_time' => carbon($extraction->chunk_arrival_time),
-                'natural_decay_time' => carbon($extraction->natural_decay_time),
+                'moon_id'               => $extraction->moon_id,
+                'chunk_arrival_time'    => carbon($extraction->chunk_arrival_time),
+                'natural_decay_time'    => carbon($extraction->natural_decay_time),
             ])->save();
         });
     }

--- a/src/Jobs/Industry/Corporation/Mining/ObserverDetails.php
+++ b/src/Jobs/Industry/Corporation/Mining/ObserverDetails.php
@@ -70,7 +70,7 @@ class ObserverDetails extends AbstractCorporationJob
     protected $page = 1;
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Industry/Corporation/Mining/Observers.php
+++ b/src/Jobs/Industry/Corporation/Mining/Observers.php
@@ -79,7 +79,7 @@ class Observers extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $mining_observers = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),

--- a/src/Jobs/Industry/Corporation/Mining/Observers.php
+++ b/src/Jobs/Industry/Corporation/Mining/Observers.php
@@ -86,9 +86,9 @@ class Observers extends AbstractCorporationJob
 
             CorporationIndustryMiningObserver::firstOrNew([
                 'corporation_id' => $this->getCorporationId(),
-                'observer_id' => $observer->observer_id,
+                'observer_id'    => $observer->observer_id,
             ])->fill([
-                'last_updated' => carbon($observer->last_updated),
+                'last_updated'  => carbon($observer->last_updated),
                 'observer_type' => $observer->observer_type,
             ])->save();
         });

--- a/src/Jobs/Industry/Corporation/Mining/Observers.php
+++ b/src/Jobs/Industry/Corporation/Mining/Observers.php
@@ -69,7 +69,7 @@ class Observers extends AbstractCorporationJob
     protected $page = 1;
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Killmails/Corporation/Detail.php
+++ b/src/Jobs/Killmails/Corporation/Detail.php
@@ -61,7 +61,7 @@ class Detail extends AbstractCorporationJob
     protected $tags = ['corporation', 'killmails'];
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Killmails/Corporation/Detail.php
+++ b/src/Jobs/Killmails/Corporation/Detail.php
@@ -69,13 +69,10 @@ class Detail extends EsiBase
      */
     public function handle()
     {
-        logger()->debug('Corporation Killmails Detail Job has been queued', [
-            'unique_key' => implode(':', array_merge($this->tags, [$this->getCorporationId()])),
-        ]);
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $killmails = CorporationKillmail::where('corporation_id', $this->getCorporationId())
                 ->whereNotIn('killmail_id', function ($query) {
@@ -154,7 +151,6 @@ class Detail extends EsiBase
 
         }, function () {
 
-            logger()->warning('Corporation Killmails Details job will be removed since another similar job is already queued.');
             return $this->delete();
 
         });

--- a/src/Jobs/Killmails/Corporation/Detail.php
+++ b/src/Jobs/Killmails/Corporation/Detail.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\Killmails\Corporation;
 
+use Illuminate\Support\Facades\Redis;
 use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\Killmails\CorporationKillmail;
 use Seat\Eveapi\Models\Killmails\KillmailAttacker;
@@ -68,82 +69,94 @@ class Detail extends EsiBase
      */
     public function handle()
     {
+        logger()->debug('Corporation Killmails Detail Job has been queued', [
+            'unique_key' => implode(':', array_merge($this->tags, [$this->getCorporationId()])),
+        ]);
 
-        if (! $this->preflighted()) return;
+        Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-        $killmails = CorporationKillmail::where('corporation_id', $this->getCorporationId())
-            ->whereNotIn('killmail_id', function ($query) {
+            if (!$this->preflighted()) return;
 
-                $query->select('killmail_id')
-                    ->from('killmail_details');
+            $killmails = CorporationKillmail::where('corporation_id', $this->getCorporationId())
+                ->whereNotIn('killmail_id', function ($query) {
 
-            })->pluck('killmail_id', 'killmail_hash');
+                    $query->select('killmail_id')
+                        ->from('killmail_details');
 
-        $killmails->each(function ($killmail_id, $killmail_hash) {
+                })->pluck('killmail_id', 'killmail_hash');
 
-            $detail = $this->retrieve([
-                'killmail_id'   => $killmail_id,
-                'killmail_hash' => $killmail_hash,
-            ]);
+            $killmails->each(function ($killmail_id, $killmail_hash) {
 
-            if ($detail->isCachedLoad()) return;
-
-            KillmailDetail::firstOrCreate([
-                'killmail_id'     => $killmail_id,
-            ], [
-                'killmail_time'   => carbon($detail->killmail_time),
-                'solar_system_id' => $detail->solar_system_id,
-                'moon_id'         => $detail->moon_id ?? null,
-                'war_id'          => $detail->war_id ?? null,
-            ]);
-
-            KillmailVictim::firstOrCreate([
-                'killmail_id'    => $killmail_id,
-            ], [
-                'character_id'   => $detail->victim->character_id ?? null,
-                'corporation_id' => $detail->victim->corporation_id ?? null,
-                'alliance_id'    => $detail->victim->alliance_id ?? null,
-                'faction_id'     => $detail->victim->faction_id ?? null,
-                'damage_taken'   => $detail->victim->damage_taken,
-                'ship_type_id'   => $detail->victim->ship_type_id,
-                'x'              => $detail->victim->position->x ?? null,
-                'y'              => $detail->victim->position->y ?? null,
-                'z'              => $detail->victim->position->z ?? null,
-            ]);
-
-            collect($detail->attackers)->each(function ($attacker) use ($killmail_id) {
-
-                KillmailAttacker::firstOrCreate([
-                    'killmail_id'     => $killmail_id,
-                    'character_id'    => $attacker->character_id ?? null,
-                    'corporation_id'  => $attacker->corporation_id ?? null,
-                    'alliance_id'     => $attacker->alliance_id ?? null,
-                    'faction_id'      => $attacker->faction_id ?? null,
-                    'security_status' => $attacker->security_status,
-                    'final_blow'      => $attacker->final_blow,
-                    'damage_done'     => $attacker->damage_done,
-                    'ship_type_id'    => $attacker->ship_type_id ?? null,
-                    'weapon_type_id'  => $attacker->weapon_type_id ?? null,
+                $detail = $this->retrieve([
+                    'killmail_id' => $killmail_id,
+                    'killmail_hash' => $killmail_hash,
                 ]);
+
+                if ($detail->isCachedLoad()) return;
+
+                KillmailDetail::firstOrCreate([
+                    'killmail_id' => $killmail_id,
+                ], [
+                    'killmail_time' => carbon($detail->killmail_time),
+                    'solar_system_id' => $detail->solar_system_id,
+                    'moon_id' => $detail->moon_id ?? null,
+                    'war_id' => $detail->war_id ?? null,
+                ]);
+
+                KillmailVictim::firstOrCreate([
+                    'killmail_id' => $killmail_id,
+                ], [
+                    'character_id' => $detail->victim->character_id ?? null,
+                    'corporation_id' => $detail->victim->corporation_id ?? null,
+                    'alliance_id' => $detail->victim->alliance_id ?? null,
+                    'faction_id' => $detail->victim->faction_id ?? null,
+                    'damage_taken' => $detail->victim->damage_taken,
+                    'ship_type_id' => $detail->victim->ship_type_id,
+                    'x' => $detail->victim->position->x ?? null,
+                    'y' => $detail->victim->position->y ?? null,
+                    'z' => $detail->victim->position->z ?? null,
+                ]);
+
+                collect($detail->attackers)->each(function ($attacker) use ($killmail_id) {
+
+                    KillmailAttacker::firstOrCreate([
+                        'killmail_id' => $killmail_id,
+                        'character_id' => $attacker->character_id ?? null,
+                        'corporation_id' => $attacker->corporation_id ?? null,
+                        'alliance_id' => $attacker->alliance_id ?? null,
+                        'faction_id' => $attacker->faction_id ?? null,
+                        'security_status' => $attacker->security_status,
+                        'final_blow' => $attacker->final_blow,
+                        'damage_done' => $attacker->damage_done,
+                        'ship_type_id' => $attacker->ship_type_id ?? null,
+                        'weapon_type_id' => $attacker->weapon_type_id ?? null,
+                    ]);
+                });
+
+                if (property_exists($detail->victim, 'items')) {
+
+                    collect($detail->victim->items)->each(function ($item) use ($killmail_id) {
+
+                        KillmailVictimItem::firstOrNew([
+                            'killmail_id' => $killmail_id,
+                            'item_type_id' => $item->item_type_id,
+                        ])->fill([
+                            'quantity_destroyed' => $item->quantity_destroyed ?? null,
+                            'quantity_dropped' => $item->quantity_dropped ?? null,
+                            'singleton' => $item->singleton,
+                            'flag' => $item->flag,
+                        ])->save();
+
+                        // TODO: Process $item->items as a nested model.
+                    });
+                }
             });
 
-            if (property_exists($detail->victim, 'items')) {
+        }, function () {
 
-                collect($detail->victim->items)->each(function ($item) use ($killmail_id) {
+            logger()->warning('Corporation Killmails Details job will be removed since another similar job is already queued.');
+            return $this->delete();
 
-                    KillmailVictimItem::firstOrNew([
-                        'killmail_id'  => $killmail_id,
-                        'item_type_id' => $item->item_type_id,
-                    ])->fill([
-                        'quantity_destroyed' => $item->quantity_destroyed ?? null,
-                        'quantity_dropped'   => $item->quantity_dropped ?? null,
-                        'singleton'          => $item->singleton,
-                        'flag'               => $item->flag,
-                    ])->save();
-
-                    // TODO: Process $item->items as a nested model.
-                });
-            }
         });
     }
 }

--- a/src/Jobs/Killmails/Corporation/Detail.php
+++ b/src/Jobs/Killmails/Corporation/Detail.php
@@ -88,39 +88,39 @@ class Detail extends AbstractCorporationJob
             KillmailDetail::firstOrCreate([
                 'killmail_id' => $killmail_id,
             ], [
-                'killmail_time' => carbon($detail->killmail_time),
+                'killmail_time'   => carbon($detail->killmail_time),
                 'solar_system_id' => $detail->solar_system_id,
-                'moon_id' => $detail->moon_id ?? null,
-                'war_id' => $detail->war_id ?? null,
+                'moon_id'         => $detail->moon_id ?? null,
+                'war_id'          => $detail->war_id ?? null,
             ]);
 
             KillmailVictim::firstOrCreate([
                 'killmail_id' => $killmail_id,
             ], [
-                'character_id' => $detail->victim->character_id ?? null,
+                'character_id'   => $detail->victim->character_id ?? null,
                 'corporation_id' => $detail->victim->corporation_id ?? null,
-                'alliance_id' => $detail->victim->alliance_id ?? null,
-                'faction_id' => $detail->victim->faction_id ?? null,
-                'damage_taken' => $detail->victim->damage_taken,
-                'ship_type_id' => $detail->victim->ship_type_id,
-                'x' => $detail->victim->position->x ?? null,
-                'y' => $detail->victim->position->y ?? null,
-                'z' => $detail->victim->position->z ?? null,
+                'alliance_id'    => $detail->victim->alliance_id ?? null,
+                'faction_id'     => $detail->victim->faction_id ?? null,
+                'damage_taken'   => $detail->victim->damage_taken,
+                'ship_type_id'   => $detail->victim->ship_type_id,
+                'x'              => $detail->victim->position->x ?? null,
+                'y'              => $detail->victim->position->y ?? null,
+                'z'              => $detail->victim->position->z ?? null,
             ]);
 
             collect($detail->attackers)->each(function ($attacker) use ($killmail_id) {
 
                 KillmailAttacker::firstOrCreate([
-                    'killmail_id' => $killmail_id,
-                    'character_id' => $attacker->character_id ?? null,
-                    'corporation_id' => $attacker->corporation_id ?? null,
-                    'alliance_id' => $attacker->alliance_id ?? null,
-                    'faction_id' => $attacker->faction_id ?? null,
+                    'killmail_id'     => $killmail_id,
+                    'character_id'    => $attacker->character_id ?? null,
+                    'corporation_id'  => $attacker->corporation_id ?? null,
+                    'alliance_id'     => $attacker->alliance_id ?? null,
+                    'faction_id'      => $attacker->faction_id ?? null,
                     'security_status' => $attacker->security_status,
-                    'final_blow' => $attacker->final_blow,
-                    'damage_done' => $attacker->damage_done,
-                    'ship_type_id' => $attacker->ship_type_id ?? null,
-                    'weapon_type_id' => $attacker->weapon_type_id ?? null,
+                    'final_blow'      => $attacker->final_blow,
+                    'damage_done'     => $attacker->damage_done,
+                    'ship_type_id'    => $attacker->ship_type_id ?? null,
+                    'weapon_type_id'  => $attacker->weapon_type_id ?? null,
                 ]);
             });
 
@@ -129,13 +129,13 @@ class Detail extends AbstractCorporationJob
                 collect($detail->victim->items)->each(function ($item) use ($killmail_id) {
 
                     KillmailVictimItem::firstOrNew([
-                        'killmail_id' => $killmail_id,
+                        'killmail_id'  => $killmail_id,
                         'item_type_id' => $item->item_type_id,
                     ])->fill([
                         'quantity_destroyed' => $item->quantity_destroyed ?? null,
-                        'quantity_dropped' => $item->quantity_dropped ?? null,
-                        'singleton' => $item->singleton,
-                        'flag' => $item->flag,
+                        'quantity_dropped'   => $item->quantity_dropped ?? null,
+                        'singleton'          => $item->singleton,
+                        'flag'               => $item->flag,
                     ])->save();
 
                     // TODO: Process $item->items as a nested model.

--- a/src/Jobs/Killmails/Corporation/Recent.php
+++ b/src/Jobs/Killmails/Corporation/Recent.php
@@ -73,7 +73,7 @@ class Recent extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $killmails = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),

--- a/src/Jobs/Killmails/Corporation/Recent.php
+++ b/src/Jobs/Killmails/Corporation/Recent.php
@@ -79,7 +79,7 @@ class Recent extends AbstractCorporationJob
 
             CorporationKillmail::firstOrCreate([
                 'corporation_id' => $this->getCorporationId(),
-                'killmail_id' => $killmail->killmail_id,
+                'killmail_id'    => $killmail->killmail_id,
             ], [
                 'killmail_hash' => $killmail->killmail_hash,
             ]);

--- a/src/Jobs/Killmails/Corporation/Recent.php
+++ b/src/Jobs/Killmails/Corporation/Recent.php
@@ -62,7 +62,7 @@ class Recent extends AbstractCorporationJob
     protected $tags = ['corporation', 'killmails'];
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Market/Corporation/Orders.php
+++ b/src/Jobs/Market/Corporation/Orders.php
@@ -77,7 +77,7 @@ class Orders extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             while (true) {
 
@@ -110,7 +110,7 @@ class Orders extends EsiBase
                     ])->save();
                 });
 
-                if (!$this->nextPage($orders->pages))
+                if (! $this->nextPage($orders->pages))
                     return;
             }
 

--- a/src/Jobs/Market/Corporation/Orders.php
+++ b/src/Jobs/Market/Corporation/Orders.php
@@ -67,7 +67,7 @@ class Orders extends AbstractCorporationJob
     protected $page = 1;
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Market/Corporation/Orders.php
+++ b/src/Jobs/Market/Corporation/Orders.php
@@ -86,22 +86,22 @@ class Orders extends AbstractCorporationJob
 
                 CorporationOrder::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
-                    'order_id' => $order->order_id,
+                    'order_id'       => $order->order_id,
                 ])->fill([
-                    'type_id' => $order->type_id,
-                    'region_id' => $order->region_id,
-                    'location_id' => $order->location_id,
-                    'range' => $order->range,
-                    'is_buy_order' => $order->is_buy_order ?? null,
-                    'price' => $order->price,
-                    'volume_total' => $order->volume_total,
-                    'volume_remain' => $order->volume_remain,
-                    'issued' => carbon($order->issued),
-                    'issued_by' => $order->issued_by,
-                    'min_volume' => $order->min_volume ?? null,
+                    'type_id'         => $order->type_id,
+                    'region_id'       => $order->region_id,
+                    'location_id'     => $order->location_id,
+                    'range'           => $order->range,
+                    'is_buy_order'    => $order->is_buy_order ?? null,
+                    'price'           => $order->price,
+                    'volume_total'    => $order->volume_total,
+                    'volume_remain'   => $order->volume_remain,
+                    'issued'          => carbon($order->issued),
+                    'issued_by'       => $order->issued_by,
+                    'min_volume'      => $order->min_volume ?? null,
                     'wallet_division' => $order->wallet_division ?? null,
-                    'duration' => $order->duration ?? null,
-                    'escrow' => $order->escrow ?? null,
+                    'duration'        => $order->duration ?? null,
+                    'escrow'          => $order->escrow ?? null,
                 ])->save();
             });
 

--- a/src/Jobs/PlanetaryInteraction/Corporation/CustomsOfficeLocations.php
+++ b/src/Jobs/PlanetaryInteraction/Corporation/CustomsOfficeLocations.php
@@ -98,11 +98,11 @@ class CustomsOfficeLocations extends AbstractCorporationJob
 
                 CorporationCustomsOffice::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
-                    'office_id' => $location->item_id,
+                    'office_id'      => $location->item_id,
                 ])->fill([
-                    'x' => $location->position->x,
-                    'y' => $location->position->y,
-                    'z' => $location->position->z,
+                    'x'           => $location->position->x,
+                    'y'           => $location->position->y,
+                    'z'           => $location->position->z,
                     'location_id' => $nearest_celestial['map_id'],
                 ])->save();
 

--- a/src/Jobs/PlanetaryInteraction/Corporation/CustomsOfficeLocations.php
+++ b/src/Jobs/PlanetaryInteraction/Corporation/CustomsOfficeLocations.php
@@ -75,7 +75,7 @@ class CustomsOfficeLocations extends EsiBase
 
         Redis::funnel(implode(':', $this->tags()))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $customs_offices = CorporationCustomsOffice::where('corporation_id', $this->getCorporationId())->get();
 

--- a/src/Jobs/PlanetaryInteraction/Corporation/CustomsOfficeLocations.php
+++ b/src/Jobs/PlanetaryInteraction/Corporation/CustomsOfficeLocations.php
@@ -65,7 +65,7 @@ class CustomsOfficeLocations extends AbstractCorporationJob
     protected $tags = ['corporation', 'customs_offices', 'locations'];
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/PlanetaryInteraction/Corporation/CustomsOffices.php
+++ b/src/Jobs/PlanetaryInteraction/Corporation/CustomsOffices.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\PlanetaryInteraction\Corporation;
 
+use Illuminate\Support\Facades\Redis;
 use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\PlanetaryInteraction\CorporationCustomsOffice;
 use Seat\Eveapi\Models\RefreshToken;
@@ -93,48 +94,56 @@ class CustomsOffices extends EsiBase
     public function handle()
     {
 
-        if (! $this->preflighted()) return;
+        Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-        while (true) {
+            if (!$this->preflighted()) return;
 
-            $customs_offices = $this->retrieve([
-                'corporation_id' => $this->getCorporationId(),
-            ]);
+            while (true) {
 
-            if ($customs_offices->isCachedLoad()) return;
-
-            collect($customs_offices)->each(function ($customs_office) {
-
-                CorporationCustomsOffice::firstOrNew([
+                $customs_offices = $this->retrieve([
                     'corporation_id' => $this->getCorporationId(),
-                    'office_id'      => $customs_office->office_id,
-                ])->fill([
-                    'system_id'                   => $customs_office->system_id,
-                    'reinforce_exit_start'        => $customs_office->reinforce_exit_start,
-                    'reinforce_exit_end'          => $customs_office->reinforce_exit_end,
-                    'corporation_tax_rate'        => $customs_office->corporation_tax_rate ?? null,
-                    'allow_alliance_access'       => $customs_office->allow_alliance_access,
-                    'alliance_tax_rate'           => $customs_office->alliance_tax_rate ?? null,
-                    'allow_access_with_standings' => $customs_office->allow_access_with_standings,
-                    'standing_level'              => $customs_office->standing_level ?? null,
-                    'excellent_standing_tax_rate' => $customs_office->excellent_standing_tax_rate ?? null,
-                    'good_standing_tax_rate'      => $customs_office->good_standing_tax_rate ?? null,
-                    'neutral_standing_tax_rate'   => $customs_office->neutral_standing_tax_rate ?? null,
-                    'bad_standing_tax_rate'       => $customs_office->bad_standing_tax_rate ?? null,
-                    'terrible_standing_tax_rate'  => $customs_office->terrible_standing_tax_rate ?? null,
-                ])->save();
+                ]);
 
-                $this->known_structures->push($customs_office->office_id);
+                if ($customs_offices->isCachedLoad()) return;
 
-            });
+                collect($customs_offices)->each(function ($customs_office) {
 
-            if (! $this->nextPage($customs_offices->pages))
-                break;
-        }
+                    CorporationCustomsOffice::firstOrNew([
+                        'corporation_id' => $this->getCorporationId(),
+                        'office_id' => $customs_office->office_id,
+                    ])->fill([
+                        'system_id' => $customs_office->system_id,
+                        'reinforce_exit_start' => $customs_office->reinforce_exit_start,
+                        'reinforce_exit_end' => $customs_office->reinforce_exit_end,
+                        'corporation_tax_rate' => $customs_office->corporation_tax_rate ?? null,
+                        'allow_alliance_access' => $customs_office->allow_alliance_access,
+                        'alliance_tax_rate' => $customs_office->alliance_tax_rate ?? null,
+                        'allow_access_with_standings' => $customs_office->allow_access_with_standings,
+                        'standing_level' => $customs_office->standing_level ?? null,
+                        'excellent_standing_tax_rate' => $customs_office->excellent_standing_tax_rate ?? null,
+                        'good_standing_tax_rate' => $customs_office->good_standing_tax_rate ?? null,
+                        'neutral_standing_tax_rate' => $customs_office->neutral_standing_tax_rate ?? null,
+                        'bad_standing_tax_rate' => $customs_office->bad_standing_tax_rate ?? null,
+                        'terrible_standing_tax_rate' => $customs_office->terrible_standing_tax_rate ?? null,
+                    ])->save();
 
-        // Cleanup customs offices that were not in the response.
-        CorporationCustomsOffice::where('corporation_id', $this->getCorporationId())
-            ->whereNotIn('office_id', $this->known_structures->flatten()->all())
-            ->delete();
+                    $this->known_structures->push($customs_office->office_id);
+
+                });
+
+                if (!$this->nextPage($customs_offices->pages))
+                    break;
+            }
+
+            // Cleanup customs offices that were not in the response.
+            CorporationCustomsOffice::where('corporation_id', $this->getCorporationId())
+                ->whereNotIn('office_id', $this->known_structures->flatten()->all())
+                ->delete();
+
+        }, function () {
+
+            return $this->delete();
+
+        });
     }
 }

--- a/src/Jobs/PlanetaryInteraction/Corporation/CustomsOffices.php
+++ b/src/Jobs/PlanetaryInteraction/Corporation/CustomsOffices.php
@@ -96,7 +96,7 @@ class CustomsOffices extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             while (true) {
 
@@ -131,7 +131,7 @@ class CustomsOffices extends EsiBase
 
                 });
 
-                if (!$this->nextPage($customs_offices->pages))
+                if (! $this->nextPage($customs_offices->pages))
                     break;
             }
 

--- a/src/Jobs/PlanetaryInteraction/Corporation/CustomsOffices.php
+++ b/src/Jobs/PlanetaryInteraction/Corporation/CustomsOffices.php
@@ -105,21 +105,21 @@ class CustomsOffices extends AbstractCorporationJob
 
                 CorporationCustomsOffice::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
-                    'office_id' => $customs_office->office_id,
+                    'office_id'      => $customs_office->office_id,
                 ])->fill([
-                    'system_id' => $customs_office->system_id,
-                    'reinforce_exit_start' => $customs_office->reinforce_exit_start,
-                    'reinforce_exit_end' => $customs_office->reinforce_exit_end,
-                    'corporation_tax_rate' => $customs_office->corporation_tax_rate ?? null,
-                    'allow_alliance_access' => $customs_office->allow_alliance_access,
-                    'alliance_tax_rate' => $customs_office->alliance_tax_rate ?? null,
+                    'system_id'                   => $customs_office->system_id,
+                    'reinforce_exit_start'        => $customs_office->reinforce_exit_start,
+                    'reinforce_exit_end'          => $customs_office->reinforce_exit_end,
+                    'corporation_tax_rate'        => $customs_office->corporation_tax_rate ?? null,
+                    'allow_alliance_access'       => $customs_office->allow_alliance_access,
+                    'alliance_tax_rate'           => $customs_office->alliance_tax_rate ?? null,
                     'allow_access_with_standings' => $customs_office->allow_access_with_standings,
-                    'standing_level' => $customs_office->standing_level ?? null,
+                    'standing_level'              => $customs_office->standing_level ?? null,
                     'excellent_standing_tax_rate' => $customs_office->excellent_standing_tax_rate ?? null,
-                    'good_standing_tax_rate' => $customs_office->good_standing_tax_rate ?? null,
-                    'neutral_standing_tax_rate' => $customs_office->neutral_standing_tax_rate ?? null,
-                    'bad_standing_tax_rate' => $customs_office->bad_standing_tax_rate ?? null,
-                    'terrible_standing_tax_rate' => $customs_office->terrible_standing_tax_rate ?? null,
+                    'good_standing_tax_rate'      => $customs_office->good_standing_tax_rate ?? null,
+                    'neutral_standing_tax_rate'   => $customs_office->neutral_standing_tax_rate ?? null,
+                    'bad_standing_tax_rate'       => $customs_office->bad_standing_tax_rate ?? null,
+                    'terrible_standing_tax_rate'  => $customs_office->terrible_standing_tax_rate ?? null,
                 ])->save();
 
                 $this->known_structures->push($customs_office->office_id);

--- a/src/Jobs/PlanetaryInteraction/Corporation/CustomsOffices.php
+++ b/src/Jobs/PlanetaryInteraction/Corporation/CustomsOffices.php
@@ -86,7 +86,7 @@ class CustomsOffices extends AbstractCorporationJob
     }
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Wallet/Corporation/Balances.php
+++ b/src/Jobs/Wallet/Corporation/Balances.php
@@ -72,7 +72,7 @@ class Balances extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             $balances = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),

--- a/src/Jobs/Wallet/Corporation/Balances.php
+++ b/src/Jobs/Wallet/Corporation/Balances.php
@@ -79,7 +79,7 @@ class Balances extends AbstractCorporationJob
 
             CorporationWalletBalance::firstOrNew([
                 'corporation_id' => $this->getCorporationId(),
-                'division' => $balance->division,
+                'division'       => $balance->division,
             ])->fill([
                 'balance' => $balance->balance,
             ])->save();

--- a/src/Jobs/Wallet/Corporation/Balances.php
+++ b/src/Jobs/Wallet/Corporation/Balances.php
@@ -62,7 +62,7 @@ class Balances extends AbstractCorporationJob
     protected $tags = ['corporation', 'wallet', 'balance'];
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Wallet/Corporation/Journals.php
+++ b/src/Jobs/Wallet/Corporation/Journals.php
@@ -75,7 +75,7 @@ class Journals extends AbstractCorporationJob
     protected $from_id = PHP_INT_MAX;
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Wallet/Corporation/Journals.php
+++ b/src/Jobs/Wallet/Corporation/Journals.php
@@ -22,8 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\Wallet\Corporation;
 
-use Illuminate\Support\Facades\Redis;
-use Seat\Eveapi\Jobs\EsiBase;
+use Seat\Eveapi\Jobs\AbstractCorporationJob;
 use Seat\Eveapi\Models\Corporation\CorporationDivision;
 use Seat\Eveapi\Models\Wallet\CorporationWalletJournal;
 
@@ -31,7 +30,7 @@ use Seat\Eveapi\Models\Wallet\CorporationWalletJournal;
  * Class Journals.
  * @package Seat\Eveapi\Jobs\Wallet\Corporation
  */
-class Journals extends EsiBase
+class Journals extends AbstractCorporationJob
 {
     /**
      * @var string
@@ -76,86 +75,76 @@ class Journals extends EsiBase
     protected $from_id = PHP_INT_MAX;
 
     /**
-     * Execute the job.
+     * Contains the job process.
      *
+     * @return void
      * @throws \Throwable
      */
-    public function handle()
+    protected function job(): void
     {
+        CorporationDivision::where('corporation_id', $this->getCorporationId())->get()
+            ->each(function ($division) {
 
-        Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
+                // Perform a journal walk backwards to get all of the
+                // entries as far back as possible. When the response from
+                // ESI is empty, we can assume we have everything.
+                while (true) {
 
-            if (! $this->preflighted()) return;
+                    $this->query_string = ['from_id' => $this->from_id];
 
-            CorporationDivision::where('corporation_id', $this->getCorporationId())->get()
-                ->each(function ($division) {
+                    $journal = $this->retrieve([
+                        'corporation_id' => $this->getCorporationId(),
+                        'division' => $division->division,
+                    ]);
 
-                    // Perform a journal walk backwards to get all of the
-                    // entries as far back as possible. When the response from
-                    // ESI is empty, we can assume we have everything.
-                    while (true) {
+                    if ($journal->isCachedLoad()) return;
 
-                        $this->query_string = ['from_id' => $this->from_id];
+                    // If we have no more entries, break the loop.
+                    if (collect($journal)->count() === 0)
+                        break;
 
-                        $journal = $this->retrieve([
-                            'corporation_id' => $this->getCorporationId(),
-                            'division' => $division->division,
-                        ]);
+                    collect($journal)->chunk(1000)->each(function ($chunk) use ($division) {
 
-                        if ($journal->isCachedLoad()) return;
+                        $records = $chunk->map(function ($entry, $key) use ($division) {
 
-                        // If we have no more entries, break the loop.
-                        if (collect($journal)->count() === 0)
-                            break;
-
-                        collect($journal)->chunk(1000)->each(function ($chunk) use ($division) {
-
-                            $records = $chunk->map(function ($entry, $key) use ($division) {
-
-                                return [
-                                    'corporation_id' => $this->getCorporationId(),
-                                    'division' => $division->division,
-                                    'id' => $entry->id,
-                                    'date' => carbon($entry->date),
-                                    'ref_type' => $entry->ref_type,
-                                    'first_party_id' => $entry->first_party_id ?? null,
-                                    'second_party_id' => $entry->second_party_id ?? null,
-                                    'amount' => $entry->amount ?? null,
-                                    'balance' => $entry->balance ?? null,
-                                    'reason' => $entry->reason ?? null,
-                                    'tax_receiver_id' => $entry->tax_receiver_id ?? null,
-                                    'tax' => $entry->tax ?? null,
-                                    // introduced in v4
-                                    'description' => $entry->description,
-                                    'context_id' => $entry->context_id ?? null,
-                                    'context_id_type' => $entry->context_id_type ?? null,
-                                    'created_at' => carbon(),
-                                    'updated_at' => carbon(),
-                                ];
-                            });
-
-                            CorporationWalletJournal::insertIgnore($records->toArray());
+                            return [
+                                'corporation_id' => $this->getCorporationId(),
+                                'division' => $division->division,
+                                'id' => $entry->id,
+                                'date' => carbon($entry->date),
+                                'ref_type' => $entry->ref_type,
+                                'first_party_id' => $entry->first_party_id ?? null,
+                                'second_party_id' => $entry->second_party_id ?? null,
+                                'amount' => $entry->amount ?? null,
+                                'balance' => $entry->balance ?? null,
+                                'reason' => $entry->reason ?? null,
+                                'tax_receiver_id' => $entry->tax_receiver_id ?? null,
+                                'tax' => $entry->tax ?? null,
+                                // introduced in v4
+                                'description' => $entry->description,
+                                'context_id' => $entry->context_id ?? null,
+                                'context_id_type' => $entry->context_id_type ?? null,
+                                'created_at' => carbon(),
+                                'updated_at' => carbon(),
+                            ];
                         });
 
-                        // Update the from_id to be the new lowest ref_id we
-                        // know of. The next call will use this.
-                        $this->from_id = collect($journal)->min('id') - 1;
+                        CorporationWalletJournal::insertIgnore($records->toArray());
+                    });
 
-                        if (! $this->nextPage($journal->pages))
-                            break;
-                    }
+                    // Update the from_id to be the new lowest ref_id we
+                    // know of. The next call will use this.
+                    $this->from_id = collect($journal)->min('id') - 1;
 
-                    // Reset the from_id for the next wallet division
-                    $this->from_id = PHP_INT_MAX;
+                    if (! $this->nextPage($journal->pages))
+                        break;
+                }
 
-                    // Reset the page for the next wallet division
-                    $this->page = 1;
-                });
+                // Reset the from_id for the next wallet division
+                $this->from_id = PHP_INT_MAX;
 
-        }, function () {
-
-            return $this->delete();
-
-        });
+                // Reset the page for the next wallet division
+                $this->page = 1;
+            });
     }
 }

--- a/src/Jobs/Wallet/Corporation/Journals.php
+++ b/src/Jobs/Wallet/Corporation/Journals.php
@@ -94,7 +94,7 @@ class Journals extends AbstractCorporationJob
 
                     $journal = $this->retrieve([
                         'corporation_id' => $this->getCorporationId(),
-                        'division' => $division->division,
+                        'division'       => $division->division,
                     ]);
 
                     if ($journal->isCachedLoad()) return;
@@ -108,24 +108,24 @@ class Journals extends AbstractCorporationJob
                         $records = $chunk->map(function ($entry, $key) use ($division) {
 
                             return [
-                                'corporation_id' => $this->getCorporationId(),
-                                'division' => $division->division,
-                                'id' => $entry->id,
-                                'date' => carbon($entry->date),
-                                'ref_type' => $entry->ref_type,
-                                'first_party_id' => $entry->first_party_id ?? null,
+                                'corporation_id'  => $this->getCorporationId(),
+                                'division'        => $division->division,
+                                'id'              => $entry->id,
+                                'date'            => carbon($entry->date),
+                                'ref_type'        => $entry->ref_type,
+                                'first_party_id'  => $entry->first_party_id ?? null,
                                 'second_party_id' => $entry->second_party_id ?? null,
-                                'amount' => $entry->amount ?? null,
-                                'balance' => $entry->balance ?? null,
-                                'reason' => $entry->reason ?? null,
+                                'amount'          => $entry->amount ?? null,
+                                'balance'         => $entry->balance ?? null,
+                                'reason'          => $entry->reason ?? null,
                                 'tax_receiver_id' => $entry->tax_receiver_id ?? null,
-                                'tax' => $entry->tax ?? null,
+                                'tax'             => $entry->tax ?? null,
                                 // introduced in v4
-                                'description' => $entry->description,
-                                'context_id' => $entry->context_id ?? null,
+                                'description'     => $entry->description,
+                                'context_id'      => $entry->context_id ?? null,
                                 'context_id_type' => $entry->context_id_type ?? null,
-                                'created_at' => carbon(),
-                                'updated_at' => carbon(),
+                                'created_at'      => carbon(),
+                                'updated_at'      => carbon(),
                             ];
                         });
 

--- a/src/Jobs/Wallet/Corporation/Journals.php
+++ b/src/Jobs/Wallet/Corporation/Journals.php
@@ -85,7 +85,7 @@ class Journals extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             CorporationDivision::where('corporation_id', $this->getCorporationId())->get()
                 ->each(function ($division) {
@@ -141,7 +141,7 @@ class Journals extends EsiBase
                         // know of. The next call will use this.
                         $this->from_id = collect($journal)->min('id') - 1;
 
-                        if (!$this->nextPage($journal->pages))
+                        if (! $this->nextPage($journal->pages))
                             break;
                     }
 

--- a/src/Jobs/Wallet/Corporation/Transactions.php
+++ b/src/Jobs/Wallet/Corporation/Transactions.php
@@ -89,7 +89,7 @@ class Transactions extends AbstractCorporationJob
 
                     $transactions = $this->retrieve([
                         'corporation_id' => $this->getCorporationId(),
-                        'division' => $division->division,
+                        'division'       => $division->division,
                     ]);
 
                     if ($transactions->isCachedLoad()) return;
@@ -102,7 +102,7 @@ class Transactions extends AbstractCorporationJob
 
                         $transaction_entry = CorporationWalletTransaction::firstOrNew([
                             'corporation_id' => $this->getCorporationId(),
-                            'division' => $division->division,
+                            'division'       => $division->division,
                             'transaction_id' => $transaction->transaction_id,
                         ]);
 
@@ -112,13 +112,13 @@ class Transactions extends AbstractCorporationJob
                             return;
 
                         $transaction_entry->fill([
-                            'date' => carbon($transaction->date),
-                            'type_id' => $transaction->type_id,
-                            'location_id' => $transaction->location_id,
-                            'unit_price' => $transaction->unit_price,
-                            'quantity' => $transaction->quantity,
-                            'client_id' => $transaction->client_id,
-                            'is_buy' => $transaction->is_buy,
+                            'date'           => carbon($transaction->date),
+                            'type_id'        => $transaction->type_id,
+                            'location_id'    => $transaction->location_id,
+                            'unit_price'     => $transaction->unit_price,
+                            'quantity'       => $transaction->quantity,
+                            'client_id'      => $transaction->client_id,
+                            'is_buy'         => $transaction->is_buy,
                             'journal_ref_id' => $transaction->journal_ref_id,
                         ])->save();
                     });

--- a/src/Jobs/Wallet/Corporation/Transactions.php
+++ b/src/Jobs/Wallet/Corporation/Transactions.php
@@ -70,7 +70,7 @@ class Transactions extends AbstractCorporationJob
     protected $from_id = PHP_INT_MAX;
 
     /**
-     * Contains the job process.
+     * Execute the job.
      *
      * @return void
      * @throws \Throwable

--- a/src/Jobs/Wallet/Corporation/Transactions.php
+++ b/src/Jobs/Wallet/Corporation/Transactions.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\Wallet\Corporation;
 
+use Illuminate\Support\Facades\Redis;
 use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\Corporation\CorporationDivision;
 use Seat\Eveapi\Models\Wallet\CorporationWalletTransaction;
@@ -77,61 +78,69 @@ class Transactions extends EsiBase
     public function handle()
     {
 
-        if (! $this->preflighted()) return;
+        Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-        CorporationDivision::where('corporation_id', $this->getCorporationId())->get()
-            ->each(function ($division) {
+            if (!$this->preflighted()) return;
 
-                // Perform a journal walk backwards to get all of the
-                // entries as far back as possible. When the response from
-                // ESI is empty, we can assume we have everything.
-                while (true) {
+            CorporationDivision::where('corporation_id', $this->getCorporationId())->get()
+                ->each(function ($division) {
 
-                    $this->query_string = ['from_id' => $this->from_id];
+                    // Perform a journal walk backwards to get all of the
+                    // entries as far back as possible. When the response from
+                    // ESI is empty, we can assume we have everything.
+                    while (true) {
 
-                    $transactions = $this->retrieve([
-                        'corporation_id' => $this->getCorporationId(),
-                        'division'       => $division->division,
-                    ]);
+                        $this->query_string = ['from_id' => $this->from_id];
 
-                    if ($transactions->isCachedLoad()) return;
-
-                    // If we have no more entries, break the loop.
-                    if (collect($transactions)->count() === 0)
-                        break;
-
-                    collect($transactions)->each(function ($transaction) use ($division) {
-
-                        $transaction_entry = CorporationWalletTransaction::firstOrNew([
+                        $transactions = $this->retrieve([
                             'corporation_id' => $this->getCorporationId(),
-                            'division'       => $division->division,
-                            'transaction_id' => $transaction->transaction_id,
+                            'division' => $division->division,
                         ]);
 
-                        // If this transaction entry has already been recorded,
-                        // move on to the next.
-                        if ($transaction_entry->exists)
-                            return;
+                        if ($transactions->isCachedLoad()) return;
 
-                        $transaction_entry->fill([
-                            'date'           => carbon($transaction->date),
-                            'type_id'        => $transaction->type_id,
-                            'location_id'    => $transaction->location_id,
-                            'unit_price'     => $transaction->unit_price,
-                            'quantity'       => $transaction->quantity,
-                            'client_id'      => $transaction->client_id,
-                            'is_buy'         => $transaction->is_buy,
-                            'journal_ref_id' => $transaction->journal_ref_id,
-                        ])->save();
-                    });
+                        // If we have no more entries, break the loop.
+                        if (collect($transactions)->count() === 0)
+                            break;
 
-                    // Update the from_id to be the new lowest (ref_id - 1) that we
-                    // know of. The next all will use this.
-                    $this->from_id = collect($transactions)->min('transaction_id') - 1;
-                }
+                        collect($transactions)->each(function ($transaction) use ($division) {
 
-                // Reset the from_id for the next wallet division
-                $this->from_id = PHP_INT_MAX;
-            });
+                            $transaction_entry = CorporationWalletTransaction::firstOrNew([
+                                'corporation_id' => $this->getCorporationId(),
+                                'division' => $division->division,
+                                'transaction_id' => $transaction->transaction_id,
+                            ]);
+
+                            // If this transaction entry has already been recorded,
+                            // move on to the next.
+                            if ($transaction_entry->exists)
+                                return;
+
+                            $transaction_entry->fill([
+                                'date' => carbon($transaction->date),
+                                'type_id' => $transaction->type_id,
+                                'location_id' => $transaction->location_id,
+                                'unit_price' => $transaction->unit_price,
+                                'quantity' => $transaction->quantity,
+                                'client_id' => $transaction->client_id,
+                                'is_buy' => $transaction->is_buy,
+                                'journal_ref_id' => $transaction->journal_ref_id,
+                            ])->save();
+                        });
+
+                        // Update the from_id to be the new lowest (ref_id - 1) that we
+                        // know of. The next all will use this.
+                        $this->from_id = collect($transactions)->min('transaction_id') - 1;
+                    }
+
+                    // Reset the from_id for the next wallet division
+                    $this->from_id = PHP_INT_MAX;
+                });
+
+        }, function () {
+
+            return $this->delete();
+
+        });
     }
 }

--- a/src/Jobs/Wallet/Corporation/Transactions.php
+++ b/src/Jobs/Wallet/Corporation/Transactions.php
@@ -80,7 +80,7 @@ class Transactions extends EsiBase
 
         Redis::funnel(implode(':', array_merge($this->tags, [$this->getCorporationId()])))->limit(1)->then(function () {
 
-            if (!$this->preflighted()) return;
+            if (! $this->preflighted()) return;
 
             CorporationDivision::where('corporation_id', $this->getCorporationId())->get()
                 ->each(function ($division) {


### PR DESCRIPTION
In order to reduce SeAT impact on hosting server, this is introducing a
throttler for all corporation jobs. In case a similar job is already
queued, the newly queued jobs will simply be kicked away from the queue.

Job thumbprint is based on its own tags and the attached corporation ID.