### PR TITLE
Update CorporationMemberTracking model from User to RefreshToken

### DIFF
--- a/src/Models/Corporation/CorporationMemberTracking.php
+++ b/src/Models/Corporation/CorporationMemberTracking.php
@@ -23,12 +23,12 @@
 namespace Seat\Eveapi\Models\Corporation;
 
 use Illuminate\Database\Eloquent\Model;
+use Seat\Eveapi\Models\RefreshToken;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Models\Sde\StaStation;
 use Seat\Eveapi\Models\Universe\UniverseName;
 use Seat\Eveapi\Models\Universe\UniverseStructure;
-use Seat\Web\Models\User;
 
 /**
  * Class CorporationMemberTracking.
@@ -196,10 +196,10 @@ class CorporationMemberTracking extends Model
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      * @deprecated
      */
-    public function user()
+    public function refresh_token()
     {
 
-        return $this->belongsTo(User::class, 'character_id', 'id');
+        return $this->belongsTo(RefreshToken::class, 'character_id', 'character_id');
     }
 
     /**


### PR DESCRIPTION
Related to https://github.com/eveseat/services/pull/120 and https://github.com/eveseat/web/pull/386.

Following the removal of the direct correlation between a Character and a SeAT user, updated the model to use RefreshToken instead (which provides a relation to the User model).