### PR TITLE
fix(jobs): allow url from corporation infos table to store up to 510 characters

### DIFF
--- a/src/database/migrations/2020_12_27_203329_extend_url_size_from_corporation_infos_table.php
+++ b/src/database/migrations/2020_12_27_203329_extend_url_size_from_corporation_infos_table.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Class ExtendUrlSizeFromCorporationInfosTable.
+ */
+class ExtendUrlSizeFromCorporationInfosTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('corporation_infos', function (Blueprint $table) {
+            $table->string('url', 510)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('corporation_infos', function (Blueprint $table) {
+            $table->string('url', 255)->change();
+        });
+    }
+}


### PR DESCRIPTION
some corporation seems using url field for another thing than website promotion

```json
{
  "ceo_id": 2116552965,
  "creator_id": 2116552965,
  "date_founded": "2020-03-29T08:41:27Z",
  "description": "Im going to build a wall and make Mexico pay for it. Its going to be the biggest tallest wall you have ever seen. its going to be HUGE!<br><br>Because it came from CHY-NA<br><br><br>https://images.squarespace-cdn.com/content/v1/5b636d3df2e6b15f497da1a3/1544995181232-YSK4I3IXPHKJI8RKH6K2/ke17ZwdGBToddI8pDm48kFTEgwhRQcX9r3XtU0e50sUUqsxRUqqbr1mOJYKfIPR7LoDQ9mXPOjoJoqy81S2I8N_N4V1vUb5AoIIIbLZhVYxCRW4BPu10St3TBAUQYVKcW7uEhC96WQdj-SwE5EpM0lAopPba9ZX3O0oeNTVSRxdHAmtcci_6bmVLoSDQq_pb/Trump.jpg?format=750w",
  "home_station_id": 60014719,
  "member_count": 3,
  "name": "The Offices of Donald J. Trump",
  "shares": 1000,
  "tax_rate": 0.001,
  "ticker": "TOODJ",
  "url": "https://images.squarespace-cdn.com/content/v1/5b636d3df2e6b15f497da1a3/1544995181232-YSK4I3IXPHKJI8RKH6K2/ke17ZwdGBToddI8pDm48kFTEgwhRQcX9r3XtU0e50sUUqsxRUqqbr1mOJYKfIPR7LoDQ9mXPOjoJoqy81S2I8N_N4V1vUb5AoIIIbLZhVYxCRW4BPu10St3TBAUQYVKcW7uEhC96WQdj-SwE5EpM0lAopPba9ZX3O0oeNTVSRxdHAmtcci_6bmVLoSDQq_pb/Trump.jpg?format=750w"
}
```