### PR TITLE
fix: update table name for migration to remove conflict with previous esi_statuses migration

### DIFF
--- a/src/database/migrations/2020_05_31_110744_add_id_column_to_server_statuses_table.php
+++ b/src/database/migrations/2020_05_31_110744_add_id_column_to_server_statuses_table.php
@@ -31,14 +31,14 @@ class AddIdColumnToServerStatusesTable extends Migration
 {
     public function up()
     {
-        Schema::table('esi_statuses', function (Blueprint $table) {
+        Schema::table('server_statuses', function (Blueprint $table) {
             $table->bigIncrements('id')->first();
         });
     }
 
     public function down()
     {
-        Schema::table('esi_statuses', function (Blueprint $table) {
+        Schema::table('server_statuses', function (Blueprint $table) {
             $table->dropColumn('id');
         });
     }


### PR DESCRIPTION
This fixes migration conflict with src/database/migrations/2020_05_31_110435_add_id_column_to_esi_statuses_table.php