### PR TITLE
Ensure Universe structures jobs can get updated names, and process structure ids correctly

### DIFF
--- a/src/Jobs/Universe/CharacterStructures.php
+++ b/src/Jobs/Universe/CharacterStructures.php
@@ -116,11 +116,6 @@ class CharacterStructures extends AbstractAuthCharacterJob implements IStructure
                     ->where('character_id', $this->getCharacterId())
                     ->distinct();
             })
-            // exclude already resolved structures
-            ->whereNotIn('location_id', function ($query) {
-                $query->select('structure_id')
-                    ->from((new UniverseStructure)->getTable());
-            })
             ->select('location_id')
             ->distinct()
             // Until CCP can sort out this endpoint, pick 30 random locations
@@ -129,7 +124,7 @@ class CharacterStructures extends AbstractAuthCharacterJob implements IStructure
             ->inRandomOrder()
             ->limit(15)
             ->get()
-            ->values()
+            ->pluck('location_id')
             ->all();
     }
 }

--- a/src/Jobs/Universe/CorporationStructures.php
+++ b/src/Jobs/Universe/CorporationStructures.php
@@ -123,11 +123,6 @@ class CorporationStructures extends AbstractAuthCorporationJob implements IStruc
                     ->where('corporation_id', $this->getCorporationId())
                     ->distinct();
             })
-            // exclude already resolved structures
-            ->whereNotIn('location_id', function ($query) {
-                $query->select('structure_id')
-                    ->from((new UniverseStructure)->getTable());
-            })
             ->select('location_id')
             ->distinct()
             // Until CCP can sort out this endpoint, pick 30 random locations
@@ -136,17 +131,13 @@ class CorporationStructures extends AbstractAuthCorporationJob implements IStruc
             ->inRandomOrder()
             ->limit(15)
             ->get()
-            ->values()
+            ->pluck('location_id')
             ->all();
 
         $structures = CorporationStructure::where('corporation_id', $this->getCorporationId())
-            ->whereNotIn('structure_id', function ($query) {
-                $query->select('structure_id')
-                    ->from((new UniverseStructure)->getTable());
-            })
             ->select('structure_id')
             ->get()
-            ->values()
+            ->pluck('structure_id')
             ->all();
 
         return array_merge($assets, $structures);


### PR DESCRIPTION
Currently the universe structure update jobs exclude structures that are already populated in the Universe Names table, however since default entries with a name of "Unknown Structure" are inserted by the Character and Corporation structure jobs, names are never updated.

This PR ensures the universe structure jobs form a valid array of structure id's to request (presently it passes an object to Guzzle resulting in a 400 Bad Request), and that subsequent runs are checking for updated structure names.