### PR TITLE
feat(notifications): Update notification endpoint according to latest ESI spec changes

### DIFF
--- a/src/Jobs/Character/Notifications.php
+++ b/src/Jobs/Character/Notifications.php
@@ -44,7 +44,7 @@ class Notifications extends EsiBase
     /**
      * @var int
      */
-    protected $version = 'v3';
+    protected $version = 'v4';
 
     /**
      * @var string


### PR DESCRIPTION
Since 11th December, CCP deprecated v3 notification endpoint with
v4.

There are no major change with our architecture as they only
provide a new value for their notification type enumeration
field.

https://github.com/esi/esi-issues/blob/master/changelog.md#2018-12-11