### PR TITLE
fix for CharacterAffiliation job and User relation on RefreshToken model

### DIFF
--- a/src/Jobs/Character/Affiliation.php
+++ b/src/Jobs/Character/Affiliation.php
@@ -24,6 +24,7 @@ namespace Seat\Eveapi\Jobs\Character;
 
 use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\Character\CharacterAffiliation;
+use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Eveapi\Models\Character\CharacterNotification;
 use Seat\Eveapi\Models\Contacts\CharacterContact;
 use Seat\Eveapi\Models\Contracts\ContractDetail;
@@ -102,7 +103,7 @@ class Affiliation extends EsiBase
                 ->select('client_id'),
             'contact_id'      => CharacterContact::where('contact_type', 'character'),
             'issuer_id'       => (new ContractDetail),
-            'character_id'    => (new MailHeader),
+            'character_id'    => (new CharacterInfo),
             'from'            => MailHeader::whereBetween('from', [3000000, 4000000])
                 ->orWhereBetween('from', [90000000, 98000000])
                 ->select('from'),

--- a/src/Models/RefreshToken.php
+++ b/src/Models/RefreshToken.php
@@ -169,6 +169,6 @@ class RefreshToken extends Model
     public function user()
     {
 
-        return $this->belongsTo(User::class, 'character_id', 'id');
+        return $this->belongsTo(User::class, 'user_id', 'id');
     }
 }

--- a/src/Observers/CharacterAffiliationObserver.php
+++ b/src/Observers/CharacterAffiliationObserver.php
@@ -43,7 +43,7 @@ class CharacterAffiliationObserver
         if (! CorporationInfo::find($affiliation->corporation_id))
             dispatch(new CorporationInfoJob($affiliation->corporation_id))->onQueue('high');
 
-        if (! Alliance::find($affiliation->alliance_id))
+        if (! empty($affiliation->alliance_id) && ! Alliance::find($affiliation->alliance_id))
             dispatch(new AllianceInfoJob($affiliation->alliance_id))->onQueue('high');
     }
 }


### PR DESCRIPTION
- Updates the User model relation on the RefreshToken model to use new foreign key.
- character_id does not exist on MailHeaders model any more.  A better use of this was to update CharacterInfo affiliations so we get the characters updated corporation when they change corps since we no longer get this stored directly on the CharacterInfo model any more so it doesn't get updated.