### PR TITLE
SSO Token Version Handling

### DIFF
--- a/src/Exception/TokenVersionException.php
+++ b/src/Exception/TokenVersionException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eveapi\Exception;
+
+/**
+ * Class TokenVersionException.
+ * @package Seat\Eveapi\Exception
+ */
+class TokenVersionException extends \Exception
+{
+
+}

--- a/src/Jobs/AbstractAuthCorporationJob.php
+++ b/src/Jobs/AbstractAuthCorporationJob.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs;
 
 use Seat\Eveapi\Jobs\Middleware\CheckTokenScope;
+use Seat\Eveapi\Jobs\Middleware\CheckTokenVersion;
 use Seat\Eveapi\Jobs\Middleware\IgnoreNpcCorporation;
 use Seat\Eveapi\Jobs\Middleware\RequireCorporationRole;
 use Seat\Eveapi\Models\RefreshToken;
@@ -66,6 +67,7 @@ abstract class AbstractAuthCorporationJob extends AbstractCorporationJob
     {
         return array_merge(parent::middleware(), [
             new CheckTokenScope,
+            new CheckTokenVersion,
             new IgnoreNpcCorporation,
             new RequireCorporationRole,
         ]);

--- a/src/Jobs/Middleware/CheckTokenVersion.php
+++ b/src/Jobs/Middleware/CheckTokenVersion.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eveapi\Jobs\Middleware;
+
+use Seat\Eveapi\Jobs\EsiBase;
+
+/**
+ * Class CheckTokenVersion.
+ *
+ * @package Seat\Eveapi\Jobs\Middleware
+ */
+class CheckTokenVersion
+{
+
+    const CURRENT_VERSION = 2;
+    /**
+     * @param \Seat\Eveapi\Jobs\EsiBase $job
+     * @param $next
+     */
+    public function handle($job, $next)
+    {
+
+        logger()->error("TEST");
+                
+        // in case the job is not ESI related - bypass this check
+        if (! is_subclass_of($job, EsiBase::class)) {
+            $next($job);
+
+            return;
+        }
+
+        $ver = $job->getToken()->version;
+        logger()->error($ver);
+
+        if ($ver == self::CURRENT_VERSION ){
+            logger()->error('Job running with up to date token', [
+                'job' => get_class($job),
+                'token_id' => $job->getToken()->character_id,
+            ]);
+            $next($job);
+        } else {
+            logger()->error('Job deleted due to token version', [
+                'job' => get_class($job),
+                'token_id' => $job->getToken()->character_id,
+            ]);
+            $job->delete();
+        }
+
+    }
+}

--- a/src/Jobs/Middleware/CheckTokenVersion.php
+++ b/src/Jobs/Middleware/CheckTokenVersion.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Middleware;
 
 use Seat\Eveapi\Jobs\EsiBase;
+use Seat\Eveapi\Exception\TokenVersionException;
 
 /**
  * Class CheckTokenVersion.
@@ -61,7 +62,7 @@ class CheckTokenVersion
                 'job' => get_class($job),
                 'token_id' => $job->getToken()->character_id,
             ]);
-            $job->delete();
+            $job->fail(new TokenVersionException('Token Version Mismatch. Run command `php artisan seat:token:upgrade` in order to fix.'));
         }
 
     }

--- a/src/Jobs/Middleware/CheckTokenVersion.php
+++ b/src/Jobs/Middleware/CheckTokenVersion.php
@@ -33,6 +33,7 @@ class CheckTokenVersion
 {
 
     const CURRENT_VERSION = 2;
+
     /**
      * @param \Seat\Eveapi\Jobs\EsiBase $job
      * @param $next
@@ -40,8 +41,8 @@ class CheckTokenVersion
     public function handle($job, $next)
     {
 
-        logger()->error("TEST");
-                
+        logger()->error('TEST');
+
         // in case the job is not ESI related - bypass this check
         if (! is_subclass_of($job, EsiBase::class)) {
             $next($job);
@@ -52,7 +53,7 @@ class CheckTokenVersion
         $ver = $job->getToken()->version;
         logger()->error($ver);
 
-        if ($ver == self::CURRENT_VERSION ){
+        if ($ver == self::CURRENT_VERSION){
             logger()->error('Job running with up to date token', [
                 'job' => get_class($job),
                 'token_id' => $job->getToken()->character_id,

--- a/src/Jobs/Middleware/CheckTokenVersion.php
+++ b/src/Jobs/Middleware/CheckTokenVersion.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Middleware;
 
 use Seat\Eveapi\Exception\TokenVersionException;
+use Seat\Eveapi\Models\RefreshToken;
 use Seat\Eveapi\Jobs\EsiBase;
 
 /**
@@ -32,8 +33,6 @@ use Seat\Eveapi\Jobs\EsiBase;
  */
 class CheckTokenVersion
 {
-
-    const CURRENT_VERSION = 2;
 
     /**
      * @param \Seat\Eveapi\Jobs\EsiBase $job
@@ -51,7 +50,7 @@ class CheckTokenVersion
 
         $ver = $job->getToken()->version;
 
-        if ($ver == self::CURRENT_VERSION){
+        if ($ver == RefreshToken::CURRENT_VERSION){
             logger()->debug('Job running with up to date token', [
                 'job' => get_class($job),
                 'token_id' => $job->getToken()->character_id,

--- a/src/Jobs/Middleware/CheckTokenVersion.php
+++ b/src/Jobs/Middleware/CheckTokenVersion.php
@@ -23,8 +23,8 @@
 namespace Seat\Eveapi\Jobs\Middleware;
 
 use Seat\Eveapi\Exception\TokenVersionException;
-use Seat\Eveapi\Models\RefreshToken;
 use Seat\Eveapi\Jobs\EsiBase;
+use Seat\Eveapi\Models\RefreshToken;
 
 /**
  * Class CheckTokenVersion.
@@ -33,7 +33,6 @@ use Seat\Eveapi\Jobs\EsiBase;
  */
 class CheckTokenVersion
 {
-
     /**
      * @param \Seat\Eveapi\Jobs\EsiBase $job
      * @param $next

--- a/src/Jobs/Middleware/CheckTokenVersion.php
+++ b/src/Jobs/Middleware/CheckTokenVersion.php
@@ -22,8 +22,8 @@
 
 namespace Seat\Eveapi\Jobs\Middleware;
 
-use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Exception\TokenVersionException;
+use Seat\Eveapi\Jobs\EsiBase;
 
 /**
  * Class CheckTokenVersion.

--- a/src/Jobs/Middleware/CheckTokenVersion.php
+++ b/src/Jobs/Middleware/CheckTokenVersion.php
@@ -41,8 +41,6 @@ class CheckTokenVersion
     public function handle($job, $next)
     {
 
-        logger()->error('TEST');
-
         // in case the job is not ESI related - bypass this check
         if (! is_subclass_of($job, EsiBase::class)) {
             $next($job);
@@ -51,10 +49,9 @@ class CheckTokenVersion
         }
 
         $ver = $job->getToken()->version;
-        logger()->error($ver);
 
         if ($ver == self::CURRENT_VERSION){
-            logger()->error('Job running with up to date token', [
+            logger()->debug('Job running with up to date token', [
                 'job' => get_class($job),
                 'token_id' => $job->getToken()->character_id,
             ]);

--- a/src/Models/RefreshToken.php
+++ b/src/Models/RefreshToken.php
@@ -46,6 +46,13 @@ use Seat\Web\Models\User;
  *     description="Character ID to which the token is tied",
  *     property="character_id"
  * )
+ * @OA\Property(
+ *     type="integer",
+ *     format="uint8",
+ *     minimum=1,
+ *     description="Refresh Token SSO Version",
+ *     property="version"
+ * )
  *
  * @OA\Property(
  *     type="string",
@@ -119,7 +126,7 @@ class RefreshToken extends Model
      * @var array
      */
     protected $fillable = [
-        'character_id', 'user_id', 'character_owner_hash', 'refresh_token', 'scopes', 'expires_on', 'token',
+        'character_id', 'version', 'user_id', 'character_owner_hash', 'refresh_token', 'scopes', 'expires_on', 'token',
     ];
 
     /**

--- a/src/Models/RefreshToken.php
+++ b/src/Models/RefreshToken.php
@@ -105,6 +105,8 @@ class RefreshToken extends Model
 {
     use SoftDeletes;
 
+    const CURRENT_VERSION = 2;
+
     /**
      * @var array
      */

--- a/src/database/migrations/2020_11_26_000001_add_version_to_refresh_token.php
+++ b/src/database/migrations/2020_11_26_000001_add_version_to_refresh_token.php
@@ -38,11 +38,11 @@ class AddVersionToRefreshToken extends Migration
 
         DB::table('refresh_tokens')
             ->update(['version' => 1]);
-        
+
         Schema::table('refresh_tokens', function (Blueprint $table) {
             $table->unsignedSmallInteger('version')->default(2)->change();
         });
-    
+
     }
 
     public function down()

--- a/src/database/migrations/2020_11_26_000001_add_version_to_refresh_token.php
+++ b/src/database/migrations/2020_11_26_000001_add_version_to_refresh_token.php
@@ -20,44 +20,35 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-namespace Seat\Eveapi\Jobs;
-
-use Seat\Eveapi\Jobs\Middleware\CheckTokenScope;
-use Seat\Eveapi\Jobs\Middleware\CheckTokenVersion;
-use Seat\Eveapi\Models\RefreshToken;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 /**
- * Class AbstractAuthenticatedCharacterJob.
- *
- * @package Seat\Eveapi\Jobs
+ * Class AddVersionToRefreshToken.
  */
-abstract class AbstractAuthCharacterJob extends AbstractCharacterJob
+class AddVersionToRefreshToken extends Migration
 {
-    /**
-     * {@inheritdoc}
-     */
-    public $queue = 'characters';
-
-    /**
-     * AbstractCharacterJob constructor.
-     *
-     * @param \Seat\Eveapi\Models\RefreshToken $token
-     */
-    public function __construct(RefreshToken $token)
+    public function up()
     {
-        $this->token = $token;
+        Schema::table('refresh_tokens', function (Blueprint $table) {
+            $table->unsignedSmallInteger('version')->after('character_id');
+        });
 
-        parent::__construct($token->character_id);
+        DB::table('refresh_tokens')
+            ->update(['version' => 1]);
+        
+        Schema::table('refresh_tokens', function (Blueprint $table) {
+            $table->unsignedSmallInteger('version')->default(2)->change();
+        });
+    
     }
 
-    /**
-     * @return array
-     */
-    public function middleware()
+    public function down()
     {
-        return array_merge(parent::middleware(), [
-            new CheckTokenScope,
-            new CheckTokenVersion,
-        ]);
+        Schema::table('refresh_tokens', function (Blueprint $table) {
+            $table->dropColumn('version');
+        });
     }
 }


### PR DESCRIPTION
This PR contains an update to token handling within seat. Now, only correct version tokens will be used. While older versions will be bounced by the middleware. It also adds a console command to update tokens to the latest version.

This relies upon https://github.com/eveseat/console/pull/80
Closes eveseat/seat#675