### PR TITLE
Some job improvement

### DIFF
--- a/src/Jobs/Alliances/Alliances.php
+++ b/src/Jobs/Alliances/Alliances.php
@@ -48,7 +48,7 @@ class Alliances extends EsiBase
     /**
      * @var array
      */
-    protected $tags = ['alliances'];
+    protected $tags = ['alliance'];
 
     /**
      * @throws \Throwable

--- a/src/Jobs/Alliances/Info.php
+++ b/src/Jobs/Alliances/Info.php
@@ -54,7 +54,7 @@ class Info extends EsiBase
     /**
      * @var array
      */
-    protected $tags = ['alliances', 'info'];
+    protected $tags = ['alliance'];
 
     /**
      * Info constructor.

--- a/src/Jobs/Alliances/Members.php
+++ b/src/Jobs/Alliances/Members.php
@@ -54,7 +54,7 @@ class Members extends EsiBase
     /**
      * @var array
      */
-    protected $tags = ['alliances', 'members'];
+    protected $tags = ['alliance'];
 
     /**
      * Members constructor.

--- a/src/Jobs/Assets/Character/Assets.php
+++ b/src/Jobs/Assets/Character/Assets.php
@@ -45,7 +45,7 @@ class Assets extends AbstractAuthCharacterJob
     /**
      * @var string
      */
-    protected $version = 'v4';
+    protected $version = 'v5';
 
     /**
      * @var string

--- a/src/Jobs/Assets/Character/Assets.php
+++ b/src/Jobs/Assets/Character/Assets.php
@@ -55,7 +55,7 @@ class Assets extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['assets'];
+    protected $tags = ['character', 'asset'];
 
     /**
      * @var int

--- a/src/Jobs/Assets/Character/Locations.php
+++ b/src/Jobs/Assets/Character/Locations.php
@@ -57,7 +57,7 @@ class Locations extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['assets', 'locations'];
+    protected $tags = ['character', 'asset'];
 
     /**
      * The maximum number of itemids we can request location

--- a/src/Jobs/Assets/Character/Names.php
+++ b/src/Jobs/Assets/Character/Names.php
@@ -61,7 +61,7 @@ class Names extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['assets', 'names'];
+    protected $tags = ['character', 'asset'];
 
     /**
      * The maximum number of itemids we can request name

--- a/src/Jobs/Assets/Corporation/Assets.php
+++ b/src/Jobs/Assets/Corporation/Assets.php
@@ -45,7 +45,7 @@ class Assets extends AbstractAuthCorporationJob
     /**
      * @var string
      */
