### PR TITLE
feat: bypass cache control in case we have no data in DB

### DIFF
--- a/src/Jobs/Alliances/Alliances.php
+++ b/src/Jobs/Alliances/Alliances.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Alliances;
 
 use Seat\Eveapi\Jobs\EsiBase;
+use Seat\Eveapi\Models\Alliances\Alliance;
 
 /**
  * Class Alliances.
@@ -58,7 +59,8 @@ class Alliances extends EsiBase
 
         $alliances = $this->retrieve();
 
-        if ($alliances->isCachedLoad()) return;
+        if ($alliances->isCachedLoad() && Alliance::count() > 0)
+            return;
 
         collect($alliances)->each(function ($alliance_id) {
 

--- a/src/Jobs/Alliances/Info.php
+++ b/src/Jobs/Alliances/Info.php
@@ -80,7 +80,8 @@ class Info extends EsiBase
             'alliance_id' => $this->alliance_id,
         ]);
 
-        if ($info->isCachedLoad()) return;
+        if ($info->isCachedLoad() && Alliance::find($this->alliance_id))
+            return;
 
         Alliance::updateOrCreate([
             'alliance_id' => $this->alliance_id,

--- a/src/Jobs/Alliances/Members.php
+++ b/src/Jobs/Alliances/Members.php
@@ -78,7 +78,8 @@ class Members extends EsiBase
             'alliance_id' => $this->alliance_id,
         ]);
 
-        if ($corporations->isCachedLoad()) return;
+        if ($corporations->isCachedLoad() && AllianceMember::where('alliance_id', $this->alliance_id)->count() > 0)
+            return;
 
         $corporation_ids = collect($corporations);
 

--- a/src/Jobs/Assets/Character/Assets.php
+++ b/src/Jobs/Assets/Character/Assets.php
@@ -94,7 +94,8 @@ class Assets extends AbstractAuthCharacterJob
                 'character_id' => $this->getCharacterId(),
             ]);
 
-            if ($assets->isCachedLoad()) return;
+            if ($assets->isCachedLoad() && CharacterAsset::where('character_id', $this->getCharacterId())->count() > 0)
+                return;
 
             collect($assets)->each(function ($asset) {
 

--- a/src/Jobs/Assets/Corporation/Assets.php
+++ b/src/Jobs/Assets/Corporation/Assets.php
@@ -99,7 +99,8 @@ class Assets extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($assets->isCachedLoad()) return;
+            if ($assets->isCachedLoad() && CorporationAsset::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($assets)->chunk(1000)->each(function ($chunk) {
 

--- a/src/Jobs/Bookmarks/Character/Bookmarks.php
+++ b/src/Jobs/Bookmarks/Character/Bookmarks.php
@@ -98,7 +98,8 @@ class Bookmarks extends AbstractAuthCharacterJob
                 'character_id' => $this->getCharacterId(),
             ]);
 
-            if ($bookmarks->isCachedLoad()) return;
+            if ($bookmarks->isCachedLoad() && CharacterBookmark::where('character_id', $this->getCharacterId())->count() > 0)
+                return;
 
             collect($bookmarks)->chunk(1000)->each(function ($chunk) {
 

--- a/src/Jobs/Bookmarks/Character/Folders.php
+++ b/src/Jobs/Bookmarks/Character/Folders.php
@@ -95,7 +95,8 @@ class Folders extends AbstractAuthCharacterJob
                 'character_id' => $this->getCharacterId(),
             ]);
 
-            if ($folders->isCachedLoad()) return;
+            if ($folders->isCachedLoad() && CharacterBookmarkFolder::where('character_id', $this->getCharacterId())->count() > 0)
+                return;
 
             collect($folders)->each(function ($folder) {
 

--- a/src/Jobs/Bookmarks/Corporation/Bookmarks.php
+++ b/src/Jobs/Bookmarks/Corporation/Bookmarks.php
@@ -97,7 +97,8 @@ class Bookmarks extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($bookmarks->isCachedLoad()) return;
+            if ($bookmarks->isCachedLoad() && CorporationBookmark::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($bookmarks)->each(function ($bookmark) {
 

--- a/src/Jobs/Bookmarks/Corporation/Folders.php
+++ b/src/Jobs/Bookmarks/Corporation/Folders.php
@@ -94,7 +94,8 @@ class Folders extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($folders->isCachedLoad()) return;
+            if ($folders->isCachedLoad() && CorporationBookmarkFolder::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($folders)->each(function ($folder) {
 

--- a/src/Jobs/Calendar/Attendees.php
+++ b/src/Jobs/Calendar/Attendees.php
@@ -89,7 +89,10 @@ class Attendees extends AbstractAuthCharacterJob
                     'event_id'     => $event->event_id,
                 ]);
 
-                if ($attendees->isCachedLoad()) return;
+                if ($attendees->isCachedLoad() &&
+                    CharacterCalendarAttendee::where('character_id', $this->getCharacterId())
+                        ->where('event_id', $event->event_id)->count() > 0)
+                    return;
 
                 collect($attendees)->each(function ($attendee) use ($event) {
 

--- a/src/Jobs/Calendar/Detail.php
+++ b/src/Jobs/Calendar/Detail.php
@@ -83,7 +83,8 @@ class Detail extends AbstractAuthCharacterJob
                     'event_id' => $event_id,
                 ]);
 
-                if ($detail->isCachedLoad()) return;
+                if ($detail->isCachedLoad() && CharacterCalendarEventDetail::where('event_id', $event_id)->count() > 0)
+                    return;
 
                 CharacterCalendarEventDetail::firstOrCreate([
                     'event_id' => $event_id,

--- a/src/Jobs/Calendar/Events.php
+++ b/src/Jobs/Calendar/Events.php
@@ -70,7 +70,9 @@ class Events extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($events->isCachedLoad()) return;
+        if ($events->isCachedLoad() &&
+            CharacterCalendarEvent::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         collect($events)->each(function ($event) {
 

--- a/src/Jobs/Character/AgentsResearch.php
+++ b/src/Jobs/Character/AgentsResearch.php
@@ -70,7 +70,9 @@ class AgentsResearch extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($agents_research->isCachedLoad()) return;
+        if ($agents_research->isCachedLoad() &&
+            CharacterAgentResearch::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         collect($agents_research)->each(function ($agent_research) {
 

--- a/src/Jobs/Character/Blueprints.php
+++ b/src/Jobs/Character/Blueprints.php
@@ -100,7 +100,9 @@ class Blueprints extends AbstractAuthCharacterJob
                 'character_id' => $this->getCharacterId(),
             ]);
 
-            if ($blueprints->isCachedLoad()) return;
+            if ($blueprints->isCachedLoad() &&
+                CharacterBlueprint::where('character_id', $this->getCharacterId())->count() > 0)
+                return;
 
             // Process the blueprints from the response
             collect($blueprints)->chunk(100)->each(function ($chunk) {

--- a/src/Jobs/Character/CorporationHistory.php
+++ b/src/Jobs/Character/CorporationHistory.php
@@ -61,7 +61,9 @@ class CorporationHistory extends AbstractCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($corporation_history->isCachedLoad()) return;
+        if ($corporation_history->isCachedLoad() &&
+            CharacterCorporationHistory::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         collect($corporation_history)->each(function ($corporation) {
 

--- a/src/Jobs/Character/Fatigue.php
+++ b/src/Jobs/Character/Fatigue.php
@@ -70,7 +70,8 @@ class Fatigue extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($fatigue->isCachedLoad()) return;
+        if ($fatigue->isCachedLoad() && CharacterFatigue::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         CharacterFatigue::firstOrNew([
             'character_id' => $this->getCharacterId(),

--- a/src/Jobs/Character/Info.php
+++ b/src/Jobs/Character/Info.php
@@ -65,7 +65,7 @@ class Info extends AbstractCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($character_info->isCachedLoad()) return;
+        if ($character_info->isCachedLoad() && CharacterInfo::find($this->getCharacterId())) return;
 
         CharacterInfo::firstOrNew(['character_id' => $this->getCharacterId()])->fill([
             'name'            => $character_info->name,

--- a/src/Jobs/Character/Medals.php
+++ b/src/Jobs/Character/Medals.php
@@ -70,7 +70,8 @@ class Medals extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($medals->isCachedLoad()) return;
+        if ($medals->isCachedLoad() && CharacterMedal::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         collect($medals)->each(function ($medal) {
 

--- a/src/Jobs/Character/Notifications.php
+++ b/src/Jobs/Character/Notifications.php
@@ -70,7 +70,9 @@ class Notifications extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($notifications->isCachedLoad()) return;
+        if ($notifications->isCachedLoad() &&
+            CharacterNotification::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         collect($notifications)->each(function ($notification) {
 

--- a/src/Jobs/Character/Roles.php
+++ b/src/Jobs/Character/Roles.php
@@ -70,7 +70,8 @@ class Roles extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($roles->isCachedLoad()) return;
+        if ($roles->isCachedLoad() && CharacterRole::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         foreach (['roles', 'roles_at_hq', 'roles_at_base', 'roles_at_other'] as $scope) {
 

--- a/src/Jobs/Character/Standings.php
+++ b/src/Jobs/Character/Standings.php
@@ -70,7 +70,9 @@ class Standings extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($standings->isCachedLoad()) return;
+        if ($standings->isCachedLoad() &&
+            CharacterStanding::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         collect($standings)->each(function ($standing) {
 

--- a/src/Jobs/Character/Stats.php
+++ b/src/Jobs/Character/Stats.php
@@ -70,7 +70,9 @@ class Stats extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($stats->isCachedLoad()) return;
+        if ($stats->isCachedLoad() &&
+            CharacterStats::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         // Process each years aggregate
         collect($stats)->each(function ($aggregate) {

--- a/src/Jobs/Character/Titles.php
+++ b/src/Jobs/Character/Titles.php
@@ -76,12 +76,12 @@ class Titles extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($titles->isCachedLoad()) return;
-
         $character = CharacterInfo::find($this->getCharacterId());
 
         if (is_null($character))
             return;
+
+        if ($titles->isCachedLoad() && $character->titles()->count() > 0) return;
 
         $this->active_titles = collect();
 

--- a/src/Jobs/Clones/Clones.php
+++ b/src/Jobs/Clones/Clones.php
@@ -71,7 +71,8 @@ class Clones extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($clone->isCachedLoad()) return;
+        if ($clone->isCachedLoad() && CharacterClone::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         // Populate current clone information
         CharacterClone::firstOrNew([

--- a/src/Jobs/Clones/Implants.php
+++ b/src/Jobs/Clones/Implants.php
@@ -70,7 +70,8 @@ class Implants extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($implants->isCachedLoad()) return;
+        if ($implants->isCachedLoad() && CharacterImplant::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         collect($implants)->each(function ($implant) {
 

--- a/src/Jobs/Contacts/Character/Contacts.php
+++ b/src/Jobs/Contacts/Character/Contacts.php
@@ -96,7 +96,9 @@ class Contacts extends AbstractAuthCharacterJob
                 'character_id' => $this->getCharacterId(),
             ]);
 
-            if ($contacts->isCachedLoad()) return;
+            if ($contacts->isCachedLoad() &&
+                CharacterContact::where('character_id', $this->getCharacterId())->count() > 0)
+                return;
 
             collect($contacts)->each(function ($contact) {
 

--- a/src/Jobs/Contacts/Character/Labels.php
+++ b/src/Jobs/Contacts/Character/Labels.php
@@ -70,7 +70,9 @@ class Labels extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($labels->isCachedLoad()) return;
+        if ($labels->isCachedLoad() &&
+            CharacterLabel::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         collect($labels)->each(function ($label) {
 

--- a/src/Jobs/Contacts/Corporation/Contacts.php
+++ b/src/Jobs/Contacts/Corporation/Contacts.php
@@ -94,7 +94,9 @@ class Contacts extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($contacts->isCachedLoad()) return;
+            if ($contacts->isCachedLoad() &&
+                CorporationContact::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($contacts)->each(function ($contact) {
 

--- a/src/Jobs/Contacts/Corporation/Labels.php
+++ b/src/Jobs/Contacts/Corporation/Labels.php
@@ -68,7 +68,9 @@ class Labels extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if ($labels->isCachedLoad()) return;
+        if ($labels->isCachedLoad() &&
+            CorporationLabel::where('corporation_id', $this->getCorporationId())->count() > 0)
+            return;
 
         collect($labels)->each(function ($label) {
 

--- a/src/Jobs/Contracts/Character/Bids.php
+++ b/src/Jobs/Contracts/Character/Bids.php
@@ -123,7 +123,9 @@ class Bids extends AbstractAuthCharacterJob
                         'contract_id' => $this->contract_id,
                     ]);
 
-                    if ($bids->isCachedLoad()) return;
+                    if ($bids->isCachedLoad() &&
+                        ContractBid::where('contract_id', $this->contract_id)->count() > 0)
+                        return;
 
                     collect($bids)->each(function ($bid) {
 

--- a/src/Jobs/Contracts/Character/Contracts.php
+++ b/src/Jobs/Contracts/Character/Contracts.php
@@ -78,7 +78,9 @@ class Contracts extends AbstractAuthCharacterJob
                 'character_id' => $this->getCharacterId(),
             ]);
 
-            if ($contracts->isCachedLoad()) return;
+            if ($contracts->isCachedLoad() &&
+                ContractDetail::where('character_id', $this->getCharacterId())->count() > 0)
+                return;
 
             collect($contracts)->each(function ($contract) {
 

--- a/src/Jobs/Contracts/Character/Items.php
+++ b/src/Jobs/Contracts/Character/Items.php
@@ -138,7 +138,9 @@ class Items extends AbstractAuthCharacterJob
                     'contract_id' => $this->contract_id,
                 ]);
 
-                if ($items->isCachedLoad()) return;
+                if ($items->isCachedLoad() &&
+                    ContractItem::where('contract_id', $this->contract_id)->count() > 0)
+                    return;
 
                 collect($items)->each(function ($item) {
 

--- a/src/Jobs/Contracts/Corporation/Bids.php
+++ b/src/Jobs/Contracts/Corporation/Bids.php
@@ -129,7 +129,9 @@ class Bids extends AbstractAuthCorporationJob
                             'contract_id' => $this->contract_id,
                         ]);
 
-                        if ($bids->isCachedLoad()) return;
+                        if ($bids->isCachedLoad() &&
+                            ContractBid::where('contract_id', $this->contract_id)->count() > 0)
+                            return;
 
                         collect($bids)->each(function ($bid) {
 

--- a/src/Jobs/Contracts/Corporation/Contracts.php
+++ b/src/Jobs/Contracts/Corporation/Contracts.php
@@ -76,7 +76,9 @@ class Contracts extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($contracts->isCachedLoad()) return;
+            if ($contracts->isCachedLoad() &&
+                CorporationContract::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($contracts)->each(function ($contract) {
 

--- a/src/Jobs/Contracts/Corporation/Items.php
+++ b/src/Jobs/Contracts/Corporation/Items.php
@@ -138,7 +138,9 @@ class Items extends AbstractAuthCorporationJob
                     'contract_id' => $this->contract_id,
                 ]);
 
-                if ($items->isCachedLoad()) return;
+                if ($items->isCachedLoad() &&
+                    ContractItem::where('contract_id', $this->contract_id)->count() > 0)
+                    return;
 
                 collect($items)->each(function ($item) {
 

--- a/src/Jobs/Corporation/AllianceHistory.php
+++ b/src/Jobs/Corporation/AllianceHistory.php
@@ -63,7 +63,9 @@ class AllianceHistory extends AbstractCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if ($history->isCachedLoad()) return;
+        if ($history->isCachedLoad() &&
+            CorporationAllianceHistory::where('corporation_id', $this->getCorporationId())->count() > 0)
+            return;
 
         collect($history)->each(function ($alliance) {
 

--- a/src/Jobs/Corporation/Blueprints.php
+++ b/src/Jobs/Corporation/Blueprints.php
@@ -100,7 +100,9 @@ class Blueprints extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($blueprints->isCachedLoad()) return;
+            if ($blueprints->isCachedLoad() &&
+                CorporationBlueprint::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($blueprints)->chunk(100)->each(function ($chunk) {
 

--- a/src/Jobs/Corporation/ContainerLogs.php
+++ b/src/Jobs/Corporation/ContainerLogs.php
@@ -80,7 +80,9 @@ class ContainerLogs extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($logs->isCachedLoad()) return;
+            if ($logs->isCachedLoad() &&
+                CorporationContainerLog::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($logs)->each(function ($log) {
 

--- a/src/Jobs/Corporation/Divisions.php
+++ b/src/Jobs/Corporation/Divisions.php
@@ -73,7 +73,9 @@ class Divisions extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if ($divisions->isCachedLoad()) return;
+        if ($divisions->isCachedLoad() &&
+            CorporationDivision::where('corporation_id', $this->getCorporationId())->count() > 0)
+            return;
 
         if (property_exists($divisions, 'hangar'))
 

--- a/src/Jobs/Corporation/Facilities.php
+++ b/src/Jobs/Corporation/Facilities.php
@@ -73,7 +73,9 @@ class Facilities extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if ($facilities->isCachedLoad()) return;
+        if ($facilities->isCachedLoad() &&
+            CorporationFacility::where('corporation_id', $this->getCorporationId())->count() > 0)
+            return;
 
         collect($facilities)->each(function ($facility) {
 

--- a/src/Jobs/Corporation/Info.php
+++ b/src/Jobs/Corporation/Info.php
@@ -63,7 +63,7 @@ class Info extends AbstractCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if ($corporation->isCachedLoad()) return;
+        if ($corporation->isCachedLoad() && CorporationInfo::find($this->getCorporationId())) return;
 
         CorporationInfo::firstOrNew([
             'corporation_id' => $this->getCorporationId(),

--- a/src/Jobs/Corporation/IssuedMedals.php
+++ b/src/Jobs/Corporation/IssuedMedals.php
@@ -80,7 +80,9 @@ class IssuedMedals extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($medals->isCachedLoad()) return;
+            if ($medals->isCachedLoad() &&
+                CorporationIssuedMedal::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($medals)->each(function ($medal) {
 

--- a/src/Jobs/Corporation/Medals.php
+++ b/src/Jobs/Corporation/Medals.php
@@ -78,7 +78,9 @@ class Medals extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($medals->isCachedLoad()) return;
+            if ($medals->isCachedLoad() &&
+                CorporationMedal::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($medals)->each(function ($medal) {
 

--- a/src/Jobs/Corporation/MemberTracking.php
+++ b/src/Jobs/Corporation/MemberTracking.php
@@ -73,7 +73,9 @@ class MemberTracking extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if ($members->isCachedLoad()) return;
+        if ($members->isCachedLoad() &&
+            CorporationMemberTracking::where('corporation_id', $this->getCorporationId())->count() > 0)
+            return;
 
         collect($members)->each(function ($member) {
 

--- a/src/Jobs/Corporation/Members.php
+++ b/src/Jobs/Corporation/Members.php
@@ -68,7 +68,9 @@ class Members extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if ($members->isCachedLoad()) return;
+        if ($members->isCachedLoad() &&
+            CorporationMember::where('corporation_id', $this->getCorporationId())->count() > 0)
+            return;
 
         collect($members)->each(function ($member_id) {
 

--- a/src/Jobs/Corporation/MembersLimit.php
+++ b/src/Jobs/Corporation/MembersLimit.php
@@ -73,7 +73,9 @@ class MembersLimit extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if ($limit->isCachedLoad()) return;
+        if ($limit->isCachedLoad() &&
+            CorporationMemberLimits::where('corporation_id', $this->getCorporationId())->count() > 0)
+            return;
 
         if (! property_exists($limit, 'scalar'))
             return;

--- a/src/Jobs/Corporation/MembersTitles.php
+++ b/src/Jobs/Corporation/MembersTitles.php
@@ -73,7 +73,9 @@ class MembersTitles extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if ($member_titles->isCachedLoad()) return;
+        if ($member_titles->isCachedLoad() &&
+            CorporationMemberTitle::where('corporation_id', $this->getCorporationId())->count() > 0)
+            return;
 
         collect($member_titles)->filter(function ($member) {
 

--- a/src/Jobs/Corporation/RoleHistories.php
+++ b/src/Jobs/Corporation/RoleHistories.php
@@ -80,7 +80,9 @@ class RoleHistories extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($roles->isCachedLoad()) return;
+            if ($roles->isCachedLoad() &&
+                CorporationRoleHistory::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($roles)->each(function ($role) {
 

--- a/src/Jobs/Corporation/Roles.php
+++ b/src/Jobs/Corporation/Roles.php
@@ -87,7 +87,9 @@ class Roles extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if ($roles->isCachedLoad()) return;
+        if ($roles->isCachedLoad() &&
+            CorporationRole::where('corporation_id', $this->getCorporationId())->count() > 0)
+            return;
 
         collect($roles)->each(function ($role) {
 

--- a/src/Jobs/Corporation/Shareholders.php
+++ b/src/Jobs/Corporation/Shareholders.php
@@ -99,7 +99,9 @@ class Shareholders extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($shareholders->isCachedLoad()) return;
+            if ($shareholders->isCachedLoad() &&
+                CorporationShareholder::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($shareholders)->each(function ($shareholder) {
 

--- a/src/Jobs/Corporation/Standings.php
+++ b/src/Jobs/Corporation/Standings.php
@@ -75,7 +75,9 @@ class Standings extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($standings->isCachedLoad()) return;
+            if ($standings->isCachedLoad() &&
+                CorporationStanding::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($standings)->chunk(100)->each(function ($chunk) {
 

--- a/src/Jobs/Corporation/Starbases.php
+++ b/src/Jobs/Corporation/Starbases.php
@@ -99,7 +99,9 @@ class Starbases extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($starbases->isCachedLoad()) return;
+            if ($starbases->isCachedLoad() &&
+                CorporationStarbase::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($starbases)->each(function ($starbase) {
 

--- a/src/Jobs/Corporation/Structures.php
+++ b/src/Jobs/Corporation/Structures.php
@@ -101,7 +101,9 @@ class Structures extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($structures->isCachedLoad()) return;
+            if ($structures->isCachedLoad() &&
+                CorporationStructure::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($structures)->each(function ($structure) {
 

--- a/src/Jobs/Corporation/Titles.php
+++ b/src/Jobs/Corporation/Titles.php
@@ -107,7 +107,9 @@ class Titles extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if ($titles->isCachedLoad()) return;
+        if ($titles->isCachedLoad() &&
+            CorporationTitle::where('corporation_id', $this->getCorporationId())->count() > 0)
+            return;
 
         collect($titles)->each(function ($title) {
 

--- a/src/Jobs/Fittings/Character/Fittings.php
+++ b/src/Jobs/Fittings/Character/Fittings.php
@@ -68,7 +68,9 @@ class Fittings extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($fittings->isCachedLoad()) return;
+        if ($fittings->isCachedLoad() &&
+            CharacterFitting::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         collect($fittings)->each(function ($fitting) {
 

--- a/src/Jobs/Fittings/Insurances.php
+++ b/src/Jobs/Fittings/Insurances.php
@@ -60,7 +60,7 @@ class Insurances extends EsiBase
     {
         $insurances = $this->retrieve();
 
-        if ($insurances->isCachedLoad()) return;
+        if ($insurances->isCachedLoad() && Insurance::count() > 0) return;
 
         collect($insurances)->each(function ($insurance) {
 

--- a/src/Jobs/Industry/Character/Jobs.php
+++ b/src/Jobs/Industry/Character/Jobs.php
@@ -74,7 +74,9 @@ class Jobs extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($industry_jobs->isCachedLoad()) return;
+        if ($industry_jobs->isCachedLoad() &&
+            CharacterIndustryJob::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         collect($industry_jobs)->each(function ($job) {
 

--- a/src/Jobs/Industry/Character/Mining.php
+++ b/src/Jobs/Industry/Character/Mining.php
@@ -75,7 +75,9 @@ class Mining extends AbstractAuthCharacterJob
                 'character_id' => $this->getCharacterId(),
             ]);
 
-            if ($mining->isCachedLoad()) return;
+            if ($mining->isCachedLoad() &&
+                CharacterMining::where('character_id', $this->getCharacterId())->count() > 0)
+                return;
 
             collect($mining)->each(function ($ledger_entry) {
 

--- a/src/Jobs/Industry/Corporation/Jobs.php
+++ b/src/Jobs/Industry/Corporation/Jobs.php
@@ -87,7 +87,9 @@ class Jobs extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($industry_jobs->isCachedLoad()) return;
+            if ($industry_jobs->isCachedLoad() &&
+                CorporationIndustryJob::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($industry_jobs)->each(function ($job) {
 

--- a/src/Jobs/Industry/Corporation/Mining/Extractions.php
+++ b/src/Jobs/Industry/Corporation/Mining/Extractions.php
@@ -73,7 +73,9 @@ class Extractions extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if ($mining_extractions->isCachedLoad()) return;
+        if ($mining_extractions->isCachedLoad() &&
+            CorporationIndustryMiningExtraction::where('corporation_id', $this->getCorporationId())->count() > 0)
+            return;
 
         collect($mining_extractions)->each(function ($extraction) {
 

--- a/src/Jobs/Industry/Corporation/Mining/ObserverDetails.php
+++ b/src/Jobs/Industry/Corporation/Mining/ObserverDetails.php
@@ -87,7 +87,9 @@ class ObserverDetails extends AbstractAuthCorporationJob
                         'observer_id'    => $observer->observer_id,
                     ]);
 
-                    if ($detail->isCachedLoad()) return;
+                    if ($detail->isCachedLoad() &&
+                        CorporationIndustryMiningObserverData::where('corporation_id', $this->getCorporationId())->count() > 0)
+                        return;
 
                     collect($detail)->each(function ($data) use ($observer) {
 

--- a/src/Jobs/Industry/Corporation/Mining/Observers.php
+++ b/src/Jobs/Industry/Corporation/Mining/Observers.php
@@ -80,7 +80,9 @@ class Observers extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if ($mining_observers->isCachedLoad()) return;
+        if ($mining_observers->isCachedLoad() &&
+            CorporationIndustryMiningObserver::where('corporation_id', $this->getCorporationId())->count() > 0)
+            return;
 
         collect($mining_observers)->each(function ($observer) {
 

--- a/src/Jobs/Killmails/Detail.php
+++ b/src/Jobs/Killmails/Detail.php
@@ -90,9 +90,7 @@ class Detail extends EsiBase
             'killmail_hash' => $this->killmail_hash,
         ]);
 
-        if ($detail->isCachedLoad()) return;
-
-        logger()->debug('I am spawning models');
+        if ($detail->isCachedLoad() && KillmailDetail::find($this->killmail_id)) return;
 
         $killmail = KillmailDetail::firstOrCreate([
             'killmail_id'     => $this->killmail_id,

--- a/src/Jobs/Location/Character/Location.php
+++ b/src/Jobs/Location/Character/Location.php
@@ -67,7 +67,7 @@ class Location extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($location->isCachedLoad()) return;
+        if ($location->isCachedLoad() && CharacterLocation::find($this->getCharacterId())) return;
 
         CharacterLocation::firstOrNew([
             'character_id' => $this->getCharacterId(),

--- a/src/Jobs/Location/Character/Online.php
+++ b/src/Jobs/Location/Character/Online.php
@@ -67,7 +67,7 @@ class Online extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($online->isCachedLoad()) return;
+        if ($online->isCachedLoad() && CharacterOnline::find($this->getCharacterId())) return;
 
         CharacterOnline::firstOrNew([
             'character_id' => $this->getCharacterId(),

--- a/src/Jobs/Location/Character/Ship.php
+++ b/src/Jobs/Location/Character/Ship.php
@@ -67,7 +67,7 @@ class Ship extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($ship->isCachedLoad()) return;
+        if ($ship->isCachedLoad() && CharacterShip::find($this->getCharacterId())) return;
 
         CharacterShip::firstOrNew([
             'character_id' => $this->getCharacterId(),

--- a/src/Jobs/Mail/Labels.php
+++ b/src/Jobs/Mail/Labels.php
@@ -67,7 +67,9 @@ class Labels extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($labels->isCachedLoad()) return;
+        if ($labels->isCachedLoad() &&
+            MailLabel::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         collect($labels->labels)->each(function ($label) {
 

--- a/src/Jobs/Mail/MailingLists.php
+++ b/src/Jobs/Mail/MailingLists.php
@@ -67,7 +67,9 @@ class MailingLists extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($mailing_lists->isCachedLoad()) return;
+        if ($mailing_lists->isCachedLoad() &&
+            MailMailingList::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         collect($mailing_lists)->each(function ($list) {
 

--- a/src/Jobs/Mail/Mails.php
+++ b/src/Jobs/Mail/Mails.php
@@ -74,7 +74,9 @@ class Mails extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($mail->isCachedLoad()) return;
+        if ($mail->isCachedLoad() &&
+            MailRecipient::where('recipient_id', $this->getCharacterId())->count() > 0)
+            return;
 
         collect($mail)->each(function ($header) use ($last_known_mail) {
 

--- a/src/Jobs/Market/Character/Orders.php
+++ b/src/Jobs/Market/Character/Orders.php
@@ -67,7 +67,9 @@ class Orders extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($orders->isCachedLoad()) return;
+        if ($orders->isCachedLoad() &&
+            CharacterOrder::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         collect($orders)->each(function ($order) {
 

--- a/src/Jobs/Market/Corporation/Orders.php
+++ b/src/Jobs/Market/Corporation/Orders.php
@@ -80,7 +80,9 @@ class Orders extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($orders->isCachedLoad()) return;
+            if ($orders->isCachedLoad() &&
+                CorporationOrder::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($orders)->each(function ($order) {
 

--- a/src/Jobs/Market/History.php
+++ b/src/Jobs/Market/History.php
@@ -91,7 +91,7 @@ class History extends EsiBase
                     'region_id' => $region_id,
                 ]);
 
-                if ($prices->isCachedLoad()) return;
+                if ($prices->isCachedLoad() && Price::count() > 0) return;
 
                 // search the more recent entry in returned history.
                 $price = collect($prices)->where('order_count', '>', 0)

--- a/src/Jobs/Market/Prices.php
+++ b/src/Jobs/Market/Prices.php
@@ -60,7 +60,7 @@ class Prices extends EsiBase
     {
         $prices = $this->retrieve();
 
-        if ($prices->isCachedLoad()) return;
+        if ($prices->isCachedLoad() && Price::count() > 0) return;
 
         collect($prices)->chunk(1000)->each(function ($chunk) {
 

--- a/src/Jobs/PlanetaryInteraction/Corporation/CustomsOfficeLocations.php
+++ b/src/Jobs/PlanetaryInteraction/Corporation/CustomsOfficeLocations.php
@@ -85,7 +85,9 @@ class CustomsOfficeLocations extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($locations->isCachedLoad()) return;
+            if ($locations->isCachedLoad() &&
+                CorporationCustomsOffice::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($locations)->each(function ($location) use ($chunk) {
 

--- a/src/Jobs/PlanetaryInteraction/Corporation/CustomsOffices.php
+++ b/src/Jobs/PlanetaryInteraction/Corporation/CustomsOffices.php
@@ -99,7 +99,9 @@ class CustomsOffices extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if ($customs_offices->isCachedLoad()) return;
+            if ($customs_offices->isCachedLoad() &&
+                CorporationCustomsOffice::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
 
             collect($customs_offices)->each(function ($customs_office) {
 

--- a/src/Jobs/Skills/Character/Attributes.php
+++ b/src/Jobs/Skills/Character/Attributes.php
@@ -67,7 +67,7 @@ class Attributes extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($attributes->isCachedLoad()) return;
+        if ($attributes->isCachedLoad() && CharacterAttribute::find($this->getCharacterId())) return;
 
         CharacterAttribute::firstOrNew([
             'character_id' => $this->getCharacterId(),

--- a/src/Jobs/Skills/Character/Queue.php
+++ b/src/Jobs/Skills/Character/Queue.php
@@ -74,7 +74,9 @@ class Queue extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($skill_queue->isCachedLoad()) return;
+        if ($skill_queue->isCachedLoad() &&
+            CharacterSkillQueue::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         collect($skill_queue)->each(function ($skill) {
 

--- a/src/Jobs/Skills/Character/Skills.php
+++ b/src/Jobs/Skills/Character/Skills.php
@@ -69,7 +69,7 @@ class Skills extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($character_skills->isCachedLoad()) return;
+        if ($character_skills->isCachedLoad() && CharacterInfoSkill::find($this->getCharacterId())) return;
 
         CharacterInfo::firstOrCreate(['character_id' => $this->getCharacterId()]);
 

--- a/src/Jobs/Sovereignty/Map.php
+++ b/src/Jobs/Sovereignty/Map.php
@@ -60,7 +60,7 @@ class Map extends EsiBase
     {
         $systems = $this->retrieve();
 
-        if ($systems->isCachedLoad()) return;
+        if ($systems->isCachedLoad() && SovereigntyMap::count() > 0) return;
 
         collect($systems)->chunk(1000)->each(function ($chunk) {
 

--- a/src/Jobs/Sovereignty/Structures.php
+++ b/src/Jobs/Sovereignty/Structures.php
@@ -60,7 +60,7 @@ class Structures extends EsiBase
     {
         $structures = $this->retrieve();
 
-        if ($structures->isCachedLoad()) return;
+        if ($structures->isCachedLoad() && SovereigntyStructure::count() > 0) return;
 
         collect($structures)->each(function ($structure) {
 

--- a/src/Jobs/Wallet/Character/Balance.php
+++ b/src/Jobs/Wallet/Character/Balance.php
@@ -67,7 +67,7 @@ class Balance extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($balance->isCachedLoad()) return;
+        if ($balance->isCachedLoad() && CharacterWalletBalance::find($this->getCharacterId())) return;
 
         CharacterWalletBalance::firstOrNew([
             'character_id' => $this->getCharacterId(),

--- a/src/Jobs/Wallet/Character/Journal.php
+++ b/src/Jobs/Wallet/Character/Journal.php
@@ -94,7 +94,9 @@ class Journal extends AbstractAuthCharacterJob
                 'character_id' => $this->getCharacterId(),
             ]);
 
-            if ($journal->isCachedLoad()) return;
+            if ($journal->isCachedLoad() &&
+                CharacterWalletJournal::where('character_id', $this->getCharacterId())->count() > 0)
+                return;
 
             $entries = collect($journal);
 

--- a/src/Jobs/Wallet/Character/Transactions.php
+++ b/src/Jobs/Wallet/Character/Transactions.php
@@ -82,7 +82,9 @@ class Transactions extends AbstractAuthCharacterJob
                 'character_id' => $this->getCharacterId(),
             ]);
 
-            if ($transactions->isCachedLoad()) return;
+            if ($transactions->isCachedLoad() &&
+                CharacterWalletTransaction::where('character_id', $this->getCharacterId())->count() > 0)
+                return;
 
             // If we have no more entries, break the loop.
             if (collect($transactions)->count() === 0)

--- a/src/Jobs/Wallet/Corporation/Balances.php
+++ b/src/Jobs/Wallet/Corporation/Balances.php
@@ -73,7 +73,9 @@ class Balances extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if ($balances->isCachedLoad()) return;
+        if ($balances->isCachedLoad() &&
+            CorporationWalletBalance::where('corporation_id', $this->getCorporationId())->count() > 0)
+            return;
 
         collect($balances)->each(function ($balance) {
 

--- a/src/Jobs/Wallet/Corporation/Journals.php
+++ b/src/Jobs/Wallet/Corporation/Journals.php
@@ -106,7 +106,9 @@ class Journals extends AbstractAuthCorporationJob
                         'division'       => $balance->division,
                     ]);
 
-                    if ($journal->isCachedLoad()) return;
+                    if ($journal->isCachedLoad() &&
+                        CorporationWalletJournal::where('corporation_id', $this->getCorporationId())->count() > 0)
+                        return;
 
                     $entries = collect($journal);
 

--- a/src/Jobs/Wallet/Corporation/Transactions.php
+++ b/src/Jobs/Wallet/Corporation/Transactions.php
@@ -92,7 +92,9 @@ class Transactions extends AbstractAuthCorporationJob
                         'division'       => $balance->division,
                     ]);
 
-                    if ($transactions->isCachedLoad()) return;
+                    if ($transactions->isCachedLoad() &&
+                        CorporationWalletTransaction::where('corporation_id', $this->getCorporationId())->count() > 0)
+                        return;
 
                     // If we have no more entries, break the loop.
                     if (collect($transactions)->count() === 0)


### PR DESCRIPTION
in certain case, we might be in the following situation:

there is a cached entry related to a job call which is still valid (either the expiration date/time is not reached or ESI tell us cached entry is unchanged)

as a result, jobs will not process data and be mark as completed.

if that would be expectable, in case the related entry have been dropped (ie: deleted user, deleted character, deleted corporation, ...) - an admin will have to clear cache to allow those data to populate database again.