### PR TITLE
feat: publish esi configuration outside package

### DIFF
--- a/src/Config/esi.php
+++ b/src/Config/esi.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+return [
+
+    // API Joblog logging
+    'enable_joblog'         => false,
+
+    'eseye_logfile'         => storage_path('logs'),
+    'eseye_cache'           => storage_path('eseye'),
+    'eseye_loglevel'        => 'info', // valid entries are RFC 5424 levels ('debug', 'info', 'warn', 'error')
+
+    'eseye_client_id'       => env('EVE_CLIENT_ID'),
+    'eseye_client_secret'   => env('EVE_CLIENT_SECRET'),
+    'eseye_client_callback' => env('EVE_CALLBACK_URL'),
+
+    'eseye_esi_scheme'      => env('EVE_ESI_SCHEME', 'https'),
+    'eseye_esi_host'        => env('EVE_ESI_HOST', 'esi.evetech.net'),
+    'eseye_esi_port'        => env('EVE_ESI_PORT', 443),
+    'eseye_esi_datasource'  => env('EVE_ESI_DATASOURCE', 'tranquility'),
+    'eseye_sso_scheme'      => env('EVE_SSO_SCHEME', 'https'),
+    'eseye_sso_host'        => env('EVE_SSO_HOST', 'login.eveonline.com'),
+    'eseye_sso_port'        => env('EVE_SSO_PORT', 443),
+];

--- a/src/Config/eveapi.config.php
+++ b/src/Config/eveapi.config.php
@@ -21,25 +21,5 @@
  */
 
 return [
-
     'version'               => '4.0.x-dev',
-
-    // API Joblog logging
-    'enable_joblog'         => false,
-
-    'eseye_logfile'         => storage_path('logs'),
-    'eseye_cache'           => storage_path('eseye'),
-    'eseye_loglevel'        => 'info', // valid entries are RFC 5424 levels ('debug', 'info', 'warn', 'error')
-
-    'eseye_client_id'       => env('EVE_CLIENT_ID'),
-    'eseye_client_secret'   => env('EVE_CLIENT_SECRET'),
-    'eseye_client_callback' => env('EVE_CALLBACK_URL'),
-
-    'eseye_esi_scheme'      => env('EVE_ESI_SCHEME', 'https'),
-    'eseye_esi_host'        => env('EVE_ESI_HOST', 'esi.evetech.net'),
-    'eseye_esi_port'        => env('EVE_ESI_PORT', 443),
-    'eseye_esi_datasource'  => env('EVE_ESI_DATASOURCE', 'tranquility'),
-    'eseye_sso_scheme'      => env('EVE_SSO_SCHEME', 'https'),
-    'eseye_sso_host'        => env('EVE_SSO_HOST', 'login.eveonline.com'),
-    'eseye_sso_port'        => env('EVE_SSO_PORT', 443),
 ];

--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -46,6 +46,9 @@ class EveapiServiceProvider extends AbstractSeatPlugin
         // Inform Laravel how to load migrations
         $this->add_migrations();
 
+        // Register ESI configuration
+        $this->add_esi_config();
+
         // Update api config
         $this->configure_api();
 
@@ -79,6 +82,16 @@ class EveapiServiceProvider extends AbstractSeatPlugin
     private function add_migrations()
     {
         $this->loadMigrationsFrom(__DIR__ . '/database/migrations/');
+    }
+
+    /**
+     * Publish esi configuration file - so user can tweak it.
+     */
+    private function add_esi_config()
+    {
+        $this->publishes([
+            __DIR__ . '/Config/esi.php' => config_path('esi.php'),
+        ], ['config', 'seat']);
     }
 
     /**

--- a/src/Helpers/EseyeSetup.php
+++ b/src/Helpers/EseyeSetup.php
@@ -41,16 +41,16 @@ class EseyeSetup
 
         $config = Configuration::getInstance();
         $config->http_user_agent = 'SeAT v' . config('eveapi.config.version');
-        $config->logfile_location = config('eveapi.config.eseye_logfile');
-        $config->file_cache_location = config('eveapi.config.eseye_cache');
-        $config->logger_level = config('eveapi.config.eseye_loglevel');
-        $config->esi_scheme = config('eveapi.config.eseye_esi_scheme');
-        $config->esi_host = config('eveapi.config.eseye_esi_host');
-        $config->esi_port = config('eveapi.config.eseye_esi_port');
-        $config->datasource = config('eveapi.config.eseye_esi_datasource');
-        $config->sso_scheme = config('eveapi.config.eseye_sso_scheme');
-        $config->sso_host = config('eveapi.config.eseye_sso_host');
-        $config->sso_port = config('eveapi.config.eseye_sso_port');
+        $config->logfile_location = config('esi.eseye_logfile');
+        $config->file_cache_location = config('esi.eseye_cache');
+        $config->logger_level = config('esi.eseye_loglevel');
+        $config->esi_scheme = config('esi.eseye_esi_scheme');
+        $config->esi_host = config('esi.eseye_esi_host');
+        $config->esi_port = config('esi.eseye_esi_port');
+        $config->datasource = config('esi.eseye_esi_datasource');
+        $config->sso_scheme = config('esi.eseye_sso_scheme');
+        $config->sso_host = config('esi.eseye_sso_host');
+        $config->sso_port = config('esi.eseye_sso_port');
     }
 
     /**
@@ -71,8 +71,8 @@ class EseyeSetup
 
             tap($authentication, function ($auth) {
 
-                $auth->client_id = config('eveapi.config.eseye_client_id');
-                $auth->secret = config('eveapi.config.eseye_client_secret');
+                $auth->client_id = config('esi.eseye_client_id');
+                $auth->secret = config('esi.eseye_client_secret');
             });
 
             return new Eseye($authentication);


### PR DESCRIPTION
Configuration related to ESI will now be available inside `SEAT_PATH/config/esi.php` and a new tag will be available (`seat`) - allowing to publish certain part of the project.

This will avoid to use `php artisan vendor:publish --all` :)

Special thanks to @wfjsw which point me to that workflow.