-    protected $version = 'v4';
+    protected $version = 'v5';
 
     /**
      * @var string

--- a/src/Jobs/Assets/Corporation/Assets.php
+++ b/src/Jobs/Assets/Corporation/Assets.php
@@ -60,7 +60,7 @@ class Assets extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['assets'];
+    protected $tags = ['corporation', 'asset'];
 
     /**
      * @var int

--- a/src/Jobs/Assets/Corporation/Locations.php
+++ b/src/Jobs/Assets/Corporation/Locations.php
@@ -62,7 +62,7 @@ class Locations extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['assets', 'locations'];
+    protected $tags = ['corporation', 'asset'];
 
     /**
      * The maximum number of itemids we can request location

--- a/src/Jobs/Assets/Corporation/Names.php
+++ b/src/Jobs/Assets/Corporation/Names.php
@@ -59,7 +59,7 @@ class Names extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['assets', 'names'];
+    protected $tags = ['corporation', 'asset'];
 
     /**
      * The maximum number of itemids we can request name

--- a/src/Jobs/Bookmarks/Character/Bookmarks.php
+++ b/src/Jobs/Bookmarks/Character/Bookmarks.php
@@ -58,7 +58,7 @@ class Bookmarks extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['bookmarks', 'details'];
+    protected $tags = ['character', 'bookmark'];
 
     /**
      * @var int

--- a/src/Jobs/Bookmarks/Character/Folders.php
+++ b/src/Jobs/Bookmarks/Character/Folders.php
@@ -55,7 +55,7 @@ class Folders extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['bookmarks', 'folders'];
+    protected $tags = ['character', 'bookmark'];
 
     /**
      * @var int

--- a/src/Jobs/Bookmarks/Corporation/Bookmarks.php
+++ b/src/Jobs/Bookmarks/Corporation/Bookmarks.php
@@ -58,7 +58,7 @@ class Bookmarks extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['bookmarks'];
+    protected $tags = ['corporation', 'bookmark'];
 
     /**
      * @var int

--- a/src/Jobs/Bookmarks/Corporation/Folders.php
+++ b/src/Jobs/Bookmarks/Corporation/Folders.php
@@ -55,7 +55,7 @@ class Folders extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['bookmarks', 'folders'];
+    protected $tags = ['corporation', 'bookmark'];
 
     /**
      * @var int

--- a/src/Jobs/Calendar/Attendees.php
+++ b/src/Jobs/Calendar/Attendees.php
@@ -55,7 +55,7 @@ class Attendees extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['calendar', 'attendees'];
+    protected $tags = ['calendar'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Calendar/Detail.php
+++ b/src/Jobs/Calendar/Detail.php
@@ -56,7 +56,7 @@ class Detail extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['calendar', 'detail'];
+    protected $tags = ['calendar'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Calendar/Events.php
+++ b/src/Jobs/Calendar/Events.php
@@ -54,7 +54,7 @@ class Events extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['calendar', 'events'];
+    protected $tags = ['calendar'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Character/Affiliation.php
+++ b/src/Jobs/Character/Affiliation.php
@@ -57,7 +57,7 @@ class Affiliation extends EsiBase
     /**
      * @var array
      */
