### PR TITLE
fix(esi): paginated endpoint may not return x-pages header

### DIFF
--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -400,14 +400,14 @@ abstract class EsiBase implements ShouldQueue
      * based on the number of pages available and the
      * current page.
      *
-     * @param int $pages
+     * @param int|null $pages
      *
      * @return bool
      */
-    public function nextPage(int $pages): bool
+    public function nextPage(?int $pages): bool
     {
 
-        if ($this->page >= $pages)
+        if (is_null($pages) || $this->page >= $pages)
             return false;
 
         $this->page++;


### PR DESCRIPTION
related to recent changes applied to bookmark endpoints
https://developers.eveonline.com/blog/article/temporary-blackout-of-esi-bookmarks

```
access-control-allow-credentials: true
access-control-allow-headers: Content-Type,Authorization,If-None-Match,X-User-Agent
access-control-allow-methods: GET,HEAD,OPTIONS
access-control-allow-origin: *
access-control-expose-headers: Content-Type,Warning,ETag,X-Pages
X-ESI-Error-Limit-Remain,X-ESI-Error-Limit-Reset
access-control-max-age: 600
allow: GET,HEAD,OPTIONS
cache-control: private
content-length: 2
content-type: application/json; charset=UTF-8
date: Tue, 26 Nov 2019 20:10:03 GMT
etag: "ed2e5773d709f4a0654d954884b08db4e152aeb8a70cb70b54e01bc4"
expires: Tue, 26 Nov 2019 21:10:03 GMT
last-modified: Tue, 26 Nov 2019 20:10:03 GMT
strict-transport-security: max-age=31536000
x-esi-error-limit-remain: 100
x-esi-error-limit-reset: 57
x-esi-request-id: d7317e84-bb8b-4a73-8fa9-ced575091e4e
x-firefox-spdy: h2
```