### PR TITLE
fix(jobs): better handling esi errors

### DIFF
--- a/src/Exception/PermanentInvalidTokenException.php
+++ b/src/Exception/PermanentInvalidTokenException.php
@@ -25,11 +25,11 @@ namespace Seat\Eveapi\Exception;
 use Exception;
 
 /**
- * Class TokenVersionException.
+ * Class PermanentInvalidTokenException.
  *
  * @package Seat\Eveapi\Exception
  */
-class TokenVersionException extends Exception
+class PermanentInvalidTokenException extends Exception
 {
 
 }

--- a/src/Exception/TemporaryEsiOutageException.php
+++ b/src/Exception/TemporaryEsiOutageException.php
@@ -25,11 +25,11 @@ namespace Seat\Eveapi\Exception;
 use Exception;
 
 /**
- * Class TokenVersionException.
+ * Class TemporaryEsiOutageException.
  *
  * @package Seat\Eveapi\Exception
  */
-class TokenVersionException extends Exception
+class TemporaryEsiOutageException extends Exception
 {
 
 }

--- a/src/Exception/UnavailableEveServersException.php
+++ b/src/Exception/UnavailableEveServersException.php
@@ -25,11 +25,11 @@ namespace Seat\Eveapi\Exception;
 use Exception;
 
 /**
- * Class TokenVersionException.
+ * Class UnavailableEveServersException.
  *
  * @package Seat\Eveapi\Exception
  */
-class TokenVersionException extends Exception
+class UnavailableEveServersException extends Exception
 {
 
 }

--- a/src/Jobs/AbstractJob.php
+++ b/src/Jobs/AbstractJob.php
@@ -81,9 +81,6 @@ abstract class AbstractJob implements ShouldQueue
             ->set('type', 'exception')
             ->set('exd', get_class($exception) . ':' . $exception->getMessage())
             ->set('exf', 1))))->onQueue('default');
-
-        // Rethrow the original exception for Horizon
-        throw $exception;
     }
 
     /**

--- a/src/Listeners/EsiFailedCall.php
+++ b/src/Listeners/EsiFailedCall.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eveapi\Listeners;
+
+use Exception;
+use Illuminate\Queue\Events\JobExceptionOccurred;
+use Seat\Eseye\Exceptions\RequestFailedException;
+use Seat\Eveapi\Exception\PermanentInvalidTokenException;
+use Seat\Eveapi\Exception\UnavailableEveServersException;
+
+/**
+ * Class EsiFailedCall.
+ *
+ * @package Seat\Eveapi\Listeners
+ */
+class EsiFailedCall
+{
+    /**
+     * @param \Illuminate\Queue\Events\JobExceptionOccurred $event
+     */
+    public function handle(JobExceptionOccurred $event)
+    {
+        try {
+            // if esi tell us that used token is permanently invalid
+            // remove it from the system and mark job as failed.
+            if ($event->exception instanceof PermanentInvalidTokenException) {
+                $esi_job = unserialize($event->job->payload()['data']['command']);
+                $esi_job->getToken()->delete();
+
+                $event->job->fail($event->exception);
+            }
+
+            // if esi tell us that Tranquility was unavailable, update its local status
+            // so middlewares will prevent further jobs to be processed.
+            if ($event->exception instanceof UnavailableEveServersException) {
+                cache()->remember('eve_db_status', 60, function () {
+                    return null;
+                });
+            }
+
+            // if esi tell us our request was invalid, mark the job as failed.
+            if ($event->exception instanceof RequestFailedException) {
+                if ($event->exception->getCode() >= 400 && $event->exception->getCode() < 500) {
+                    $event->job->fail($event->exception);
+                }
+            }
+        } catch (Exception $exception) {
+            logger()->error($exception->getMessage());
+        }
+
+        logger()->debug('An exception occurred while processing an ESI job.', [
+            'connection' => $event->connectionName,
+            'job' => $event->job,
+            'exception' => $event->exception,
+        ]);
+    }
+}


### PR DESCRIPTION
This is addressing few design issues with the way Jobs are built and processed.

## Failed
Remove the unnecessary `throw exception` which was in `failed` method. This is called by worker once a job has been reported as failed and must be use to handle cleanup and report only.

The method has also been split between AbstractJob and EsiBase to handle things related to their "nature".
Since AbstractJob is the really base job class, we only handle telemetry reports here.
EsiBase is used by all ESI jobs - we handle token removal and cache update.

## Error Handling
Use a listener to prevent jobs to run excessive calls against ESI.
By default, all ESI jobs can run up to 3 times - when they encounter issue. This is usefull for temporary outage. However, it's non relevant when ESI exclusively tell us that what we're doing is invalid.

After investigation, it appears `failed` method is called only once - when the job is finally mark as failed. A job is mark as failed only when all its attempt burned. However, they're reporting every single exception encountered at each attempt.

As a result, we use listener to force fail a job that we identify as non runable :
 - used token is invalid
 - send request is invalid (http@4xx)

The new flow can do the following :
 - queued job -> processing job -> esi call (2xx) -> success
 - queued job -> processing job -> esi call (4xx) -> failed
 - queued job -> processing job -> esi call (5xx) -> cooldown -> processing job -> esi call (5xx) -> cooldown -> processing job -> esi call (2xx) -> success
 - queued job -> processing job -> esi call (5xx) -> cooldown -> processing job -> esi call (5xx) -> cooldown -> processing job -> esi call (>=4xx) -> failed

## Idiot SSO
Sometime, delivered token are returned with a crazy expiration time and some ESI controls prevent its usage. However, since eseye got the information that the used token didn't expire, it will reuse it.

To prevent such dead lock, we erase the expiration date/time to force token renewal.

## Eseye instance
To ensure every eseye call are using up-to-date token, especially on retrying jobs, we force it to be instanciated at every call.

## Refactor
Eseye exception handling has been refactored a little bit to provide more meaningful error message.