### PR TITLE
fix(migrations): handle duplicate mining observer ids

### DIFF
--- a/src/database/migrations/2020_02_29_004319_remove_corporation_industry_mining_observers_surrogate_key.php
+++ b/src/database/migrations/2020_02_29_004319_remove_corporation_industry_mining_observers_surrogate_key.php
@@ -34,6 +34,16 @@ class RemoveCorporationIndustryMiningObserversSurrogateKey extends Migration
         Schema::table('corporation_industry_mining_observers', function (Blueprint $table) {
             $table->dropPrimary(['corporation_id', 'observer_id']);
         });
+        
+        Schema::table('corporation_industry_mining_observers', function (Blueprint $table) {
+            $table->bigIncrements('id')->first();
+        });
+
+        DB::statement('DELETE a FROM corporation_industry_mining_observers a INNER JOIN corporation_industry_mining_observers b WHERE a.id < b.id AND a.observer_id = b.observer_id');
+
+        Schema::table('corporation_industry_mining_observers', function (Blueprint $table) {
+            $table->dropColumn('id');
+        });
 
         Schema::table('corporation_industry_mining_observers', function (Blueprint $table) {
             $table->primary('observer_id');

--- a/src/database/migrations/2020_02_29_004319_remove_corporation_industry_mining_observers_surrogate_key.php
+++ b/src/database/migrations/2020_02_29_004319_remove_corporation_industry_mining_observers_surrogate_key.php
@@ -34,7 +34,7 @@ class RemoveCorporationIndustryMiningObserversSurrogateKey extends Migration
         Schema::table('corporation_industry_mining_observers', function (Blueprint $table) {
             $table->dropPrimary(['corporation_id', 'observer_id']);
         });
-        
+
         Schema::table('corporation_industry_mining_observers', function (Blueprint $table) {
             $table->bigIncrements('id')->first();
         });


### PR DESCRIPTION
Handles the case where there are multiple mining observer ids with differing corporation ids.