-    protected $tags = ['affiliations'];
+    protected $tags = ['character'];
 
     /**
      * The maximum number of itemids we can request affiliation

--- a/src/Jobs/Character/AgentsResearch.php
+++ b/src/Jobs/Character/AgentsResearch.php
@@ -54,7 +54,7 @@ class AgentsResearch extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['agents_research'];
+    protected $tags = ['character', 'industry'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Character/Blueprints.php
+++ b/src/Jobs/Character/Blueprints.php
@@ -55,7 +55,7 @@ class Blueprints extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['blueprints'];
+    protected $tags = ['character', 'industry'];
 
     /**
      * @var int

--- a/src/Jobs/Character/CorporationHistory.php
+++ b/src/Jobs/Character/CorporationHistory.php
@@ -45,7 +45,7 @@ class CorporationHistory extends AbstractCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['corporation_history'];
+    protected $tags = ['character'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Character/Fatigue.php
+++ b/src/Jobs/Character/Fatigue.php
@@ -54,7 +54,7 @@ class Fatigue extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['fatigue'];
+    protected $tags = ['character'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Character/Info.php
+++ b/src/Jobs/Character/Info.php
@@ -49,7 +49,7 @@ class Info extends AbstractCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['info'];
+    protected $tags = ['character'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Character/Medals.php
+++ b/src/Jobs/Character/Medals.php
@@ -54,7 +54,7 @@ class Medals extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['medals'];
+    protected $tags = ['character'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Character/Notifications.php
+++ b/src/Jobs/Character/Notifications.php
@@ -54,7 +54,7 @@ class Notifications extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['notifications'];
+    protected $tags = ['character', 'notification'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Character/Roles.php
+++ b/src/Jobs/Character/Roles.php
@@ -54,7 +54,7 @@ class Roles extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['roles'];
+    protected $tags = ['character', 'role'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Character/Standings.php
+++ b/src/Jobs/Character/Standings.php
@@ -54,7 +54,7 @@ class Standings extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['standings'];
+    protected $tags = ['character'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Character/Stats.php
+++ b/src/Jobs/Character/Stats.php
@@ -54,7 +54,7 @@ class Stats extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['stats'];
+    protected $tags = ['character'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Character/Stats.php
+++ b/src/Jobs/Character/Stats.php
@@ -77,7 +77,7 @@ class Stats extends AbstractAuthCharacterJob
 
             // Separate stats by categories
             foreach (['character', 'combat', 'industry', 'inventory', 'isk', 'market',
-                         'mining', 'module', 'orbital', 'pve', 'social', 'travel', ] as $category) {
+                'mining', 'module', 'orbital', 'pve', 'social', 'travel', ] as $category) {
 
                 CharacterStats::firstOrCreate([
                     'character_id' => $this->getCharacterId(),

--- a/src/Jobs/Character/Titles.php
+++ b/src/Jobs/Character/Titles.php
@@ -55,7 +55,7 @@ class Titles extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['titles'];
+    protected $tags = ['character', 'role'];
 
     /**
      * @var \Illuminate\Support\Collection

--- a/src/Jobs/Clones/Clones.php
+++ b/src/Jobs/Clones/Clones.php
@@ -55,7 +55,7 @@ class Clones extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['clones'];
+    protected $tags = ['character', 'clone'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Clones/Implants.php
+++ b/src/Jobs/Clones/Implants.php
@@ -54,7 +54,7 @@ class Implants extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['implants'];
+    protected $tags = ['character', 'clone'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Contacts/Character/Contacts.php
+++ b/src/Jobs/Contacts/Character/Contacts.php
@@ -55,7 +55,7 @@ class Contacts extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['contacts'];
+    protected $tags = ['character', 'contact'];
 
     /**
      * @var int

--- a/src/Jobs/Contacts/Character/Labels.php
+++ b/src/Jobs/Contacts/Character/Labels.php
@@ -54,7 +54,7 @@ class Labels extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['contacts', 'labels'];
+    protected $tags = ['character', 'contact'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Contacts/Corporation/Contacts.php
+++ b/src/Jobs/Contacts/Corporation/Contacts.php
@@ -55,7 +55,7 @@ class Contacts extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['contacts'];
+    protected $tags = ['corporation', 'contact'];
 
     /**
      * @var int

--- a/src/Jobs/Contacts/Corporation/Labels.php
+++ b/src/Jobs/Contacts/Corporation/Labels.php
@@ -54,7 +54,7 @@ class Labels extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['contacts', 'labels'];
+    protected $tags = ['corporation', 'contact'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Contracts/Character/Bids.php
+++ b/src/Jobs/Contracts/Character/Bids.php
@@ -76,7 +76,7 @@ class Bids extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['contracts', 'bids'];
+    protected $tags = ['character', 'contract'];
 
     /**
      * Bids constructor.

--- a/src/Jobs/Contracts/Character/Contracts.php
+++ b/src/Jobs/Contracts/Character/Contracts.php
@@ -55,7 +55,7 @@ class Contracts extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['contracts'];
+    protected $tags = ['character', 'contract'];
 
     /**
      * @var int

--- a/src/Jobs/Contracts/Character/Items.php
+++ b/src/Jobs/Contracts/Character/Items.php
@@ -77,7 +77,7 @@ class Items extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['contracts', 'items'];
+    protected $tags = ['character', 'contract'];
 
     /**
      * @var int

--- a/src/Jobs/Contracts/Corporation/Bids.php
+++ b/src/Jobs/Contracts/Corporation/Bids.php
@@ -76,7 +76,7 @@ class Bids extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['contracts', 'bids'];
+    protected $tags = ['corporation', 'contract'];
 
     /**
      * @var int

--- a/src/Jobs/Contracts/Corporation/Contracts.php
+++ b/src/Jobs/Contracts/Corporation/Contracts.php
@@ -55,7 +55,7 @@ class Contracts extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['contracts'];
+    protected $tags = ['corporation', 'contract'];
 
     /**
      * @var int

--- a/src/Jobs/Contracts/Corporation/Items.php
+++ b/src/Jobs/Contracts/Corporation/Items.php
@@ -77,7 +77,7 @@ class Items extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['contracts', 'items'];
+    protected $tags = ['corporation', 'contract'];
 
     /**
      * @var int

--- a/src/Jobs/Corporation/AllianceHistory.php
+++ b/src/Jobs/Corporation/AllianceHistory.php
@@ -49,7 +49,7 @@ class AllianceHistory extends AbstractCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['alliance_history'];
+    protected $tags = ['corporation'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Corporation/Blueprints.php
+++ b/src/Jobs/Corporation/Blueprints.php
@@ -61,7 +61,7 @@ class Blueprints extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['blueprints'];
+    protected $tags = ['corporation', 'industry'];
 
     /**
      * @var int

--- a/src/Jobs/Corporation/ContainerLogs.php
+++ b/src/Jobs/Corporation/ContainerLogs.php
@@ -59,7 +59,7 @@ class ContainerLogs extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['container_logs'];
+    protected $tags = ['corporation', 'asset'];
 
     /**
      * @var int

--- a/src/Jobs/Corporation/Divisions.php
+++ b/src/Jobs/Corporation/Divisions.php
@@ -59,7 +59,7 @@ class Divisions extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['divisions'];
+    protected $tags = ['corporation'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Corporation/Facilities.php
+++ b/src/Jobs/Corporation/Facilities.php
@@ -59,7 +59,7 @@ class Facilities extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['facilities'];
+    protected $tags = ['corporation', 'industry'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Corporation/Info.php
+++ b/src/Jobs/Corporation/Info.php
@@ -49,7 +49,7 @@ class Info extends AbstractCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['info'];
+    protected $tags = ['corporation'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Corporation/IssuedMedals.php
+++ b/src/Jobs/Corporation/IssuedMedals.php
@@ -59,7 +59,7 @@ class IssuedMedals extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['issued_medals'];
+    protected $tags = ['corporation'];
 
     /**
      * @var int

--- a/src/Jobs/Corporation/Medals.php
+++ b/src/Jobs/Corporation/Medals.php
@@ -57,7 +57,7 @@ class Medals extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['medals'];
+    protected $tags = ['corporation'];
 
     /**
      * @var int

--- a/src/Jobs/Corporation/MemberTracking.php
+++ b/src/Jobs/Corporation/MemberTracking.php
@@ -59,7 +59,7 @@ class MemberTracking extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['member_tracking'];
+    protected $tags = ['corporation', 'member'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Corporation/Members.php
+++ b/src/Jobs/Corporation/Members.php
@@ -54,7 +54,7 @@ class Members extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['members'];
+    protected $tags = ['corporation', 'member'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Corporation/MembersLimit.php
+++ b/src/Jobs/Corporation/MembersLimit.php
@@ -59,7 +59,7 @@ class MembersLimit extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['members', 'limit'];
+    protected $tags = ['corporation', 'member'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Corporation/MembersTitles.php
+++ b/src/Jobs/Corporation/MembersTitles.php
@@ -59,7 +59,7 @@ class MembersTitles extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['member_titles'];
+    protected $tags = ['corporation', 'member', 'role'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Corporation/RoleHistories.php
+++ b/src/Jobs/Corporation/RoleHistories.php
@@ -59,7 +59,7 @@ class RoleHistories extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['roles', 'history'];
+    protected $tags = ['corporation', 'role'];
 
     /**
      * @var int

--- a/src/Jobs/Corporation/Roles.php
+++ b/src/Jobs/Corporation/Roles.php
@@ -59,7 +59,7 @@ class Roles extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['roles'];
+    protected $tags = ['corporation', 'role'];
 
     /**
      * @var array

--- a/src/Jobs/Corporation/Shareholders.php
+++ b/src/Jobs/Corporation/Shareholders.php
@@ -60,7 +60,7 @@ class Shareholders extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['shareholders'];
+    protected $tags = ['corporation'];
 
     /**
      * @var int

--- a/src/Jobs/Corporation/Standings.php
+++ b/src/Jobs/Corporation/Standings.php
@@ -54,7 +54,7 @@ class Standings extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['standings'];
+    protected $tags = ['corporation'];
 
     /**
      * @var int

--- a/src/Jobs/Corporation/StarbaseDetails.php
+++ b/src/Jobs/Corporation/StarbaseDetails.php
@@ -62,7 +62,7 @@ class StarbaseDetails extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['starbases', 'details'];
+    protected $tags = ['corporation', 'structure'];
 
     /**
      * @var

--- a/src/Jobs/Corporation/Starbases.php
+++ b/src/Jobs/Corporation/Starbases.php
@@ -60,7 +60,7 @@ class Starbases extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['starbases'];
+    protected $tags = ['corporation', 'structure'];
 
     /**
      * @var int

--- a/src/Jobs/Corporation/Structures.php
+++ b/src/Jobs/Corporation/Structures.php
@@ -62,7 +62,7 @@ class Structures extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['structures'];
+    protected $tags = ['corporation', 'structure'];
 
     /**
      * @var int

--- a/src/Jobs/Corporation/Titles.php
+++ b/src/Jobs/Corporation/Titles.php
@@ -61,7 +61,7 @@ class Titles extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['titles'];
+    protected $tags = ['corporation', 'role'];
 
     /**
      * @var \Illuminate\Support\Collection

--- a/src/Jobs/Fittings/Character/Fittings.php
+++ b/src/Jobs/Fittings/Character/Fittings.php
@@ -55,7 +55,7 @@ class Fittings extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['fittings'];
+    protected $tags = ['character', 'fitting'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Fittings/Insurances.php
+++ b/src/Jobs/Fittings/Insurances.php
@@ -49,7 +49,7 @@ class Insurances extends EsiBase
     /**
      * @var array
      */
