### PR TITLE
fix: ensure enqueued skills are stored

### DIFF
--- a/src/database/migrations/2020_02_09_182013_add_queues_position_to_skill_queue_table_pk.php
+++ b/src/database/migrations/2020_02_09_182013_add_queues_position_to_skill_queue_table_pk.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Class AddQueuePositionToSkillQueueTablePK.
+ */
+class AddQueuesPositionToSkillQueueTablePK extends Migration
+{
+    public function up()
+    {
+        Schema::table('character_skill_queues', function (Blueprint $table) {
+            $table->dropPrimary(['character_id', 'skill_id']);
+        });
+
+        Schema::table('character_skill_queues', function (Blueprint $table) {
+            $table->primary(['character_id', 'queue_position']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('character_skill_queues', function (Blueprint $table) {
+            $table->primary(['character_id', 'queue_position']);
+        });
+
+        Schema::table('character_skill_queues', function (Blueprint $table) {
+            $table->dropPrimary(['character_id', 'skill_id']);
+        });
+    }
+}


### PR DESCRIPTION
due to the primary key based on character_id and type_id, multiple enqueued level targeting same skill were not kept.

this fix ensure we store both level 1 & 2 from same skill if both are queued.