### PR TITLE
fix: ensure enqueued skills are stored

### DIFF
--- a/src/Jobs/Skills/Character/Queue.php
+++ b/src/Jobs/Skills/Character/Queue.php
@@ -57,9 +57,9 @@ class Queue extends EsiBase
     protected $tags = ['character', 'skills', 'queue'];
 
     /**
-     * @var \Illuminate\Support\Collection
+     * @var int
      */
-    private $known_skills;
+    protected $greatest_position;
 
     /**
      * Execute the job.
@@ -68,8 +68,7 @@ class Queue extends EsiBase
      */
     public function handle()
     {
-
-        $this->known_skills = collect();
+        $this->greatest_position = -1;
 
         if (! $this->preflighted()) return;
 
@@ -83,14 +82,14 @@ class Queue extends EsiBase
 
             CharacterSkillQueue::firstOrNew([
                 'character_id' => $this->getCharacterId(),
-                'skill_id'     => $skill->skill_id,
-                'finished_level'    => $skill->finished_level,
+                'queue_position'    => $skill->queue_position,
             ])->fill([
+                'skill_id'     => $skill->skill_id,
                 'finish_date'       => property_exists($skill, 'finish_date') ?
                     carbon($skill->finish_date) : null,
                 'start_date'        => property_exists($skill, 'start_date') ?
                     carbon($skill->start_date) : null,
-                'queue_position'    => $skill->queue_position,
+                'finished_level'    => $skill->finished_level,
                 'training_start_sp' => property_exists($skill, 'training_start_sp') ?
                     $skill->training_start_sp : null,
                 'level_end_sp'      => property_exists($skill, 'level_end_sp') ?
@@ -99,12 +98,13 @@ class Queue extends EsiBase
                     $skill->level_start_sp : null,
             ])->save();
 
-            $this->known_skills->push($skill->skill_id);
+            if ($skill->queue_position > $this->greatest_position)
+                $this->greatest_position = $skill->queue_position;
         });
 
         // dropping outdated skills
         CharacterSkillQueue::where('character_id', $this->getCharacterId())
-            ->whereNotIn('skill_id', $this->known_skills->toArray())
+            ->where('queue_position', '>', $this->greatest_position)
             ->delete();
     }
 }

--- a/src/database/migrations/2020_02_09_182013_add_queues_position_to_skill_queue_table_pk.php
+++ b/src/database/migrations/2020_02_09_182013_add_queues_position_to_skill_queue_table_pk.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Class AddQueuePositionToSkillQueueTablePK.
+ */
+class AddQueuesPositionToSkillQueueTablePK extends Migration
+{
+    public function up()
+    {
+        Schema::table('character_skill_queues', function (Blueprint $table) {
+            $table->dropPrimary(['character_id', 'skill_id']);
+        });
+
+        Schema::table('character_skill_queues', function (Blueprint $table) {
+            $table->primary(['character_id', 'queue_position']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('character_skill_queues', function (Blueprint $table) {
+            $table->primary(['character_id', 'queue_position']);
+        });
+
+        Schema::table('character_skill_queues', function (Blueprint $table) {
+            $table->dropPrimary(['character_id', 'skill_id']);
+        });
+    }
+}


### PR DESCRIPTION
due to the primary key based on character_id and type_id, multiple enqueued level targeting same skill were not kept.

this fix ensure we store both level 1 & 2 from same skill if both are queued.