### PR TITLE
Keep assets coordinates

### DIFF
--- a/src/Jobs/Assets/Character/Locations.php
+++ b/src/Jobs/Assets/Character/Locations.php
@@ -102,28 +102,33 @@ class Locations extends EsiBase
 
                 collect($locations)->each(function ($location) {
 
-                    // If we have a zero value for any of the coordinates,
-                    // continue to the next location as we can't calculate
-                    // anything
-                    if ($location->position->x === 0.0)
-                        return;
-
                     $asset_data = CharacterAsset::where('character_id', $this->getCharacterId())
                         ->where('item_id', $location->item_id)
                         ->first();
 
-                    $normalized_location = $this->find_nearest_celestial(
-                        $asset_data->location_id,
-                        $location->position->x, $location->position->y, $location->position->z);
-
-                    // Update the assets location information
+                    // Location for items in either hangar or stations match to 0, 0, 0
                     $asset_data->fill([
                         'x'        => $location->position->x,
                         'y'        => $location->position->y,
                         'z'        => $location->position->z,
-                        'map_id'   => $normalized_location['map_id'],
-                        'map_name' => $normalized_location['map_name'],
-                    ])->save();
+                        'map_id'   => 0,
+                        'map_name' => '',
+                    ]);
+
+                    // If we have a non zero value for coordinates, attempt to identify a celestial.
+                    if (($location->position->x + $location->position->y + $location->position->y) !== 0) {
+                        $normalized_location = $this->find_nearest_celestial(
+                            $asset_data->location_id,
+                            $location->position->x, $location->position->y, $location->position->z);
+
+                        // Update the assets location information
+                        $asset_data->fill([
+                            'map_id'   => $normalized_location['map_id'],
+                            'map_name' => $normalized_location['map_name'],
+                        ]);
+                    }
+
+                    $asset_data->save();
                 });
             });
 
@@ -148,28 +153,33 @@ class Locations extends EsiBase
 
                 collect($locations)->each(function ($location) {
 
-                    // If we have a zero value for any of the coordinates,
-                    // continue to the next location as we can't calculate
-                    // anything
-                    if ($location->position->x === 0.0)
-                        return;
-
                     $asset_data = CharacterAsset::where('character_id', $this->getCharacterId())
                         ->where('item_id', $location->item_id)
                         ->first();
 
-                    $normalized_location = $this->find_nearest_celestial(
-                        $asset_data->location_id,
-                        $location->position->x, $location->position->y, $location->position->z);
-
-                    // Update the assets location information
+                    // Location for items in either hangar or stations match to 0, 0, 0
                     $asset_data->fill([
                         'x'        => $location->position->x,
                         'y'        => $location->position->y,
                         'z'        => $location->position->z,
-                        'map_id'   => $normalized_location['map_id'],
-                        'map_name' => $normalized_location['map_name'],
-                    ])->save();
+                        'map_id'   => 0,
+                        'map_name' => '',
+                    ]);
+
+                    // If we have a non zero value for coordinates, attempt to identify a celestial.
+                    if (($location->position->x + $location->position->y + $location->position->y) !== 0) {
+                        $normalized_location = $this->find_nearest_celestial(
+                            $asset_data->location_id,
+                            $location->position->x, $location->position->y, $location->position->z);
+
+                        // Update the assets location information
+                        $asset_data->fill([
+                            'map_id' => $normalized_location['map_id'],
+                            'map_name' => $normalized_location['map_name'],
+                        ]);
+                    }
+
+                    $asset_data->save();
                 });
             });
     }

