### PR TITLE
refactor(jobs): make horizon be more gentle with failed jobs

### DIFF
--- a/src/Jobs/AbstractJob.php
+++ b/src/Jobs/AbstractJob.php
@@ -40,8 +40,6 @@ abstract class AbstractJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    const MAXIMUM_DELAYED_JOB_DURATION = 1800;
-
     /**
      * Execute the job.
      *
@@ -95,6 +93,6 @@ abstract class AbstractJob implements ShouldQueue
      */
     public function retryUntil()
     {
-        return now()->addSeconds(self::MAXIMUM_DELAYED_JOB_DURATION);
+        return now()->addSeconds(3600);
     }
 }

--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -47,9 +47,19 @@ abstract class EsiBase extends AbstractJob
     const RATE_LIMIT_KEY = 'esiratelimit';
 
     /**
-     * {@inheritdoc}
+     * @var string By default, queue all ESI jobs on public queue.
      */
     public $queue = 'public';
+
+    /**
+     * @var int By default, retry all ESI jobs every 5 minutes past last fail.
+     */
+    public $retryAfter = 300;
+
+    /**
+     * @var int By default, retry all ESI jobs 3 times.
+     */
+    public $tries = 3;
 
     /**
      * The HTTP method used for the API Call.


### PR DESCRIPTION
increased maximum delay before a job must be considered as zombie (30min to 1 hour).

increase attempt from ESI jobs in case of failure (from 1 to 3)

add a delay between each failed attempt (5 minutes)