### PR TITLE
feat(api): upgrade doc to OAS3

### DIFF
--- a/src/Models/Alliances/Alliance.php
+++ b/src/Models/Alliances/Alliance.php
@@ -31,6 +31,11 @@ use Illuminate\Database\Eloquent\Model;
 class Alliance extends Model
 {
     /**
+     * @var array
+     */
+    protected $hidden = ['created_at', 'updated_at'];
+
+    /**
      * @var bool
      */
     protected static $unguarded = true;

--- a/src/Models/Assets/CharacterAsset.php
+++ b/src/Models/Assets/CharacterAsset.php
@@ -35,100 +35,112 @@ use Seat\Eveapi\Traits\CanUpsertIgnoreReplace;
  * Class CharacterAsset.
  * @package Seat\Eveapi\Models\Assets
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Character Asset",
  *     title="CharacterAsset",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="item_id",
  *     description="The item identifier"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     property="type_id",
- *     description="The item inventory type identifier"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="integer",
  *     property="quantity",
  *     description="The item quantity"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="location_id",
  *     description="The place of the item"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     enum={"station", "solar_system", "other"},
  *     property="location_type",
  *     description="The location qualifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="location_flag",
  *     description="The location flag"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="is_singleton",
  *     description="True if the item is not stacked"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="x",
  *     description="The x coordinate if the item is in space"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="y",
  *     description="The y coordinate if the item is in space"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="z",
  *     description="The z coordinate if the item is in space"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="map_id",
  *     description="The map identifier into which item is located"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="map_name",
  *     description="The name of the system where the item resides"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
+ *     type="string",
+ *     property="name",
+ *     description="The name of the asset (ie: a ship name)"
+ * )
+ *
+ * @OA\Property(
  *     property="type",
- *     ref="#/definitions/InvType"
+ *     ref="#/components/schemas/InvType"
  * )
  */
 class CharacterAsset extends Model
 {
     use CanUpsertIgnoreReplace;
     use AuthorizedScope;
+
+    /**
+     * @var array
+     */
+    protected $hidden = ['character_id', 'type_id', 'created_at', 'updated_at'];
+
+    /**
+     * @var array
+     */
+    protected $casts = [
+        'is_singleton' => 'boolean',
+    ];
 
     /**
      * @var bool

--- a/src/Models/Assets/CorporationAsset.php
+++ b/src/Models/Assets/CorporationAsset.php
@@ -30,99 +30,111 @@ use Seat\Eveapi\Traits\CanUpsertIgnoreReplace;
  * Class CorporationAsset.
  * @package Seat\Eveapi\Models\Assets
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Corporation Asset",
  *     title="CorporationAsset",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="item_id",
  *     description="The item identifier"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     property="type_id",
- *     description="The item inventory type identifier"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="integer",
  *     property="quantity",
  *     description="The item quantity"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="location_id",
  *     description="The place of the item"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
- *     enum={"station", "solar_system", "other"},
+ *     enum={"item", "other", "solar_system", "station"},
  *     property="location_type",
  *     description="The location qualifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="location_flag",
  *     description="The location flag"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="is_singleton",
  *     description="True if the item is not stacked"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="x",
  *     description="The x coordinate if the item is in space"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="y",
  *     description="The y coordinate if the item is in space"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="z",
  *     description="The z coordinate if the item is in space"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="map_id",
  *     description="The map identifier into which item is located"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="map_name",
  *     description="The name of the system where the item resides"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
+ *     type="string",
+ *     property="name",
+ *     description="The name of the asset (ie: a ship name)"
+ * )
+ *
+ * @OA\Property(
  *     property="type",
- *     ref="#/definitions/InvType"
+ *     ref="#/components/schemas/InvType"
  * )
  */
 class CorporationAsset extends Model
 {
     use CanUpsertIgnoreReplace;
+
+    /**
+     * @var array
+     */
+    protected $hidden = ['corporation_id', 'type_id', 'created_at', 'updated_at'];
+
+    /**
+     * @var array
+     */
+    protected $casts = [
+        'is_singleton' => 'boolean',
+    ];
 
     /**
      * @var bool

--- a/src/Models/Bookmarks/CharacterBookmark.php
+++ b/src/Models/Bookmarks/CharacterBookmark.php
@@ -30,104 +30,104 @@ use Seat\Eveapi\Traits\CanUpsertIgnoreReplace;
  * Class CharacterBookmark.
  * @package Seat\Eveapi\Models\Assets
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Character Bookmark",
  *     title="CharacterBookmark",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="bookmark_id",
  *     description="The bookmark identifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="folder_id",
  *     description="The folder ID into which the bookmark resides"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="folder_name",
  *     description="The folder name into which the bookmark resides"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     property="system",
- *     ref="#/definitions/MapDenormalize"
+ *     ref="#/components/schemas/MapDenormalize"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="created",
  *     description="The bookmark creation date"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="label",
  *     description="The bookmark label"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="notes",
  *     description="A note attached to the bookmark"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="location_id",
  *     description="The system ID where the bookmark is"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="creator_id",
  *     description="The character who created the bookmark"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="item_id",
  *     description="The in-game item on which the bookmark has been took"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="type_id",
  *     description="The type of them item"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="x",
  *     description="The x position on the map"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="y",
  *     description="The y position on the map"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="z",
  *     description="The z position on the map"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="map_id",

--- a/src/Models/Bookmarks/CorporationBookmark.php
+++ b/src/Models/Bookmarks/CorporationBookmark.php
@@ -29,104 +29,104 @@ use Seat\Eveapi\Models\Sde\MapDenormalize;
  * Class CorporationBookmark.
  * @package Seat\Eveapi\Models\Bookmarks
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Corporation Bookmark",
  *     title="CorporationBookmark",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="bookmark_id",
  *     description="The bookmark identifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="folder_id",
  *     description="The folder ID into which the bookmark resides"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="folder_name",
  *     description="The folder name into which the bookmark resides"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     property="system",
- *     ref="#/definitions/MapDenormalize"
+ *     ref="#/components/schemas/MapDenormalize"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="created",
  *     description="The bookmark creation date"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="label",
  *     description="The bookmark label"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="notes",
  *     description="A note attached to the bookmark"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="location_id",
  *     description="The system ID where the bookmark is"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="creator_id",
  *     description="The character who created the bookmark"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="item_id",
  *     description="The in-game item on which the bookmark has been took"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="type_id",
  *     description="The type of them item"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="x",
  *     description="The x position on the map"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="y",
  *     description="The y position on the map"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="z",
  *     description="The z position on the map"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="map_id",

--- a/src/Models/Character/CharacterCorporationHistory.php
+++ b/src/Models/Character/CharacterCorporationHistory.php
@@ -29,54 +29,51 @@ use Seat\Eveapi\Models\Universe\UniverseName;
  * Class CharacterCorporationHistory.
  * @package Seat\Eveapi\Models\Character
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Character Corporation History",
  *     title="CharacterCorporationHistory",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="start_date",
  *     description="The date-time from which the character was inside the corporation"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="corporation_id",
  *     description="The corporation ID into which the character was"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="is_deleted",
  *     description="True if the corporation has been close"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="record_id",
  *     description="Sorting key"
  * )
- *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="created_at",
- *     description="The date-time when record has been created into SeAT"
- * )
- *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="updated_at",
- *     description="The date-time when record has been updated into SeAT"
- * )
  */
 class CharacterCorporationHistory extends Model
 {
+    /**
+     * @var array
+     */
+    protected $hidden = ['id', 'created_at', 'updated_at'];
+
+    /**
+     * @var array
+     */
+    protected $casts = [
+        'is_deleted' => 'boolean',
+    ];
 
     /**
      * @var bool

--- a/src/Models/Character/CharacterInfo.php
+++ b/src/Models/Character/CharacterInfo.php
@@ -56,115 +56,115 @@ use Seat\Web\Models\User;
  * Class CharacterInfo.
  * @package Seat\Eveapi\Models\Character
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Character Info",
  *     title="CharacterInfo",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="name",
  *     description="Character name"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="description",
  *     description="Character biography"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="corporation_id",
  *     description="Character corporation identifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="alliance_id",
  *     description="Character alliance identifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="birthday",
  *     description="Character birthday"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     enum={"male", "female"},
  *     property="gender",
  *     description="Character gender"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="race_id",
  *     description="Character race identifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="bloodline_id",
  *     description="Character bloodline identifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="ancenstry_id",
  *     description="Character ancenstry identifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="security_status",
  *     description="Character security status"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="faction_id",
  *     description="Character faction identifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="created_at",
  *     description="The date-time when record has been created into SeAT"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="updated_at",
  *     description="The date-time when record has been updated into SeAT"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="balance",
  *     description="Character wallet balance"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="object",
  *     property="skillpoints",
  *     description="",
- *     @SWG\Property(
+ *     @OA\Property(
  *          type="number",
  *          format="int64",
  *          property="total_sp",
  *          description="The total skill points owned by the character"
  *     ),
- *     @SWG\Property(
+ *     @OA\Property(
  *          type="number",
  *          format="int64",
  *          property="unallocated_sp",

--- a/src/Models/Character/CharacterNotification.php
+++ b/src/Models/Character/CharacterNotification.php
@@ -30,65 +30,65 @@ use Symfony\Component\Yaml\Yaml;
  * Class CharacterNotification.
  * @package Seat\Eveapi\Models\Character
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Character Notification",
  *     title="CharacterNotification",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="notification_id",
  *     description="The notification identifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="type",
  *     description="The notification type"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="sender_id",
  *     description="The entity who sent the notification"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     enum={"character","corporation","alliance","faction","other"},
  *     property="sender_type",
  *     description="The sender qualifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="timestamp",
  *     description="The date-time when notification has been sent"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="is_read",
  *     description="True if the notification has been red"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
- *     property="text",
+ *     property="object",
  *     description="The notification content"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="created_at",
  *     description="The date-time when notification has been created into SeAT"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="updated_at",
@@ -97,6 +97,18 @@ use Symfony\Component\Yaml\Yaml;
  */
 class CharacterNotification extends Model
 {
+    /**
+     * @var array
+     */
+    protected $casts = [
+        'is_read' => 'boolean',
+    ];
+
+    /**
+     * @var array
+     */
+    protected $hidden = ['created_at', 'updated_at'];
+
     /**
      * @var bool
      */

--- a/src/Models/Character/CharacterSkill.php
+++ b/src/Models/Character/CharacterSkill.php
@@ -30,45 +30,44 @@ use Seat\Eveapi\Traits\AuthorizedScope;
  * Class CharacterSkill.
  * @package Seat\Eveapi\Models\Character
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Character Skill",
  *     title="CharacterSkill",
  *     type="object"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     property="skill_id",
- *     description="The skill inventory type ID"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="skillpoints_in_skill",
  *     description="The amount of skill point actually learned for that skill"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="trained_skill_level",
  *     description="The level up to which the skill as been learned"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="active_skill_level",
  *     description="The level actually training"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     property="type",
- *     ref="#/definitions/InvType",
+ *     ref="#/components/schemas/InvType",
  *     description="The inventory type information"
  * )
  */
 class CharacterSkill extends Model
 {
     use AuthorizedScope;
+
+    /**
+     * @var array
+     */
+    protected $hidden = ['id', 'character_id', 'skill_id', 'created_at', 'updated_at'];
 
     /**
      * @var bool

--- a/src/Models/Clones/CharacterJumpClone.php
+++ b/src/Models/Clones/CharacterJumpClone.php
@@ -30,62 +30,53 @@ use Seat\Eveapi\Models\Universe\UniverseStructure;
  * Class CharacterJumpClone.
  * @package Seat\Eveapi\Models\Clones
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Character Jump Clone",
  *     title="CharacterJumpClone",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="jump_clone_id",
  *     description="Unique jump clone identifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="name",
  *     description="Clone name if set"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="location_id",
  *     description="The structure into which the clone resides"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     enum={"station","structure"},
  *     property="location_type",
  *     description="The structure type qualifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="array",
  *     property="implants",
  *     description="A list of type ID",
- *     @SWG\Items(type="integer")
- * )
- *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="created_at",
- *     description="The date-time when record has been created into SeAT"
- * )
- *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="updated_at",
- *     description="The date-time when record has been updated into SeAT"
+ *     @OA\Items(type="integer")
  * )
  */
 class CharacterJumpClone extends Model
 {
+    /**
+     * @var array
+     */
+    protected $hidden = ['id', 'created_at', 'updated_at'];
+
     /**
      * @var bool
      */

--- a/src/Models/Contacts/CharacterContact.php
+++ b/src/Models/Contacts/CharacterContact.php
@@ -29,92 +29,50 @@ use Seat\Eveapi\Models\Universe\UniverseName;
  * Class CharacterContact.
  * @package Seat\Eveapi\Models\Contacts
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Character Contact",
  *     title="CharacterContact",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="contact_id",
  *     description="The entity ID"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="float",
  *     property="standing",
  *     description="The standing between -10 and 10"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     enum={"character","corporation","alliance","faction"},
  *     property="contact_type",
  *     description="The entity type"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="is_watched",
  *     description="True if the contact is in the watchlist"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="is_blocked",
  *     description="True if the contact is in the blacklist"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     property="label_id",
- *     description="The labels mask attached to the the contact"
- * )
- *
- * @SWG\Property(
- *     type="string",
- *     property="label_data"
- * )
- *
- * @SWG\Property(
- *     type="object",
- *     property="created_at",
- *     description="The contact creation date",
- *     @SWG\Property(
- *          type="string",
- *          format="date-time",
- *          property="date"
- *     ),
- *     @SWG\Property(
- *          type="integer",
- *          property="timezone_type"
- *     ),
- *     @SWG\Property(
- *          type="string",
- *          property="timezone"
- *     )
- * )
- *
- * @SWG\Property(
- *     type="object",
- *     property="updated_at",
- *     description="The contact creation date",
- *     @SWG\Property(
- *          type="string",
- *          format="date-time",
- *          property="date"
- *     ),
- *     @SWG\Property(
- *          type="integer",
- *          property="timezone_type"
- *     ),
- *     @SWG\Property(
- *          type="string",
- *          property="timezone"
- *     )
+ * @OA\Property(
+ *     property="labels",
+ *     type="array",
+ *     description="Labels attached to the the contact",
+ *     @OA\Items(type="string")
  * )
  */
 class CharacterContact extends Model
@@ -124,7 +82,16 @@ class CharacterContact extends Model
      * @var array
      */
     protected $casts = [
+        'is_watched' => 'boolean',
+        'is_blocked' => 'boolean',
         'label_ids' => 'array',
+    ];
+
+    /**
+     * @var array
+     */
+    protected $hidden = [
+        'created_at', 'updated_at',
     ];
 
     /**

--- a/src/Models/Contacts/CorporationContact.php
+++ b/src/Models/Contacts/CorporationContact.php
@@ -29,92 +29,50 @@ use Seat\Eveapi\Models\Universe\UniverseName;
  * Class CorporationContact.
  * @package Seat\Eveapi\Models\Contacts
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Corporation Contact",
  *     title="CorporationContact",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="contact_id",
  *     description="The entity ID"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="float",
  *     property="standing",
  *     description="The standing between -10 and 10"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     enum={"character","corporation","alliance","faction"},
  *     property="contact_type",
  *     description="The entity type"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="is_watched",
  *     description="True if the contact is in the watchlist"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="is_blocked",
  *     description="True if the contact is in the blacklist"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     property="label_id",
- *     description="The labels mask attached to the the contact"
- * )
- *
- * @SWG\Property(
- *     type="string",
- *     property="label_data"
- * )
- *
- * @SWG\Property(
- *     type="object",
- *     property="created_at",
- *     description="The contact creation date",
- *     @SWG\Property(
- *          type="string",
- *          format="date-time",
- *          property="date"
- *     ),
- *     @SWG\Property(
- *          type="integer",
- *          property="timezone_type"
- *     ),
- *     @SWG\Property(
- *          type="string",
- *          property="timezone"
- *     )
- * )
- *
- * @SWG\Property(
- *     type="object",
- *     property="updated_at",
- *     description="The contact creation date",
- *     @SWG\Property(
- *          type="string",
- *          format="date-time",
- *          property="date"
- *     ),
- *     @SWG\Property(
- *          type="integer",
- *          property="timezone_type"
- *     ),
- *     @SWG\Property(
- *          type="string",
- *          property="timezone"
- *     )
+ * @OA\Property(
+ *     property="labels",
+ *     type="array",
+ *     description="Labels attached to the the contact",
+ *     @OA\Items(type="string")
  * )
  */
 class CorporationContact extends Model
@@ -124,7 +82,16 @@ class CorporationContact extends Model
      * @var array
      */
     protected $casts = [
+        'is_watched' => 'boolean',
+        'is_blocked' => 'boolean',
         'label_ids' => 'array',
+    ];
+
+    /**
+     * @var array
+     */
+    protected $hidden = [
+        'created_at', 'updated_at',
     ];
 
     /**

--- a/src/Models/Contracts/CharacterContract.php
+++ b/src/Models/Contracts/CharacterContract.php
@@ -27,24 +27,6 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Class CharacterContract.
  * @package Seat\Eveapi\Models\Contacts
- *
- * @SWG\Definition(
- *     description="Character Contract",
- *     title="CharacterContract",
- *     type="object"
- * )
- *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     property="contract_id",
- *     description="The contract identifier"
- * )
- *
- * @SWG\Property(
- *     property="detail",
- *     ref="#/definitions/ContractDetail"
- * )
  */
 class CharacterContract extends Model
 {

--- a/src/Models/Contracts/ContractBid.php
+++ b/src/Models/Contracts/ContractBid.php
@@ -27,9 +27,41 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Class ContractBid.
  * @package Seat\Eveapi\Models\Contacts
+ *
+ * @OA\Schema(
+ *     description="Contract Bid",
+ *     title="ContractBid",
+ *     type="object"
+ * )
+ *
+ * @OA\Property(
+ *     property="bidder_id",
+ *     type="integer",
+ *     format="int64",
+ *     description="Identifier from entity who put a bid"
+ * )
+ *
+ * @OA\Property(
+ *     property="date_bid",
+ *     type="string",
+ *     format="date-time",
+ *     description="Date/Time when the bid has been placed"
+ * )
+ *
+ * @OA\Property(
+ *     property="amount",
+ *     type="number",
+ *     description="Amount of placed bid"
+ * )
+ *
  */
 class ContractBid extends Model
 {
+    /**
+     * @var array
+     */
+    protected $hidden = ['bid_id', 'contract_id', 'created_at', 'updated_at'];
+
     /**
      * @var bool
      */

--- a/src/Models/Contracts/ContractDetail.php
+++ b/src/Models/Contracts/ContractDetail.php
@@ -30,179 +30,166 @@ use Seat\Eveapi\Models\Universe\UniverseStructure;
  * Class ContractDetail.
  * @package Seat\Eveapi\Models\Contacts
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Contract Detail",
  *     title="ContractDetail",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="contract_id",
  *     description="The contract identifier"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     property="issuer_id",
- *     description="The entity ID who created the contract"
- * )
- *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     property="issuer_corporation_id",
- *     description="The corporation ID from the contract creator"
- * )
- *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     property="assignee_id",
- *     description="The entity ID to whom the created has been created"
- * )
- *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     property="acceptor_id",
- *     description="The entity ID who accept the contract"
- * )
- *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     property="start_location_id",
- *     description="The structure from where the contract has been made"
- * )
- *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     property="end_location_id",
- *     description="The structure to where the contract should be deliver"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     enum={"unknown","item_exchange","auction","courier","loan"},
  *     property="type",
  *     description="The contract type"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     enum={"outstanding","in_progress","finished_issuer","finished_contractor","finished","cancelled","rejected","failed","deleted","reversed"},
  *     property="status",
  *     description="The contract status"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="title",
  *     description="The contract description"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="for_corporation",
  *     description="True if the contract is a corporation contract"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     enum={"public","personal","corporation","alliance"},
  *     property="availability",
  *     description="The contract availability scope"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="date_issued",
  *     description="The date-time when the contract has been made"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="date_expired",
  *     description="The date-time when the contract is expiring"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="date_accepted",
  *     description="The date-time when the contract has been accepted"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="days_to_complete",
  *     description="The amount of day during which the contract is going (for courier contract)"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="date_completed",
  *     description="The date-time when the contract has been completed"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="price",
  *     description="The amount of ISK the acceptor entity must pay to get the contract"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="reward",
  *     description="The amount of ISK the acceptor entity is earning by accepting the contract"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="collateral",
  *     description="The amount of ISK the acceptor entity have to pay in case of failure"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="buyout",
  *     description="The amount of ISK the contract is completed (for auction)"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="volume",
  *     description="The contract volume"
  * )
  *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="created_at",
- *     description="The date-time when the record has been created in SeAT"
+ * @OA\Property(
+ *     property="issuer",
+ *     ref="#/components/schemas/UniverseName"
  * )
  *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="updated_at",
- *     description="The date-time when the record has been updated in SeAT"
+ * @OA\Property(
+ *     property="assignee",
+ *     ref="#/components/schemas/UniverseName"
+ * )
+ *
+ * @OA\Property(
+ *     property="acceptor",
+ *     ref="#/components/schemas/UniverseName"
+ * )
+ *
+ * @OA\Property(
+ *     property="bids",
+ *     type="array",
+ *     @OA\Items(ref="#/components/schemas/ContractBid")
+ * )
+ *
+ * @OA\Property(
+ *     property="lines",
+ *     type="array",
+ *     @OA\Items(ref="#/components/schemas/ContractItem")
+ * )
+ *
+ * @OA\Property(
+ *     property="start_location",
+ *     ref="#/components/schemas/UniverseStructure"
+ * )
+ *
+ * @OA\Property(
+ *     property="end_location",
+ *     ref="#/components/schemas/UniverseStructure"
  * )
  */
 class ContractDetail extends Model
 {
+    /**
+     * @var array
+     */
+    protected $casts = [
+        'for_corporation' => 'boolean',
+    ];
     /**
      * @var bool
      */

--- a/src/Models/Contracts/ContractItem.php
+++ b/src/Models/Contracts/ContractItem.php
@@ -28,9 +28,58 @@ use Seat\Eveapi\Models\Sde\InvType;
 /**
  * Class ContractItem.
  * @package Seat\Eveapi\Models\Contacts
+ *
+ * @OA\Schema(
+ *     description="Contract Item",
+ *     title="ContractItem",
+ *     type="object"
+ * )
+ *
+ * @OA\Property(
+ *     property="type_id",
+ *     type="integer",
+ *     description="The item type identifier"
+ * )
+ *
+ * @OA\Property(
+ *     property="quantity",
+ *     type="number",
+ *     description="The item quantity"
+ * )
+ *
+ * @OA\Property(
+ *     property="raw_quantity",
+ *     type="integer",
+ *     minimum=-2
+ * )
+ *
+ * @OA\Property(
+ *     property="is_singleton",
+ *     type="boolean",
+ *     description="Determine if the item is stacked"
+ * )
+ *
+ * @OA\Property(
+ *     property="is_included",
+ *     type="boolean",
+ *     description="Determine if the item is contained in a parent item"
+ * )
  */
 class ContractItem extends Model
 {
+    /**
+     * @var array
+     */
+    protected $casts = [
+        'is_singleton' => 'boolean',
+        'is_included' => 'boolean',
+    ];
+
+    /**
+     * @var array
+     */
+    protected $hidden = ['contract_id', 'record_id', 'created_at', 'updated_at'];
+
     /**
      * @var bool
      */

--- a/src/Models/Contracts/CorporationContract.php
+++ b/src/Models/Contracts/CorporationContract.php
@@ -27,24 +27,6 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Class CorporationContract.
  * @package Seat\Eveapi\Models\Contacts
- *
- * @SWG\Definition(
- *     description="Corporation Contract",
- *     title="CorporationContract",
- *     type="object"
- * )
- *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     property="contract_id",
- *     description="The contract identifier"
- * )
- *
- * @SWG\Property(
- *     property="detail",
- *     ref="#/definitions/ContractDetail"
- * )
  */
 class CorporationContract extends Model
 {

--- a/src/Models/Corporation/CorporationInfo.php
+++ b/src/Models/Corporation/CorporationInfo.php
@@ -45,96 +45,89 @@ use Seat\Eveapi\Traits\AuthorizedScope;
  * Class CorporationInfo.
  * @package Seat\Eveapi\Models\Corporation
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *      description="Corporation Sheet",
  *      title="CorporationInfo",
  *      type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="name",
  *     description="The name of the corporation"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="ticker",
  *     description="The corporation ticker name"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="member_count",
  *     description="The member amount of the corporation"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     minimum=90000000,
- *     property="ceo_id",
- *     description="The character ID of the corporation CEO"
+ * @OA\Property(
+ *     property="ceo",
+ *     description="The character ID of the corporation CEO",
+ *     ref="#/components/schemas/UniverseName"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     minimum=99000000,
- *     property="alliance_id",
- *     description="The alliance ID of the corporation if any"
+ * @OA\Property(
+ *     property="alliance",
+ *     description="The alliance of the corporation if any",
+ *     ref="#/components/schemas/UniverseName"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="description",
  *     description="The corporation description"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="float",
  *     property="tax_rate",
  *     description="The corporation tax rate"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="date_founded",
  *     description="The corporation creation date"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     property="creator_id",
- *     description="The corporation founder character ID"
+ * @OA\Property(
+ *     property="creator",
+ *     description="The corporation founder character",
+ *     ref="#/components/schemas/UniverseName"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="uri",
  *     property="url",
  *     description="The corporation homepage link"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     minimum=500000,
- *     maximum=1000000,
- *     property="faction_id",
- *     description="The corporation faction if any"
+ * @OA\Property(
+ *     property="faction",
+ *     description="The corporation faction if any",
+ *     ref="#/components/schemas/UniverseName"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="home_station_id",
  *     description="The home station where the corporation has its HQ"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="shares",
@@ -543,5 +536,26 @@ class CorporationInfo extends Model
                 'category'  => 'character',
                 'name'      => trans('web::seat.unknown'),
             ]);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function creator()
+    {
+        return $this->hasOne(UniverseName::class, 'entity_id', 'creator_id')
+            ->withDefault([
+                'category' => 'character',
+                'name'     => trans('web::seat.unknown'),
+            ]);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function faction()
+    {
+        return $this->hasOne(UniverseName::class, 'entity_id', 'faction_id')
+            ->withDefault();
     }
 }

--- a/src/Models/Corporation/CorporationMemberTracking.php
+++ b/src/Models/Corporation/CorporationMemberTracking.php
@@ -34,146 +34,58 @@ use Seat\Eveapi\Models\Universe\UniverseStructure;
  * Class CorporationMemberTracking.
  * @package Seat\Eveapi\Models\Corporation
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *      description="Corporation Member Tracking",
  *      title="CorporationMemberTracking",
  *      type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="character_id",
  *     description="The character ID"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="start_date",
  *     description="The date since which the character is member of the corporation"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="base_id",
  *     description="The structure to which the main location of this character is set"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="logon_date",
  *     description="The last time when we saw the character"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
- *     property="logoff_time",
+ *     property="logoff_date",
  *     description="The last time when the character signed out"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="location_id",
  *     description="The place where the character is"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     property="ship_type_id",
- *     description="The typeID of the ship into which the character is in"
- * )
- *
- * @SWG\Property(
- *     type="object",
- *     property="ship_type",
+ * @OA\Property(
+ *     property="ship",
  *     description="The ship information",
- *     @SWG\Property(
- *          type="integer",
- *          property="typeID",
- *          description="The type ID of the ship"
- *     ),
- *     @SWG\Property(
- *          type="integer",
- *          property="groupID",
- *          description="The group ID of the ship"
- *     ),
- *     @SWG\Property(
- *          type="string",
- *          property="typeName",
- *          description="The name of the ship (item)"
- *     ),
- *     @SWG\Property(
- *          type="string",
- *          property="description",
- *          description="The description of the ship"
- *     ),
- *     @SWG\Property(
- *          type="number",
- *          format="double",
- *          property="mass",
- *          description="The mass of the ship"
- *     ),
- *     @SWG\Property(
- *          type="number",
- *          format="double",
- *          property="volume",
- *          description="The volume of the ship"
- *     ),
- *     @SWG\Property(
- *          type="number",
- *          format="double",
- *          property="capacity",
- *          description="The cargo capacity of the ship"
- *     ),
- *     @SWG\Property(
- *          type="integer",
- *          property="portionSize",
- *          description="The portion size of the ship"
- *     ),
- *     @SWG\Property(
- *          type="integer",
- *          property="raceID",
- *          description="The ID of the race to which the asset is related"
- *     ),
- *     @SWG\Property(
- *          type="number",
- *          format="float",
- *          property="basePrice",
- *          description="The initial price as state by CCP"
- *     ),
- *     @SWG\Property(
- *          type="boolean",
- *          property="published",
- *          description="Determine if the item is available in-game"
- *     ),
- *     @SWG\Property(
- *          type="integer",
- *          property="marketGroupID",
- *          description="The ID of the group on the market"
- *     ),
- *     @SWG\Property(
- *          type="number",
- *          format="double",
- *          property="iconID",
- *          description="The asset icon ID"
- *     ),
- *     @SWG\Property(
- *          type="number",
- *          format="double",
- *          property="soundID",
- *          description="The asset sound ID"
- *     ),
- *     @SWG\Property(
- *          type="number",
- *          format="double",
- *          property="graphicID",
- *          description="The asset graphic ID"
- *     )
+ *     ref="#/components/schemas/InvType"
  * )
  */
 class CorporationMemberTracking extends Model

--- a/src/Models/Industry/CharacterIndustryJob.php
+++ b/src/Models/Industry/CharacterIndustryJob.php
@@ -31,197 +31,164 @@ use Seat\Eveapi\Models\Universe\UniverseStructure;
  * Class CharacterIndustryJob.
  * @package Seat\Eveapi\Models\Industry
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Character Industry Jobs",
  *     title="CharacterIndustryJob",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="job_id",
  *     description="The job ID"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="installer_id",
  *     description="The character who start the job"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="facility_id",
  *     description="The structure where the job has been started"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="station_id",
  *     description="The outpost where the job has been started (deprecated)"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="activity_id",
  *     description="The activity type used for the job"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="blueprint_id",
  *     description="The item blueprint ID on which the job is based"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     property="blueprint_type_id",
- *     description="The used blueprint type"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="blueprint_location_id",
  *     description="The place where the blueprint is stored"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="output_location_id",
  *     description="The place where the resulting item should be put"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="runs",
  *     description="The runs amount for the activity"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="cost",
  *     description="The job installation cost"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="licensed_runs",
  *     description="The number of copy"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="probability",
  *     description="The success rate"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     property="product_type_id",
- *     description="The resulting item type"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     enum={"active","cancelled","delivered","paused","ready","reverted"},
  *     property="status",
  *     description="The job status"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="duration",
  *     description="The job duration in seconds"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="start_date",
  *     description="The date-time when job has been started"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="end_date",
  *     description="The date-time when job should be done"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="pause_date",
  *     description="The date-time when job has been paused"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="completed_date",
  *     description="The date-time when job has been delivered"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="completed_character_id",
  *     description="The character who deliver the job"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="successful_runs",
  *     description="The amount of completed runs"
  * )
  *
- * @SWG\Property(
- *     type="object",
- *     property="created_at",
- *     description="The contact creation date",
- *     @SWG\Property(
- *          type="string",
- *          format="date-time",
- *          property="date"
- *     ),
- *     @SWG\Property(
- *          type="integer",
- *          property="timezone_type"
- *     ),
- *     @SWG\Property(
- *          type="string",
- *          property="timezone"
- *     )
+ * @OA\Property(
+ *     property="blueprint",
+ *     description="The used blueprint type",
+ *     ref="#/components/schemas/InvType"
  * )
  *
- * @SWG\Property(
- *     type="object",
- *     property="updated_at",
- *     description="The contact creation date",
- *     @SWG\Property(
- *          type="string",
- *          format="date-time",
- *          property="date"
- *     ),
- *     @SWG\Property(
- *          type="integer",
- *          property="timezone_type"
- *     ),
- *     @SWG\Property(
- *          type="string",
- *          property="timezone"
- *     )
+ * @OA\Property(
+ *     property="product",
+ *     description="The output type",
+ *     ref="#/components/schemas/InvType"
  * )
  */
 class CharacterIndustryJob extends Model
 {
+    /**
+     * @var array
+     */
+    protected $hidden = ['created_at', 'updated_at'];
+
     /**
      * @var bool
      */

--- a/src/Models/Industry/CorporationIndustryJob.php
+++ b/src/Models/Industry/CorporationIndustryJob.php
@@ -31,197 +31,164 @@ use Seat\Eveapi\Models\Universe\UniverseStructure;
  * Class CorporationIndustryJob.
  * @package Seat\Eveapi\Models\Industry
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Corporation Industry Jobs",
  *     title="CorporationIndustryJob",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="job_id",
  *     description="The job ID"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="installer_id",
  *     description="The character who start the job"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="facility_id",
  *     description="The structure where the job has been started"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="station_id",
  *     description="The outpost where the job has been started (deprecated)"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="activity_id",
  *     description="The activity type used for the job"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="blueprint_id",
  *     description="The item blueprint ID on which the job is based"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     property="blueprint_type_id",
- *     description="The used blueprint type"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="blueprint_location_id",
  *     description="The place where the blueprint is stored"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="output_location_id",
  *     description="The place where the resulting item should be put"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="runs",
  *     description="The runs amount for the activity"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="cost",
  *     description="The job installation cost"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="licensed_runs",
  *     description="The number of copy"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="probability",
  *     description="The success rate"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     property="product_type_id",
- *     description="The resulting item type"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     enum={"active","cancelled","delivered","paused","ready","reverted"},
  *     property="status",
  *     description="The job status"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="duration",
  *     description="The job duration in seconds"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="start_date",
  *     description="The date-time when job has been started"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="end_date",
  *     description="The date-time when job should be done"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="pause_date",
  *     description="The date-time when job has been paused"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="completed_date",
  *     description="The date-time when job has been delivered"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="completed_character_id",
  *     description="The character who deliver the job"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="successful_runs",
  *     description="The amount of completed runs"
  * )
  *
- * @SWG\Property(
- *     type="object",
- *     property="created_at",
- *     description="The contact creation date",
- *     @SWG\Property(
- *          type="string",
- *          format="date-time",
- *          property="date"
- *     ),
- *     @SWG\Property(
- *          type="integer",
- *          property="timezone_type"
- *     ),
- *     @SWG\Property(
- *          type="string",
- *          property="timezone"
- *     )
+ * @OA\Property(
+ *     property="blueprint",
+ *     description="The used blueprint type",
+ *     ref="#/components/schemas/InvType"
  * )
  *
- * @SWG\Property(
- *     type="object",
- *     property="updated_at",
- *     description="The contact creation date",
- *     @SWG\Property(
- *          type="string",
- *          format="date-time",
- *          property="date"
- *     ),
- *     @SWG\Property(
- *          type="integer",
- *          property="timezone_type"
- *     ),
- *     @SWG\Property(
- *          type="string",
- *          property="timezone"
- *     )
+ * @OA\Property(
+ *     property="product",
+ *     description="The output type",
+ *     ref="#/components/schemas/InvType"
  * )
  */
 class CorporationIndustryJob extends Model
 {
+    /**
+     * @var array
+     */
+    protected $hidden = ['created_at', 'updated_at'];
+
     /**
      * @var bool
      */

--- a/src/Models/Killmails/Killmail.php
+++ b/src/Models/Killmails/Killmail.php
@@ -28,9 +28,44 @@ use Illuminate\Database\Eloquent\Model;
  * Class Killmail.
  *
  * @package Seat\Eveapi\Models\Killmails
+ *
+ * @OA\Schema(
+ *     description="Killmail informations",
+ *     title="Killmail",
+ *     type="object",
+ *     @OA\Property(
+ *       property="killmail_id",
+ *       type="integer",
+ *       format="int64",
+ *       description="The unique Killmail identifier"
+ *     ),
+ *     @OA\Property(
+ *       property="killmail_hash",
+ *       type="string",
+ *       description="The killmail hash"
+ *     ),
+ *     @OA\Property(
+ *       property="detail",
+ *       ref="#/components/schemas/KillmailDetail"
+ *     ),
+ *     @OA\Property(
+ *       property="victim",
+ *       ref="#/components/schemas/KillmailVictim"
+ *     ),
+ *     @OA\Property(
+ *       property="attackers",
+ *       type="array",
+ *       @OA\Items(ref="#/components/schemas/KillmailAttacker")
+ *     )
+ * )
  */
 class Killmail extends Model
 {
+    /**
+     * @var array
+     */
+    protected $hidden = ['created_at', 'updated_at'];
+
     /**
      * @var bool
      */

--- a/src/Models/Killmails/KillmailAttacker.php
+++ b/src/Models/Killmails/KillmailAttacker.php
@@ -29,93 +29,87 @@ use Seat\Eveapi\Models\Universe\UniverseName;
  * Class KillmailAttacker.
  * @package Seat\Eveapi\Models\Killmails
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Killmail Attacker",
  *     title="KillmailAttacker",
  *     type="object"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     property="killmail_id",
- *     description="The killmail identifier to which the attacker is attached"
+ * @OA\Property(
+ *     property="attacker_hash",
+ *     type="string",
+ *     description="A hash composite of character_id, corporation_id, alliance_id and faction_id fields"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="character_id",
  *     description="The character identifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="corporation_id",
  *     description="The corporation identifier to which the attacker depends"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="alliance_id",
  *     description="The alliance identifier to which the attacker depends"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="faction_id",
  *     description="The faction identifier to which the attacker depends (if factional warfare)"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="float",
  *     property="security_status",
  *     description="The attacker security status"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="final_blow",
  *     description="True if the attacker did the final blow"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="damage_done",
  *     description="The amount of damage the attacker applied"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="ship_type_id",
  *     description="The ship inventory type identifier into which attacker was"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="weapon_type_id",
  *     description="The weapon inventory type identifier used by the attacker"
  * )
- *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="created_at",
- *     description="The date-time when record has been created into SeAT"
- * )
- *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="updated_at",
- *     description="The date-time when record has been updated into SeAT"
- * )
  */
 class KillmailAttacker extends Model
 {
+    protected $casts = [
+        'final_blow' => 'boolean',
+    ];
+
+    /**
+     * @var array
+     */
+    protected $hidden = ['id', 'killmail_id', 'created_at', 'updated_at'];
+
     /**
      * @var bool
      */

--- a/src/Models/Killmails/KillmailDetail.php
+++ b/src/Models/Killmails/KillmailDetail.php
@@ -29,53 +29,45 @@ use Seat\Eveapi\Models\Sde\MapDenormalize;
  * Class KillmailDetail.
  * @package Seat\Eveapi\Models\Killmails
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Killmail Detail",
  *     title="KillmailDetail",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
+ *     property="killmail_time",
  *     type="string",
  *     format="date-time",
- *     property="killmail_time",
  *     description="The date-time when kill append"
  * )
  *
- * @SWG\Property(
- *     type="integer",
+ * @OA\Property(
  *     property="solar_system_id",
+ *     type="integer",
  *     description="The solar system identifier in which the kill occurs"
  * )
  *
- * @SWG\Property(
- *     type="integer",
+ * @OA\Property(
  *     property="moon_id",
+ *     type="integer",
  *     description="The moon identifier near to which the kill occurs"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
+ *     property="war_id",
  *     type="integer",
  *     format="int64",
- *     property="war_id",
  *     description="The war identifier in which the kill involves"
- * )
- *
- * @SWG\Property(
- *     type="array",
- *     property="attackers",
- *     description="A list of attackers",
- *     @SWG\Items(ref="#/definitions/KillmailAttacker")
- * )
- *
- * @SWG\Property(
- *     property="victims",
- *     description="The victim",
- *     ref="#/definitions/KillmailVictim"
  * )
  */
 class KillmailDetail extends Model
 {
+    /**
+     * @var array
+     */
+    protected $hidden = ['killmail_id', 'created_at', 'updated_at'];
+
     /**
      * @var bool
      */

--- a/src/Models/Killmails/KillmailVictim.php
+++ b/src/Models/Killmails/KillmailVictim.php
@@ -30,95 +30,79 @@ use Seat\Eveapi\Models\Universe\UniverseName;
  * Class KillmailVictim.
  * @package Seat\Eveapi\Models\Killmails
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Killmail Victim",
  *     title="KillmailVictim",
  *     type="object"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     property="killmail_id",
- *     description="The killmail identifier to which this victim is attached"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="character_id",
  *     description="The killed character identified"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="corporation_id",
  *     description="The killed character corporation identifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="alliance_id",
  *     description="The killed character alliance identifier (if any)"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="faction_id",
  *     description="The killed character faction identifier (if factional warfare)"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="damage_taken",
  *     description="The damage amount the killed character get"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="ship_type_id",
  *     description="The destroyed ship inventory type identifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="x",
  *     description="The x coordinate where the kill occurs"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="y",
  *     description="The y coordinate where the kill occurs"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="z",
  *     description="The z coordinate where the kill occurs"
  * )
- *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="created_at",
- *     description="The date-time when record has been created into SeAT"
- * )
- *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="updated_at",
- *     description="The date-time when record has been updated into SeAT"
- * )
  */
 class KillmailVictim extends Model
 {
+    /**
+     * @var array
+     */
+    protected $hidden = ['killmail_id', 'created_at', 'updated_at'];
+
     /**
      * @var bool
      */

--- a/src/Models/Mail/MailHeader.php
+++ b/src/Models/Mail/MailHeader.php
@@ -29,56 +29,56 @@ use Seat\Eveapi\Models\Universe\UniverseName;
  * Class MailHeader.
  * @package Seat\Eveapi\Models\Character
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Mail Header",
  *     title="MailHeader",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="mail_id",
  *     description="The mail identifier"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="subject",
  *     description="The mail topic"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="from",
  *     description="The mail sender"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="timestamp",
  *     description="The date-time when the mail has been sent"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="boolean",
  *     description="True if the mail has been red"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="body",
  *     description="The mail content"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="array",
  *     property="recipients",
  *     description="A list of recipients",
- *     @SWG\Items(ref="#/definitions/MailRecipient")
+ *     @OA\Items(ref="#/components/schemas/MailRecipient")
  * )
  */
 class MailHeader extends Model

--- a/src/Models/Mail/MailRecipient.php
+++ b/src/Models/Mail/MailRecipient.php
@@ -29,20 +29,20 @@ use Seat\Eveapi\Models\Universe\UniverseName;
  * Class MailRecipient.
  * @package Seat\Eveapi\Models\Mail
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Mail Recipient",
  *     title="MailRecipient",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="recipient_id",
  *     description="The recipient ID"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     enum={"character", "corporation", "alliance", "mailing_list"},
  *     property="recipient_type",

--- a/src/Models/Market/CharacterOrder.php
+++ b/src/Models/Market/CharacterOrder.php
@@ -30,119 +30,117 @@ use Seat\Eveapi\Models\Universe\UniverseStructure;
  * Class CharacterOrder.
  * @package Seat\Eveapi\Models\Market
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Character Order",
  *     title="CharacterOrder",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="order_id",
  *     description="The market order ID"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     property="type_id",
- *     description="The type to which order is referring"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="region_id",
  *     description="The region up to which the order is valid"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="location_id",
  *     description="The structure where the order is"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="range",
  *     description="The range the order is covering"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="is_buy_order",
  *     description="True if the order is a buy order"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="price",
  *     description="The unit price"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="volume_total",
  *     description="The order initial volume"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="volume_remain",
  *     description="The order remaining volume"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="issued",
  *     description="The date-time when the order has been created"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="min_volume",
  *     description="The minimum volume which is requested for a buy order"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="duration",
  *     description="The number of seconds the order is valid"
  * )
  *
- * @SWG\Property(
- *     type="number",
- *     format="double",
- *     property="escrow"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="is_corporation",
  *     description="True if the order is a corporation order"
  * )
  *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="created_at",
- *     description="The date-time when order has been created into SeAT"
+ * @OA\Property(
+ *     type="number",
+ *     format="double",
+ *     property="escrow"
  * )
  *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="updated_at",
- *     description="The date-time when order has been updated into SeAT"
+ * @OA\Property(
+ *     property="type",
+ *     ref="#/components/schemas/InvType",
+ *     description="The type to which order is referring"
  * )
  */
 class CharacterOrder extends Model
 {
+    /**
+     * @var array
+     */
+    protected $hidden = ['id', 'character_id', 'type_id', 'created_at', 'updated_at'];
+
+    /**
+     * @var array
+     */
+    protected $casts = [
+        'is_buy_order' => 'boolean',
+    ];
+
     /**
      * @var bool
      */

--- a/src/Models/Market/CorporationOrder.php
+++ b/src/Models/Market/CorporationOrder.php
@@ -30,120 +30,125 @@ use Seat\Eveapi\Models\Universe\UniverseStructure;
  * Class CorporationOrder.
  * @package Seat\Eveapi\Models\Market
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Corporation Order",
  *     title="CorporationOrder",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="order_id",
  *     description="The market order ID"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     property="type_id",
- *     description="The type to which order is referring"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="region_id",
  *     description="The region up to which the order is valid"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="location_id",
  *     description="The structure where the order is"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="range",
  *     description="The range the order is covering"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="is_buy_order",
  *     description="True if the order is a buy order"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="price",
  *     description="The unit price"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="volume_total",
  *     description="The order initial volume"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="volume_remain",
  *     description="The order remaining volume"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="issued",
  *     description="The date-time when the order has been created"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
+ *     property="issued_by",
+ *     type="integer",
+ *     format="int64",
+ *     description="The entity ID who create the order"
+ * )
+ *
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="min_volume",
  *     description="The minimum volume which is requested for a buy order"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     property="duration",
- *     description="The number of seconds the order is valid"
- * )
- *
- * @SWG\Property(
- *     type="number",
- *     format="double",
- *     property="escrow"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     minimum=1,
  *     property="wallet_division",
  *     description="The division to which the order is depending."
  * )
  *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="created_at",
- *     description="The date-time when order has been created into SeAT"
+ * @OA\Property(
+ *     type="integer",
+ *     property="duration",
+ *     description="The number of seconds the order is valid"
  * )
  *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="updated_at",
- *     description="The date-time when order has been updated into SeAT"
+ * @OA\Property(
+ *     type="number",
+ *     format="double",
+ *     property="escrow"
+ * )
+ *
+ * @OA\Property(
+ *     property="type",
+ *     ref="#/components/schemas/InvType",
+ *     description="The type to which order is referring"
  * )
  */
 class CorporationOrder extends Model
 {
+    /**
+     * @var array
+     */
+    protected $hidden = ['id', 'corporation_id', 'type_id', 'created_at', 'updated_at'];
+
+    /**
+     * @var array
+     */
+    protected $casts = [
+        'is_buy_order' => 'boolean',
+    ];
+
     /**
      * @var bool
      */

--- a/src/Models/RefreshToken.php
+++ b/src/Models/RefreshToken.php
@@ -33,13 +33,13 @@ use Seat\Web\Models\User;
  * Class RefreshToken.
  * @package Seat\Eveapi\Models
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="EVE Online SSO Refresh Token",
  *     title="RefreshToken",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     minimum=90000000,
@@ -47,47 +47,47 @@ use Seat\Web\Models\User;
  *     property="character_id"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     description="Refresh token hash",
  *     property="refresh_token"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="array",
  *     description="Scopes granted for this token",
  *     property="scopes",
- *     @SWG\Items(type="string")
+ *     @OA\Items(type="string")
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     description="The datetime UTC when the token expires",
  *     property="expires_on"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     description="The short life access token",
  *     property="token"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     description="The date-time when the token has been created into SeAT",
  *     property="created_at"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     description="The date-time when the token has been updated into SeAT",
  *     property="updated_at"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     description="The date-time when the token has been disabled",

--- a/src/Models/Sde/InvType.php
+++ b/src/Models/Sde/InvType.php
@@ -31,100 +31,100 @@ use Seat\Eveapi\Traits\IsReadOnly;
  * Class InvType.
  * @package Seat\Eveapi\Models\Sde
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Inventory Type",
  *     title="InvType",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     minimum=1,
  *     property="typeID",
  *     description="The inventory type ID"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     minimum=1,
  *     property="groupID",
  *     description="The group to which the type is related"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="typeName",
  *     description="The inventory type name"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="description",
  *     description="The inventory type description"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="mass",
  *     description="The inventory type mass"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="volume",
  *     description="The inventory type volume"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="capacity",
  *     description="The inventory type storage capacity"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="portionSize"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="raceID",
  *     description="The race to which the inventory type is tied"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="basePrice",
  *     description="The initial price used by NPC to create order"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="published",
  *     description="True if the item is available in-game"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="marketGroupID",
  *     description="The group into which the item is available on market"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="iconID"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="soundID"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="graphicID"
  * )
@@ -137,6 +137,13 @@ class InvType extends Model
      * @var bool
      */
     public $incrementing = false;
+
+    /**
+     * @var array
+     */
+    protected $casts = [
+        'published' => 'boolean',
+    ];
 
     /**
      * @var string

--- a/src/Models/Sde/MapDenormalize.php
+++ b/src/Models/Sde/MapDenormalize.php
@@ -31,101 +31,101 @@ use Seat\Eveapi\Traits\IsReadOnly;
  * Class MapDenormalize.
  * @package Seat\Eveapi\Models\Sde
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Map Denormalize",
  *     title="MapDenormalize",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="itemID",
  *     description="The entity ID"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="typeID",
  *     description="The type of the entity"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="groupID",
  *     description="The group to which the entity is related"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="solarSystemID",
  *     description="The system to which the entity is attached"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="constellationID",
  *     description="The constellation to which the entity is attached"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="regionID",
  *     description="The region to which the entity is attached"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="orbitID",
  *     description="The orbit to which the entity is depending"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="x",
  *     description="x position on the map"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="y",
  *     description="y position on the map"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="z",
  *     description="z position on the map"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="radius",
  *     description="The radius of the entity"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="itemName",
  *     description="The entity name"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="security",
  *     description="The security status of the system to which entity is attached"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="celestialIndex",
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="orbitIndex"
  * )

--- a/src/Models/Skills/CharacterSkillQueue.php
+++ b/src/Models/Skills/CharacterSkillQueue.php
@@ -29,83 +29,68 @@ use Seat\Eveapi\Models\Sde\InvType;
  * Class CharacterSkillQueue.
  * @package Seat\Eveapi\Models\Skills
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Character Skill Queue",
  *     title="CharacterSkillQueue",
  *     type="object"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     property="skill_id",
- *     description="The inventory type identifier"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="finish_date",
  *     description="The date-time when the skill training will end"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="start_date",
  *     description="The date-time when the skill training start"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="finished_level",
  *     description="The level at which the skill will be at end of the training"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="queue_position",
  *     description="The position in the queue"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="training_start_sp",
  *     description="The skillpoint amount in the skill when training start"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="level_end_sp",
  *     description="The skillpoint amount earned at end of the level training"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="level_start_sp",
  *     description="The skillpoint amount from which the training level is starting"
  * )
  *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="created_at",
- *     description="The date-time when record has been created into SeAT"
- * )
- *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="updated_at",
- *     description="The date-time when record has been updated into SeAT"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     property="type",
- *     ref="#/definitions/InvType"
+ *     ref="#/components/schemas/InvType"
  * )
  */
 class CharacterSkillQueue extends Model
 {
+    /**
+     * @var array
+     */
+    protected $hidden = ['id', 'character_id', 'skill_id', 'created_at', 'updated_at'];
+
     /**
      * @var bool
      */

--- a/src/Models/Universe/UniverseName.php
+++ b/src/Models/Universe/UniverseName.php
@@ -28,9 +28,40 @@ use Seat\Eveapi\Models\Character\CharacterAffiliation;
 /**
  * Class UniverseName.
  * @package Seat\Eveapi\Models\Universe
+ *
+ * @OA\Schema(
+ *      description="Universe Name",
+ *      title="UniverseName",
+ *      type="object"
+ * )
+ *
+ * @OA\Property(
+ *      property="entity_id",
+ *      type="integer",
+ *      format="int64",
+ *      description="The entity identifier"
+ * )
+ *
+ * @OA\Property(
+ *      property="name",
+ *      type="string",
+ *      description="The entity name"
+ * )
+ *
+ * @OA\Property(
+ *      property="category",
+ *      type="string",
+ *      enum={"alliance","character","constellation","corporation","inventory_type","region","solar_system","station","faction"},
+ *      description="The entity type"
+ * )
  */
 class UniverseName extends Model
 {
+    /**
+     * @var array
+     */
+    protected $hidden = ['created_at', 'updated_at'];
+
     /**
      * @var bool
      */

--- a/src/Models/Universe/UniverseStructure.php
+++ b/src/Models/Universe/UniverseStructure.php
@@ -29,6 +29,25 @@ use Seat\Eveapi\Models\Sde\MapDenormalize;
 /**
  * Class UniverseStructure.
  * @package Seat\Eveapi\Models\Universe
+ *
+ * @OA\Schema(
+ *     description="Universe Structure",
+ *     title="UniverseStructure",
+ *     type="object"
+ * )
+ *
+ * @OA\Property(
+ *     property="structure_id",
+ *     type="integer",
+ *     format="int64",
+ *     description="Structure identifier"
+ * )
+ *
+ * @OA\Property(
+ *     property="name",
+ *     type="string",
+ *     description="Structure name"
+ * )
  */
 class UniverseStructure extends Model
 {

--- a/src/Models/Wallet/CharacterWalletJournal.php
+++ b/src/Models/Wallet/CharacterWalletJournal.php
@@ -30,116 +30,105 @@ use Seat\Eveapi\Models\Universe\UniverseName;
  * Class CharacterWalletJournal.
  * @package Seat\Eveapi\Models\Wallet
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Character Wallet Journal",
  *     title="CharacterWalletJournal",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="id",
  *     description="Unique journal reference ID"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="date",
  *     description="Date and time of transaction"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="ref_type",
  *     description="The transaction type for the given transaction. Different transaction types will populate different attributes. Note: If you have an existing XML API application that is using ref_types, you will need to know which string ESI ref_type maps to which integer. You can look at the following file to see string->int mappings: https://github.com/ccpgames/eve-glue/blob/master/eve_glue/wallet_journal_ref.py"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     property="first_party_id",
- *     description="The id of the first party involved in the transaction. This attribute has no consistency and is different or non existant for particular ref_types. The description attribute will help make sense of what this attribute means. For more info about the given ID it can be dropped into the /universe/names/ ESI route to determine its type and name"
- * )
- *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     property="second_party_id",
- *     description="The id of the second party involved in the transaction. This attribute has no consistency and is different or non existant for particular ref_types. The description attribute will help make sense of what this attribute means. For more info about the given ID it can be dropped into the /universe/names/ ESI route to determine its type and name"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="amount",
  *     description="The amount of ISK given or taken from the wallet as a result of the given transaction. Positive when ISK is deposited into the wallet and negative when ISK is withdrawn"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="balance",
  *     description="Wallet balance after transaction occurred"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="reason",
  *     description="The user stated reason for the transaction. Only applies to some ref_types"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="tax_receiver_id",
  *     description="The corporation ID receiving any tax paid. Only applies to tax related transactions"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="tax",
  *     description="Tax amount received. Only applies to tax related transactions"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="context_id",
  *     description="An ID that gives extra context to the particular transaction. Because of legacy reasons the context is completely different per ref_type and means different things. It is also possible to not have a context_id"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     enum={"structure_id","station_id","market_transaction_id","character_id","corporation_id","alliance_id","eve_system","industry_job_id","contract_id","planet_id","system_id","type_id"},
  *     property="context_id_type",
  *     description="The type of the given context_id if present"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="description",
  *     description="The reason for the transaction, mirrors what is seen in the client"
  * )
  *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="created_at",
- *     description="The date-time when transaction has been created into SeAT"
+ * @OA\Property(
+ *     property="first_party",
+ *     description="The id of the first party involved in the transaction. This attribute has no consistency and is different or non existant for particular ref_types. The description attribute will help make sense of what this attribute means. For more info about the given ID it can be dropped into the /universe/names/ ESI route to determine its type and name",
+ *     ref="#/components/schemas/UniverseName"
  * )
  *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="updated_at",
- *     description="The date-time when transaction has been updated into SeAT"
+ * @OA\Property(
+ *     property="second_party",
+ *     description="The id of the second party involved in the transaction. This attribute has no consistency and is different or non existant for particular ref_types. The description attribute will help make sense of what this attribute means. For more info about the given ID it can be dropped into the /universe/names/ ESI route to determine its type and name",
+ *     ref="#/components/schemas/UniverseName"
  * )
  */
 class CharacterWalletJournal extends Model
 {
+    /**
+     * @var array
+     */
+    protected $hidden = ['character_id', 'first_party_id', 'second_party_id', 'created_at', 'updated_at'];
+
     /**
      * @var bool
      */

--- a/src/Models/Wallet/CharacterWalletTransaction.php
+++ b/src/Models/Wallet/CharacterWalletTransaction.php
@@ -31,91 +31,89 @@ use Seat\Eveapi\Models\Universe\UniverseStructure;
  * Class CharacterWalletTransaction.
  * @package Seat\Eveapi\Models\Wallet
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Corporation Wallet Transaction",
  *     title="CorporationWalletTransaction",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="transaction_id",
  *     description="Unique transaction ID"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="date",
  *     description="Date and time of transaction"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="location_id",
  *     description="The place where the transaction has been made"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="unit_price",
  *     description="Amount paid per unit"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="quantity"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     property="client_id"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="is_buy",
  *     description="True if the transaction is related to a buy order"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="is_personal",
  *     description="True if the transaction is not related to the corporation"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="journal_ref_id",
  *     description="-1 if there is no corresponding wallet journal entry"
  * )
  *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="created_at",
- *     description="The date-time when transaction has been created into SeAT"
+ * @OA\Property(
+ *     property="party",
+ *     ref="#/components/schemas/UniverseName"
  * )
  *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="updated_at",
- *     description="The date-time when transaction has been updated into SeAT"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     property="type",
- *     ref="#/definitions/InvType"
+ *     ref="#/components/schemas/InvType"
  * )
  */
 class CharacterWalletTransaction extends Model
 {
+    /**
+     * @var array
+     */
+    protected $casts = [
+        'is_buy' => 'boolean',
+        'is_personal' => 'boolean',
+    ];
+
+    /**
+     * @var array
+     */
+    protected $hidden = ['character_id', 'client_id', 'type_id', 'created_at', 'updated_at'];
+
     /**
      * @var bool
      */

--- a/src/Models/Wallet/CorporationWalletJournal.php
+++ b/src/Models/Wallet/CorporationWalletJournal.php
@@ -30,123 +30,112 @@ use Seat\Eveapi\Traits\CanUpsertIgnoreReplace;
  * Class CorporationWalletJournal.
  * @package Seat\Eveapi\Models\Wallet
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Corporation Wallet Journal",
  *     title="CorporationWalletJournal",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="id",
  *     description="Unique journal reference ID"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="division",
  *     description="Wallet key of the division to fetch journals from"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="date",
  *     description="Date and time of transaction"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="ref_type",
  *     description="The transaction type for the given transaction. Different transaction types will populate different attributes. Note: If you have an existing XML API application that is using ref_types, you will need to know which string ESI ref_type maps to which integer. You can look at the following file to see string->int mappings: https://github.com/ccpgames/eve-glue/blob/master/eve_glue/wallet_journal_ref.py"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     property="first_party_id",
- *     description="The id of the first party involved in the transaction. This attribute has no consistency and is different or non existant for particular ref_types. The description attribute will help make sense of what this attribute means. For more info about the given ID it can be dropped into the /universe/names/ ESI route to determine its type and name"
- * )
- *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     property="second_party_id",
- *     description="The id of the second party involved in the transaction. This attribute has no consistency and is different or non existant for particular ref_types. The description attribute will help make sense of what this attribute means. For more info about the given ID it can be dropped into the /universe/names/ ESI route to determine its type and name"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="amount",
  *     description="The amount of ISK given or taken from the wallet as a result of the given transaction. Positive when ISK is deposited into the wallet and negative when ISK is withdrawn"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="balance",
  *     description="Wallet balance after transaction occurred"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="reason",
  *     description="The user stated reason for the transaction. Only applies to some ref_types"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="tax_receiver_id",
  *     description="The corporation ID receiving any tax paid. Only applies to tax related transactions"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="tax",
  *     description="Tax amount received. Only applies to tax related transactions"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="context_id",
  *     description="An ID that gives extra context to the particular transaction. Because of legacy reasons the context is completely different per ref_type and means different things. It is also possible to not have a context_id"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     enum={"structure_id","station_id","market_transaction_id","character_id","corporation_id","alliance_id","eve_system","industry_job_id","contract_id","planet_id","system_id","type_id"},
  *     property="context_id_type",
  *     description="The type of the given context_id if present"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     property="description",
  *     description="The reason for the transaction, mirrors what is seen in the client"
  * )
  *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="created_at",
- *     description="The date-time when transaction has been created into SeAT"
+ * @OA\Property(
+ *     property="first_party",
+ *     description="The id of the first party involved in the transaction. This attribute has no consistency and is different or non existant for particular ref_types. The description attribute will help make sense of what this attribute means. For more info about the given ID it can be dropped into the /universe/names/ ESI route to determine its type and name",
+ *     ref="#/components/schemas/UniverseName"
  * )
  *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="updated_at",
- *     description="The date-time when transaction has been updated into SeAT"
+ * @OA\Property(
+ *     property="second_party",
+ *     description="The id of the second party involved in the transaction. This attribute has no consistency and is different or non existant for particular ref_types. The description attribute will help make sense of what this attribute means. For more info about the given ID it can be dropped into the /universe/names/ ESI route to determine its type and name",
+ *     ref="#/components/schemas/UniverseName"
  * )
  */
 class CorporationWalletJournal extends Model
 {
     use CanUpsertIgnoreReplace;
+
+    /**
+     * @var array
+     */
+    protected $hidden = ['corporation_id', 'first_party_id', 'second_party_id', 'created_at', 'updated_at'];
 
     /**
      * @var bool

--- a/src/Models/Wallet/CorporationWalletTransaction.php
+++ b/src/Models/Wallet/CorporationWalletTransaction.php
@@ -31,91 +31,88 @@ use Seat\Eveapi\Models\Universe\UniverseStructure;
  * Class CharacterWalletTransaction.
  * @package Seat\Eveapi\Models\Wallet
  *
- * @SWG\Definition(
+ * @OA\Schema(
  *     description="Corporation Wallet Transaction",
  *     title="CorporationWalletTransaction",
  *     type="object"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="division",
  *     description="Wallet key of the division to fetch journals from"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="transaction_id",
  *     description="Unique transaction ID"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="string",
  *     format="date-time",
  *     property="date",
  *     description="Date and time of transaction"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="location_id",
  *     description="The place where the transaction has been made"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="unit_price",
  *     description="Amount paid per unit"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     property="quantity"
  * )
  *
- * @SWG\Property(
- *     type="integer",
- *     format="int64",
- *     property="client_id"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     type="boolean",
  *     property="is_buy",
  *     description="True if the transaction is related to a buy order"
  * )
  *
- * @SWG\Property(
+ * @OA\Property(
  *     type="integer",
  *     format="int64",
  *     property="journal_ref_id",
  *     description="-1 if there is no corresponding wallet journal entry"
  * )
  *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="created_at",
- *     description="The date-time when transaction has been created into SeAT"
+ * @OA\Property(
+ *     property="party",
+ *     ref="#/components/schemas/UniverseName"
  * )
  *
- * @SWG\Property(
- *     type="string",
- *     format="date-time",
- *     property="updated_at",
- *     description="The date-time when transaction has been updated into SeAT"
- * )
- *
- * @SWG\Property(
+ * @OA\Property(
  *     property="type",
- *     ref="#/definitions/InvType"
+ *     ref="#/components/schemas/InvType"
  * )
  */
 class CorporationWalletTransaction extends Model
 {
+    /**
+     * @var array
+     */
+    protected $casts = [
+        'is_buy' => 'boolean',
+    ];
+
+    /**
+     * @var array
+     */
+    protected $hidden = ['corporation_id', 'client_id', 'type_id', 'created_at', 'updated_at'];
+
     /**
      * @var bool
      */


### PR DESCRIPTION
Prepare API package for SeAT 4.0.x

Upgrade API documentation annotation from Swagger (v2.0) to Open API (v3.0)
Main change is related to namespace which has been renamed from `SWG` to `OA`
There is also a replacement for the body parameter which got its own keyword `RequestBody`

Depends: eveseat/api#39 eveseat/web#400