### PR TITLE
Improve jobs exception handling

### DIFF
--- a/src/Exception/InvalidAssetLocation.php
+++ b/src/Exception/InvalidAssetLocation.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eveapi\Exception;
+
+use Exception;
+use Throwable;
+
+/**
+ * Class InvalidAssetLocation.
+ *
+ * @package Seat\Eveapi\Exception
+ */
+class InvalidAssetLocation extends Exception
+{
+    public function __construct(Throwable $previous = null)
+    {
+        $message = 'Invalid Asset Location requested. Check your logs to get more details.';
+        $code = 400;
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Jobs/AbstractCharacterJob.php
+++ b/src/Jobs/AbstractCharacterJob.php
@@ -22,8 +22,6 @@
 
 namespace Seat\Eveapi\Jobs;
 
-use Exception;
-
 /**
  * Class AbstractCharacterJob.
  *
@@ -66,12 +64,8 @@ abstract class AbstractCharacterJob extends EsiBase
         if (! in_array('character', $tags))
             $tags[] = 'character';
 
-        try {
-            if (! in_array($this->getCharacterId(), $tags))
-                $tags[] = $this->getCharacterId();
-        } catch (Exception $e) {
-            logger()->error($e->getMessage(), $e->getTrace());
-        }
+        if (! in_array($this->getCharacterId(), $tags))
+            $tags[] = $this->getCharacterId();
 
         return $tags;
     }

--- a/src/Jobs/AbstractCorporationJob.php
+++ b/src/Jobs/AbstractCorporationJob.php
@@ -22,8 +22,6 @@
 
 namespace Seat\Eveapi\Jobs;
 
-use Exception;
-
 /**
  * Class AbstractCorporationJob.
  *
@@ -66,12 +64,8 @@ abstract class AbstractCorporationJob extends EsiBase
         if (! in_array('corporation', $tags))
             $tags[] = 'corporation';
 
-        try {
-            if (! in_array($this->getCorporationId(), $tags))
-                $tags[] = $this->getCorporationId();
-        } catch (Exception $e) {
-            logger()->error($e->getMessage(), $e->getTrace());
-        }
+        if (! in_array($this->getCorporationId(), $tags))
+            $tags[] = $this->getCorporationId();
 
         return $tags;
     }

--- a/src/Jobs/Assets/Character/Locations.php
+++ b/src/Jobs/Assets/Character/Locations.php
@@ -22,6 +22,8 @@
 
 namespace Seat\Eveapi\Jobs\Assets\Character;
 
+use Seat\Eseye\Exceptions\RequestFailedException;
+use Seat\Eveapi\Exception\InvalidAssetLocation;
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
 use Seat\Eveapi\Models\Assets\CharacterAsset;
 use Seat\Eveapi\Traits\Utils;
@@ -33,6 +35,14 @@ use Seat\Eveapi\Traits\Utils;
 class Locations extends AbstractAuthCharacterJob
 {
     use Utils;
+
+    /**
+     * The maximum number of itemids we can request location
+     * information for.
+     *
+     * @var int
+     */
+    const ITEMS_LIMIT = 1000;
 
     /**
      * @var string
@@ -60,12 +70,9 @@ class Locations extends AbstractAuthCharacterJob
     protected $tags = ['character', 'asset'];
 
     /**
-     * The maximum number of itemids we can request location
-     * information for.
-     *
-     * @var int
+     * @var bool
      */
-    protected $item_id_limit = 1000;
+    private $has_exception = false;
 
     /**
      * Execute the job.
@@ -90,44 +97,48 @@ class Locations extends AbstractAuthCharacterJob
             // 65 : Structure
             ->whereIn('categoryID', [2, 6, 22, 23, 65])
             ->select('item_id')
-            ->chunk($this->item_id_limit, function ($item_ids) {
+            ->chunk(self::ITEMS_LIMIT, function ($item_ids) {
 
                 $this->request_body = $item_ids->pluck('item_id')->all();
 
-                $locations = $this->retrieve([
-                    'character_id' => $this->getCharacterId(),
-                ]);
-
-                collect($locations)->each(function ($location) {
-
-                    $asset_data = CharacterAsset::where('character_id', $this->getCharacterId())
-                        ->where('item_id', $location->item_id)
-                        ->first();
-
-                    // Location for items in either hangar or stations match to 0, 0, 0
-                    $asset_data->fill([
-                        'x'        => $location->position->x,
-                        'y'        => $location->position->y,
-                        'z'        => $location->position->z,
-                        'map_id'   => 0,
-                        'map_name' => '',
+                try {
+                    $locations = $this->retrieve([
+                        'character_id' => $this->getCharacterId(),
                     ]);
 
-                    // If we have a non zero value for coordinates, attempt to identify a celestial.
-                    if (($location->position->x + $location->position->y + $location->position->y) !== 0) {
-                        $normalized_location = $this->find_nearest_celestial(
-                            $asset_data->location_id,
-                            $location->position->x, $location->position->y, $location->position->z);
+                    collect($locations)->each(function ($location) {
 
-                        // Update the assets location information
+                        $asset_data = CharacterAsset::where('character_id', $this->getCharacterId())
+                            ->where('item_id', $location->item_id)
+                            ->first();
+
+                        // Location for items in either hangar or stations match to 0, 0, 0
                         $asset_data->fill([
-                            'map_id'   => $normalized_location['map_id'],
-                            'map_name' => $normalized_location['map_name'],
+                            'x' => $location->position->x,
+                            'y' => $location->position->y,
+                            'z' => $location->position->z,
+                            'map_id' => 0,
+                            'map_name' => '',
                         ]);
-                    }
 
-                    $asset_data->save();
-                });
+                        // If we have a non zero value for coordinates, attempt to identify a celestial.
+                        if (($location->position->x + $location->position->y + $location->position->y) !== 0) {
+                            $normalized_location = $this->find_nearest_celestial(
+                                $asset_data->location_id,
+                                $location->position->x, $location->position->y, $location->position->z);
+
+                            // Update the assets location information
+                            $asset_data->fill([
+                                'map_id' => $normalized_location['map_id'],
+                                'map_name' => $normalized_location['map_name'],
+                            ]);
+                        }
+
+                        $asset_data->save();
+                    });
+                } catch (RequestFailedException $exception) {
+                    $this->handleInvalidIdException($exception, $item_ids->pluck('item_id')->all());
+                }
             });
 
         // items which may not be singleton
@@ -141,44 +152,70 @@ class Locations extends AbstractAuthCharacterJob
             // 46 : Orbitals
             ->whereIn('categoryID', [46])
             ->select('item_id')
-            ->chunk($this->item_id_limit, function ($item_ids) {
+            ->chunk(self::ITEMS_LIMIT, function ($item_ids) {
 
                 $this->request_body = $item_ids->pluck('item_id')->all();
 
-                $locations = $this->retrieve([
-                    'character_id' => $this->getCharacterId(),
-                ]);
-
-                collect($locations)->each(function ($location) {
-
-                    $asset_data = CharacterAsset::where('character_id', $this->getCharacterId())
-                        ->where('item_id', $location->item_id)
-                        ->first();
-
-                    // Location for items in either hangar or stations match to 0, 0, 0
-                    $asset_data->fill([
-                        'x'        => $location->position->x,
-                        'y'        => $location->position->y,
-                        'z'        => $location->position->z,
-                        'map_id'   => 0,
-                        'map_name' => '',
+                try {
+                    $locations = $this->retrieve([
+                        'character_id' => $this->getCharacterId(),
                     ]);
 
-                    // If we have a non zero value for coordinates, attempt to identify a celestial.
-                    if (($location->position->x + $location->position->y + $location->position->y) !== 0) {
-                        $normalized_location = $this->find_nearest_celestial(
-                            $asset_data->location_id,
-                            $location->position->x, $location->position->y, $location->position->z);
+                    collect($locations)->each(function ($location) {
 
-                        // Update the assets location information
+                        $asset_data = CharacterAsset::where('character_id', $this->getCharacterId())
+                            ->where('item_id', $location->item_id)
+                            ->first();
+
+                        // Location for items in either hangar or stations match to 0, 0, 0
                         $asset_data->fill([
-                            'map_id' => $normalized_location['map_id'],
-                            'map_name' => $normalized_location['map_name'],
+                            'x' => $location->position->x,
+                            'y' => $location->position->y,
+                            'z' => $location->position->z,
+                            'map_id' => 0,
+                            'map_name' => '',
                         ]);
-                    }
 
-                    $asset_data->save();
-                });
+                        // If we have a non zero value for coordinates, attempt to identify a celestial.
+                        if (($location->position->x + $location->position->y + $location->position->y) !== 0) {
+                            $normalized_location = $this->find_nearest_celestial(
+                                $asset_data->location_id,
+                                $location->position->x, $location->position->y, $location->position->z);
+
+                            // Update the assets location information
+                            $asset_data->fill([
+                                'map_id' => $normalized_location['map_id'],
+                                'map_name' => $normalized_location['map_name'],
+                            ]);
+                        }
+
+                        $asset_data->save();
+                    });
+                } catch (RequestFailedException $exception) {
+                    $this->handleInvalidIdException($exception, $item_ids->pluck('item_id')->all());
+                }
             });
+
+        if ($this->has_exception)
+            throw new InvalidAssetLocation();
+    }
+
+    /**
+     * @param \Seat\Eseye\Exceptions\RequestFailedException $exception
+     * @param array $item_ids
+     *
+     * @throws \Seat\Eseye\Exceptions\RequestFailedException
+     */
+    private function handleInvalidIdException(RequestFailedException $exception, array $item_ids)
+    {
+        if ($exception->getError() !== 'Invalid IDs in the request')
+            throw $exception;
+
+        logger()->error('Request contains an invalid asset ID from which retrieve a location.', [
+            'character_id' => $this->character_id,
+            'assets_batch' => $item_ids,
+        ]);
+
+        $this->has_exception = true;
     }
 }

--- a/src/Jobs/Middleware/RequireCorporationRole.php
+++ b/src/Jobs/Middleware/RequireCorporationRole.php
@@ -59,6 +59,13 @@ class RequireCorporationRole
             return;
         }
 
+        logger()->warning('Unprocessable job. Character does not meet required corporation role.', [
+            'job' => get_class($job),
+            'character_id' => $job->getToken()->character_id,
+            'corporation_id' => $job->getCorporationId(),
+            'required_roles' => $job->getRoles(),
+        ]);
+
         $job->delete();
     }
 


### PR DESCRIPTION
This pull request is offering some extra things to better handle job exception, under certain condition.

When ESI is returning an HTTP 403 with message `Character is not in the corporation` when SeAT is requesting a corporation endpoint, we remove relation between the actually known Corporation and Character inside SeAT.

This change will prevent jobs to be run under the character for an invalid corporation until we got up-to-date information regarding him.

---

In order to improve debugging, when ESI is returning an HTTP 404 with message `Invalid IDs in the request`, we continue to attempt IDs resolving (since we're limited to 1000 IDs per request, and may still have valid ID to resolve). AT then end of flow, a generic error will be returned and detailed ID collection will be available in logs.

---

In order to improve debugging, when SeAT attempt to run a job under a character which does not meet required roles constraint, we log the event at warning level (default is error, which will not cover this call).