-    protected $tags = ['insurances', 'fittings'];
+    protected $tags = ['public'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Industry/Character/Jobs.php
+++ b/src/Jobs/Industry/Character/Jobs.php
@@ -61,7 +61,7 @@ class Jobs extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['industry', 'jobs'];
+    protected $tags = ['character', 'industry'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Industry/Character/Mining.php
+++ b/src/Jobs/Industry/Character/Mining.php
@@ -58,7 +58,7 @@ class Mining extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['industry', 'mining'];
+    protected $tags = ['character', 'industry'];
 
     /**
      * @var int

--- a/src/Jobs/Industry/Corporation/Jobs.php
+++ b/src/Jobs/Industry/Corporation/Jobs.php
@@ -66,7 +66,7 @@ class Jobs extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['industry', 'jobs'];
+    protected $tags = ['corporation', 'industry'];
 
     /**
      * @var int

--- a/src/Jobs/Industry/Corporation/Mining/Extractions.php
+++ b/src/Jobs/Industry/Corporation/Mining/Extractions.php
@@ -59,7 +59,7 @@ class Extractions extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['mining', 'extractions'];
+    protected $tags = ['corporation', 'industry', 'structure'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Industry/Corporation/Mining/ObserverDetails.php
+++ b/src/Jobs/Industry/Corporation/Mining/ObserverDetails.php
@@ -62,7 +62,7 @@ class ObserverDetails extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['mining', 'observers', 'details'];
+    protected $tags = ['corporation', 'industry', 'structure'];
 
     /**
      * @var int

--- a/src/Jobs/Industry/Corporation/Mining/Observers.php
+++ b/src/Jobs/Industry/Corporation/Mining/Observers.php
@@ -61,7 +61,7 @@ class Observers extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['mining', 'observers'];
+    protected $tags = ['corporation', 'industry', 'structure'];
 
     /**
      * @var int

--- a/src/Jobs/Killmails/Character/Recent.php
+++ b/src/Jobs/Killmails/Character/Recent.php
@@ -56,7 +56,7 @@ class Recent extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['killmails', 'latest'];
+    protected $tags = ['character', 'killmail'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Killmails/Character/Recent.php
+++ b/src/Jobs/Killmails/Character/Recent.php
@@ -25,6 +25,7 @@ namespace Seat\Eveapi\Jobs\Killmails\Character;
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
 use Seat\Eveapi\Jobs\Killmails\Detail;
 use Seat\Eveapi\Models\Killmails\Killmail;
+use Seat\Eveapi\Models\Killmails\KillmailDetail;
 
 /**
  * Class Recent.
@@ -78,7 +79,8 @@ class Recent extends AbstractAuthCharacterJob
                 'killmail_hash' => $killmail->killmail_hash,
             ]);
 
-            dispatch(new Detail($killmail->killmail_id, $killmail->killmail_hash));
+            if (! KillmailDetail::find($killmail->killmail_id))
+                dispatch(new Detail($killmail->killmail_id, $killmail->killmail_hash));
         });
     }
 }

--- a/src/Jobs/Killmails/Corporation/Recent.php
+++ b/src/Jobs/Killmails/Corporation/Recent.php
@@ -25,6 +25,7 @@ namespace Seat\Eveapi\Jobs\Killmails\Corporation;
 use Seat\Eveapi\Jobs\AbstractAuthCorporationJob;
 use Seat\Eveapi\Jobs\Killmails\Detail;
 use Seat\Eveapi\Models\Killmails\Killmail;
+use Seat\Eveapi\Models\Killmails\KillmailDetail;
 
 /**
  * Class Recent.
@@ -84,7 +85,8 @@ class Recent extends AbstractAuthCorporationJob
                 'killmail_hash' => $killmail->killmail_hash,
             ]);
 
-            dispatch(new Detail($killmail->killmail_id, $killmail->killmail_hash));
+            if (! KillmailDetail::find($killmail->killmail_id))
+                dispatch(new Detail($killmail->killmail_id, $killmail->killmail_hash));
         });
     }
 }

--- a/src/Jobs/Killmails/Corporation/Recent.php
+++ b/src/Jobs/Killmails/Corporation/Recent.php
@@ -61,7 +61,7 @@ class Recent extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['killmails'];
+    protected $tags = ['corporation', 'killmail'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Killmails/Detail.php
+++ b/src/Jobs/Killmails/Detail.php
@@ -62,7 +62,7 @@ class Detail extends EsiBase
     /**
      * @var array
      */
-    protected $tags = ['killmails', 'detail'];
+    protected $tags = ['killmail'];
 
     /**
      * Detail constructor.

--- a/src/Jobs/Location/Character/Location.php
+++ b/src/Jobs/Location/Character/Location.php
@@ -54,7 +54,7 @@ class Location extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['location'];
+    protected $tags = ['character', 'meta'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Location/Character/Online.php
+++ b/src/Jobs/Location/Character/Online.php
@@ -54,7 +54,7 @@ class Online extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['online'];
+    protected $tags = ['character', 'meta'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Location/Character/Ship.php
+++ b/src/Jobs/Location/Character/Ship.php
@@ -54,7 +54,7 @@ class Ship extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['ship'];
+    protected $tags = ['character', 'meta'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Mail/Labels.php
+++ b/src/Jobs/Mail/Labels.php
@@ -54,7 +54,7 @@ class Labels extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['mail', 'labels'];
+    protected $tags = ['mail'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Mail/MailingLists.php
+++ b/src/Jobs/Mail/MailingLists.php
@@ -54,7 +54,7 @@ class MailingLists extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['mails', 'mailing_lists'];
+    protected $tags = ['mail'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Mail/Mails.php
+++ b/src/Jobs/Mail/Mails.php
@@ -56,7 +56,7 @@ class Mails extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['mail', 'headers'];
+    protected $tags = ['mail'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Market/Character/Orders.php
+++ b/src/Jobs/Market/Character/Orders.php
@@ -54,7 +54,7 @@ class Orders extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['market'];
+    protected $tags = ['character', 'market'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Market/Corporation/Orders.php
+++ b/src/Jobs/Market/Corporation/Orders.php
@@ -59,7 +59,7 @@ class Orders extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['market', 'orders'];
+    protected $tags = ['corporation', 'market'];
 
     /**
      * @var int

--- a/src/Jobs/Market/Prices.php
+++ b/src/Jobs/Market/Prices.php
@@ -49,7 +49,7 @@ class Prices extends EsiBase
     /**
      * @var array
      */
-    protected $tags = ['market', 'prices'];
+    protected $tags = ['public', 'market'];
 
     /**
      * Execute the job.

--- a/src/Jobs/PlanetaryInteraction/Character/PlanetDetail.php
+++ b/src/Jobs/PlanetaryInteraction/Character/PlanetDetail.php
@@ -65,7 +65,7 @@ class PlanetDetail extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['pi', 'detail'];
+    protected $tags = ['character', 'pi'];
 
     /**
      * @var int

--- a/src/Jobs/PlanetaryInteraction/Character/Planets.php
+++ b/src/Jobs/PlanetaryInteraction/Character/Planets.php
@@ -54,7 +54,7 @@ class Planets extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['pi', 'planets'];
+    protected $tags = ['character', 'pi'];
 
     /**
      * Execute the job.

--- a/src/Jobs/PlanetaryInteraction/Corporation/CustomsOfficeLocations.php
+++ b/src/Jobs/PlanetaryInteraction/Corporation/CustomsOfficeLocations.php
@@ -62,7 +62,7 @@ class CustomsOfficeLocations extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['customs_offices', 'locations'];
+    protected $tags = ['corporation', 'pi'];
 
     /**
      * Execute the job.

--- a/src/Jobs/PlanetaryInteraction/Corporation/CustomsOffices.php
+++ b/src/Jobs/PlanetaryInteraction/Corporation/CustomsOffices.php
@@ -60,7 +60,7 @@ class CustomsOffices extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['customs_offices'];
+    protected $tags = ['corporation', 'pi'];
 
     /**
      * @var int

--- a/src/Jobs/Skills/Character/Attributes.php
+++ b/src/Jobs/Skills/Character/Attributes.php
@@ -54,7 +54,7 @@ class Attributes extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['skills', 'attributes'];
+    protected $tags = ['character', 'skill'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Skills/Character/Queue.php
+++ b/src/Jobs/Skills/Character/Queue.php
@@ -54,7 +54,7 @@ class Queue extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['skills', 'queue'];
+    protected $tags = ['character', 'skill'];
 
     /**
      * @var int

--- a/src/Jobs/Skills/Character/Skills.php
+++ b/src/Jobs/Skills/Character/Skills.php
@@ -56,7 +56,7 @@ class Skills extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['skills'];
+    protected $tags = ['character', 'skill'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Sovereignty/Map.php
+++ b/src/Jobs/Sovereignty/Map.php
@@ -49,7 +49,7 @@ class Map extends EsiBase
     /**
      * @var array
      */
-    protected $tags = ['sovereignty', 'map'];
+    protected $tags = ['sovereignty'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Sovereignty/Structures.php
+++ b/src/Jobs/Sovereignty/Structures.php
@@ -49,7 +49,7 @@ class Structures extends EsiBase
     /**
      * @var array
      */
-    protected $tags = ['sovereignty', 'structures'];
+    protected $tags = ['sovereignty'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Status/Esi.php
+++ b/src/Jobs/Status/Esi.php
@@ -50,7 +50,7 @@ class Esi extends EsiBase
     /**
      * @var array
      */
-    protected $tags = ['ccp', 'meta'];
+    protected $tags = ['public', 'meta'];
 
     /**
      * @return array

--- a/src/Jobs/Status/Status.php
+++ b/src/Jobs/Status/Status.php
@@ -54,7 +54,7 @@ class Status extends EsiBase
     /**
      * @var array
      */
-    protected $tags = ['ccp'];
+    protected $tags = ['public', 'meta'];
 
     /**
      * @return array

--- a/src/Jobs/Universe/CharacterStructures.php
+++ b/src/Jobs/Universe/CharacterStructures.php
@@ -55,6 +55,11 @@ class CharacterStructures extends AbstractAuthCharacterJob implements IStructure
     protected $version = 'v2';
 
     /**
+     * @var array
+     */
+    protected $tags = ['character', 'universe', 'structure'];
+
+    /**
      * {@inheritdoc}
      */
     public function handle()

--- a/src/Jobs/Universe/CorporationStructures.php
+++ b/src/Jobs/Universe/CorporationStructures.php
@@ -61,6 +61,11 @@ class CorporationStructures extends AbstractAuthCorporationJob implements IStruc
     protected $version = 'v2';
 
     /**
+     * @var array
+     */
+    protected $tags = ['corporation', 'universe', 'structure'];
+
+    /**
      * {@inheritdoc}
      */
     public function handle()

--- a/src/Jobs/Universe/Names.php
+++ b/src/Jobs/Universe/Names.php
@@ -57,7 +57,7 @@ class Names extends EsiBase
     /**
      * @var array
      */
-    protected $tags = ['universe', 'names'];
+    protected $tags = ['public', 'universe'];
 
     /**
      * @var \Illuminate\Support\Collection

--- a/src/Jobs/Universe/Stations.php
+++ b/src/Jobs/Universe/Stations.php
@@ -53,7 +53,7 @@ class Stations extends EsiBase
     /**
      * @var array
      */
-    protected $tags = ['universe', 'stations'];
+    protected $tags = ['public', 'universe'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Wallet/Character/Balance.php
+++ b/src/Jobs/Wallet/Character/Balance.php
@@ -54,7 +54,7 @@ class Balance extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['wallet', 'balance'];
+    protected $tags = ['character', 'wallet'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Wallet/Character/Journal.php
+++ b/src/Jobs/Wallet/Character/Journal.php
@@ -54,7 +54,7 @@ class Journal extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['wallet', 'journal'];
+    protected $tags = ['character', 'wallet'];
 
     /**
      * @var int

--- a/src/Jobs/Wallet/Character/Transactions.php
+++ b/src/Jobs/Wallet/Character/Transactions.php
@@ -54,7 +54,7 @@ class Transactions extends AbstractAuthCharacterJob
     /**
      * @var array
      */
-    protected $tags = ['wallet', 'transactions'];
+    protected $tags = ['character', 'wallet'];
 
     /**
      * A counter used to walk the transactions backwards.

--- a/src/Jobs/Wallet/Corporation/Balances.php
+++ b/src/Jobs/Wallet/Corporation/Balances.php
@@ -59,7 +59,7 @@ class Balances extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['wallet', 'balance'];
+    protected $tags = ['corporation', 'wallet'];
 
     /**
      * Execute the job.

--- a/src/Jobs/Wallet/Corporation/Journals.php
+++ b/src/Jobs/Wallet/Corporation/Journals.php
@@ -60,7 +60,7 @@ class Journals extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['wallet', 'journals'];
+    protected $tags = ['corporation', 'wallet'];
 
     /**
      * @var int

--- a/src/Jobs/Wallet/Corporation/Transactions.php
+++ b/src/Jobs/Wallet/Corporation/Transactions.php
@@ -60,7 +60,7 @@ class Transactions extends AbstractAuthCorporationJob
     /**
      * @var array
      */
-    protected $tags = ['wallets'];
+    protected $tags = ['corporation', 'wallet'];
 
     /**
      * A counter used to walk the transactions backwards.

--- a/src/Models/Character/CharacterInfo.php
+++ b/src/Models/Character/CharacterInfo.php
@@ -258,11 +258,7 @@ class CharacterInfo extends Model
     public function affiliation()
     {
         return $this->hasOne(CharacterAffiliation::class, 'character_id', 'character_id')
-            ->withDefault([
-                'corporation_id' => 0,
-                'alliance_id' => 0,
-                'faction_id' => 0,
-            ]);
+            ->withDefault();
     }
 
     /**
@@ -601,7 +597,7 @@ class CharacterInfo extends Model
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
      * @deprecated 4.0.0
      */
     public function user()


### PR DESCRIPTION
This pull request is covering multiple things related to jobs and their monitoring.

Tags logic has been updated to follow those rules :
 - all tags must be named singular (ie: character, corporation, wallet, etc...)
 - a tag must group multiple job - job name should non longer be added to tags (ie: wallet, industry, etc...)
 - share job must contain the triggering entity type tag (ie: Killmails, Contracts, Assets, etc...)

`PlanetDetail` job has been improved to avoid dead lock. To do so, we first retrieve entries which have to be deleted - and then we drop them instead asking DB to drop "all except".

Also, the `PlanetDetail` job will non longer process all planets update. Instead, it will be queue for each single planet by the `Planet` main job

Finally, Assets endpoints have been bump to v5.