### PR TITLE
feat: reduce concurrent jobs related to same entities

### DIFF
--- a/src/Jobs/AbstractAuthCharacterJob.php
+++ b/src/Jobs/AbstractAuthCharacterJob.php
@@ -24,6 +24,7 @@ namespace Seat\Eveapi\Jobs;
 
 use Seat\Eveapi\Jobs\Middleware\CheckTokenScope;
 use Seat\Eveapi\Jobs\Middleware\CheckTokenVersion;
+use Seat\Eveapi\Jobs\Middleware\EsiTokenThrottler;
 use Seat\Eveapi\Models\RefreshToken;
 
 /**
@@ -58,6 +59,7 @@ abstract class AbstractAuthCharacterJob extends AbstractCharacterJob
         return array_merge(parent::middleware(), [
             new CheckTokenScope,
             new CheckTokenVersion,
+            new EsiTokenThrottler,
         ]);
     }
 }

--- a/src/Jobs/AbstractAuthCorporationJob.php
+++ b/src/Jobs/AbstractAuthCorporationJob.php
@@ -26,6 +26,7 @@ use Exception;
 use Seat\Eseye\Exceptions\RequestFailedException;
 use Seat\Eveapi\Jobs\Middleware\CheckTokenScope;
 use Seat\Eveapi\Jobs\Middleware\CheckTokenVersion;
+use Seat\Eveapi\Jobs\Middleware\EsiTokenThrottler;
 use Seat\Eveapi\Jobs\Middleware\IgnoreNpcCorporation;
 use Seat\Eveapi\Jobs\Middleware\RequireCorporationRole;
 use Seat\Eveapi\Models\Character\CharacterAffiliation;
@@ -76,6 +77,7 @@ abstract class AbstractAuthCorporationJob extends AbstractCorporationJob
             new CheckTokenVersion,
             new IgnoreNpcCorporation,
             new RequireCorporationRole,
+            new EsiTokenThrottler,
         ]);
     }
 

--- a/src/Jobs/AbstractCorporationJob.php
+++ b/src/Jobs/AbstractCorporationJob.php
@@ -22,6 +22,8 @@
 
 namespace Seat\Eveapi\Jobs;
 
+use Seat\Eveapi\Jobs\Middleware\CorporationThrottler;
+
 /**
  * Class AbstractCorporationJob.
  *
@@ -52,6 +54,16 @@ abstract class AbstractCorporationJob extends EsiBase
     public function getCorporationId(): int
     {
         return $this->corporation_id;
+    }
+
+    /**
+     * @return array
+     */
+    public function middleware()
+    {
+        return array_merge(parent::middleware(), [
+            new CorporationThrottler,
+        ]);
     }
 
     /**

--- a/src/Jobs/Middleware/CorporationThrottler.php
+++ b/src/Jobs/Middleware/CorporationThrottler.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eveapi\Jobs\Middleware;
+
+use Illuminate\Support\Facades\Redis;
+
+/**
+ * Class CorporationThrottler.
+ *
+ * @package Seat\Eveapi\Jobs\Middleware
+ */
+class CorporationThrottler
+{
+    /**
+     * @param \Seat\Eveapi\Jobs\AbstractCorporationJob $job
+     * @param $next
+     *
+     * @throws \Illuminate\Contracts\Redis\LimiterTimeoutException
+     */
+    public function handle($job, $next)
+    {
+        $key = sprintf('corporation-%d', $job->getCorporationId());
+
+        Redis::throttle($key)->block(0)->allow(1)->every(2)->then(function () use ($job, $next) {
+            logger()->debug('Job pass corporation rate-limit check and is granted for processing.', [
+                'job' => get_class($job),
+                'corporation_id' => $job->getCorporationId(),
+            ]);
+
+            $next($job);
+        }, function () use ($job) {
+            logger()->debug('Another job is already processing data for this corporation. Delay job by 2 seconds.', [
+                'job' => get_class($job),
+                'corporation_id' => $job->getCorporationId(),
+            ]);
+
+            $job->release(2);
+        });
+    }
+}

--- a/src/Jobs/Middleware/EsiTokenThrottler.php
+++ b/src/Jobs/Middleware/EsiTokenThrottler.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eveapi\Jobs\Middleware;
+
+use Illuminate\Support\Facades\Redis;
+
+/**
+ * Class EsiTokenThrottler.
+ *
+ * @package Seat\Eveapi\Jobs\Middleware
+ */
+class EsiTokenThrottler
+{
+    /**
+     * @param \Seat\Eveapi\Jobs\EsiBase $job
+     * @param $next
+     *
+     * @throws \Illuminate\Contracts\Redis\LimiterTimeoutException
+     */
+    public function handle($job, $next)
+    {
+        $key = sprintf('token-%d', $job->getToken()->character_id);
+
+        Redis::throttle($key)->block(0)->allow(1)->every(2)->then(function () use ($job, $next) {
+            logger()->debug('Job pass token rate-limit check and is granted for processing.', [
+                'job' => get_class($job),
+                'token_id' => $job->getToken()->character_id,
+            ]);
+
+            $next($job);
+        }, function () use ($job) {
+            logger()->debug('Another job is already processing data for this token. Delay job by 2 seconds.', [
+                'job' => get_class($job),
+                'token_id' => $job->getToken()->character_id,
+            ]);
+
+            $job->release(2);
+        });
+    }
+}


### PR DESCRIPTION
in order to reduce concurrent jobs related to a refresh token, throttle them by id, allowing one job per 2 seconds.
in order to reduce concurrent jobs related to a corporation, throttle them by id, allowing one job per 2 seconds.