--- a/src/Jobs/Assets/Corporation/Locations.php
+++ b/src/Jobs/Assets/Corporation/Locations.php
@@ -109,28 +109,33 @@ class Locations extends EsiBase
 
                 collect($locations)->each(function ($location) {
 
-                    // If we have a zero value for any of the coordinates,
-                    // continue to the next location as we can't calculate
-                    // anything
-                    if ($location->position->x === 0.0)
-                        return;
-
                     $asset_data = CorporationAsset::where('corporation_id', $this->getCorporationId())
                         ->where('item_id', $location->item_id)
                         ->first();
 
-                    $normalized_location = $this->find_nearest_celestial(
-                        $asset_data->location_id,
-                        $location->position->x, $location->position->y, $location->position->z);
-
-                    // Update the assets location information
+                    // Location for items in either hangar or stations match to 0, 0, 0
                     $asset_data->fill([
                         'x'        => $location->position->x,
                         'y'        => $location->position->y,
                         'z'        => $location->position->z,
-                        'map_id'   => $normalized_location['map_id'],
-                        'map_name' => $normalized_location['map_name'],
-                    ])->save();
+                        'map_id'   => 0,
+                        'map_name' => '',
+                    ]);
+
+                    // If we have a non zero value for coordinates, attempt to identify a celestial.
+                    if (($location->position->x + $location->position->y + $location->position->y) !== 0) {
+                        $normalized_location = $this->find_nearest_celestial(
+                            $asset_data->location_id,
+                            $location->position->x, $location->position->y, $location->position->z);
+
+                        // Update the assets location information
+                        $asset_data->fill([
+                            'map_id'   => $normalized_location['map_id'],
+                            'map_name' => $normalized_location['map_name'],
+                        ]);
+                    }
+
+                    $asset_data->save();
                 });
             });
 
@@ -155,28 +160,33 @@ class Locations extends EsiBase
 
                 collect($locations)->each(function ($location) {
 
-                    // If we have a zero value for any of the coordinates,
-                    // continue to the next location as we can't calculate
-                    // anything
-                    if ($location->position->x === 0.0)
-                        return;
-
                     $asset_data = CorporationAsset::where('corporation_id', $this->getCorporationId())
                         ->where('item_id', $location->item_id)
                         ->first();
 
-                    $normalized_location = $this->find_nearest_celestial(
-                        $asset_data->location_id,
-                        $location->position->x, $location->position->y, $location->position->z);
-
-                    // Update the assets location information
+                    // Location for items in either hangar or stations match to 0, 0, 0
                     $asset_data->fill([
                         'x'        => $location->position->x,
                         'y'        => $location->position->y,
                         'z'        => $location->position->z,
-                        'map_id'   => $normalized_location['map_id'],
-                        'map_name' => $normalized_location['map_name'],
-                    ])->save();
+                        'map_id'   => 0,
+                        'map_name' => '',
+                    ]);
+
+                    // If we have a non zero value for coordinates, attempt to identify a celestial.
+                    if (($location->position->x + $location->position->y + $location->position->y) !== 0) {
+                        $normalized_location = $this->find_nearest_celestial(
+                            $asset_data->location_id,
+                            $location->position->x, $location->position->y, $location->position->z);
+
+                        // Update the assets location information
+                        $asset_data->fill([
+                            'map_id' => $normalized_location['map_id'],
+                            'map_name' => $normalized_location['map_name'],
+                        ]);
+                    }
+
+                    $asset_data->save();
                 });
             });
     }

--- a/src/database/migrations/2019_04_13_132114_add_assets_type_entity_index.php
+++ b/src/database/migrations/2019_04_13_132114_add_assets_type_entity_index.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAssetsTypeEntityIndex extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('character_assets', function (Blueprint $table) {
+            $table->index(['character_id', 'type_id'], 'character_assets_type_character_id_index');
+        });
+
+        Schema::table('corporation_assets', function (Blueprint $table) {
+            $table->index(['corporation_id', 'type_id'], 'corporation_assets_type_corporation_id_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('character_assets', function (Blueprint $table) {
+            $table->dropIndex('character_assets_type_character_id_index');
+        });
+
+        Schema::table('corporation_assets', function (Blueprint $table) {
+            $table->dropIndex('corporation_assets_type_corporation_id_index');
+        });
+    }
+}


### PR DESCRIPTION
Keeping returned coordinates from assets could help to mitigate structures resolving exception.

> Return locations for a set of item ids, which you can get from corporation assets endpoint. Coordinates for items in hangars or stations are set to (0,0,0)

Also add an index on both `type_id` and `corporation_id` or `character_id` accordingly inside `assets` tables.
This will reduce join time.