### PR TITLE
feat(jobs): store updated refresh token returned by SSO when refreshing access tokens

### DIFF
--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -395,6 +395,9 @@ abstract class EsiBase extends AbstractJob
 
             $last_auth = $this->client->getAuthentication();
 
+            if (! empty($last_auth->refresh_token))
+                $token->refresh_token = $last_auth->refresh_token;
+
             $token->token = $last_auth->access_token ?? '-';
             $token->expires_on = $last_auth->token_expires;
 


### PR DESCRIPTION
When refreshing an access token from an SSO v1 refresh token from the SSO v2 endpoints, stores the updated SSO v2 refresh token. Also helps if should CCP decide to enable refresh token rotation in the future.