### PR TITLE
fix(contracts): allow locations to be linked to either structure or station

### DIFF
--- a/src/Jobs/Contracts/Character/Contracts.php
+++ b/src/Jobs/Contracts/Character/Contracts.php
@@ -87,32 +87,9 @@ class Contracts extends AbstractAuthCharacterJob
                 // Update or create the contract details.
                 $model = ContractDetail::firstOrNew([
                     'contract_id' => $contract->contract_id,
-                ])->fill([
-                    'issuer_id'             => $contract->issuer_id,
-                    'issuer_corporation_id' => $contract->issuer_corporation_id,
-                    'assignee_id'           => $contract->assignee_id,
-                    'acceptor_id'           => $contract->acceptor_id,
-                    'start_location_id'     => isset($contract->start_location_id) ? $contract->start_location_id : null,
-                    'end_location_id'       => isset($contract->end_location_id) ? $contract->end_location_id : null,
-                    'type'                  => $contract->type,
-                    'status'                => $contract->status,
-                    'title'                 => isset($contract->title) ? $contract->title : null,
-                    'for_corporation'       => $contract->for_corporation,
-                    'availability'          => $contract->availability,
-                    'date_issued'           => carbon($contract->date_issued),
-                    'date_expired'          => carbon($contract->date_expired),
-                    'date_accepted'         => isset($contract->date_accepted) ?
-                        carbon($contract->date_accepted) : null,
-                    'days_to_complete'      => isset($contract->days_to_complete) ? $contract->days_to_complete : null,
-                    'date_completed'        => isset($contract->date_completed) ?
-                        carbon($contract->date_completed) : null,
-                    'price'                 => isset($contract->price) ? $contract->price : null,
-                    'reward'                => isset($contract->reward) ? $contract->reward : null,
-                    'collateral'            => isset($contract->collateral) ? $contract->collateral : null,
-                    'buyout'                => isset($contract->buyout) ? $contract->buyout : null,
-                    'volume'                => isset($contract->volume) ? $contract->volume : null,
                 ]);
 
+                $model->fromEsi($contract);
                 $model->save();
 
                 // Ensure the character is associated to this contract

--- a/src/Jobs/Contracts/Corporation/Contracts.php
+++ b/src/Jobs/Contracts/Corporation/Contracts.php
@@ -85,32 +85,9 @@ class Contracts extends AbstractAuthCorporationJob
                 // Update or create the contract details.
                 $model = ContractDetail::firstOrNew([
                     'contract_id' => $contract->contract_id,
-                ])->fill([
-                    'issuer_id'             => $contract->issuer_id,
-                    'issuer_corporation_id' => $contract->issuer_corporation_id,
-                    'assignee_id'           => $contract->assignee_id,
-                    'acceptor_id'           => $contract->acceptor_id,
-                    'start_location_id'     => $contract->start_location_id ?? null,
-                    'end_location_id'       => $contract->end_location_id ?? null,
-                    'type'                  => $contract->type,
-                    'status'                => $contract->status,
-                    'title'                 => $contract->title ?? null,
-                    'for_corporation'       => $contract->for_corporation,
-                    'availability'          => $contract->availability,
-                    'date_issued'           => carbon($contract->date_issued),
-                    'date_expired'          => carbon($contract->date_expired),
-                    'date_accepted'         => isset($contract->date_accepted) ?
-                        carbon($contract->date_accepted) : null,
-                    'days_to_complete'      => $contract->days_to_complete ?? null,
-                    'date_completed'        => isset($contract->date_completed) ?
-                        carbon($contract->date_completed) : null,
-                    'price'                 => $contract->price ?? null,
-                    'reward'                => $contract->reward ?? null,
-                    'collateral'            => $contract->collateral ?? null,
-                    'buyout'                => $contract->buyout ?? null,
-                    'volume'                => $contract->volume ?? null,
                 ]);
 
+                $model->fromEsi($contract);
                 $model->save();
 
                 // Ensure the character is associated to this contract

--- a/src/Models/Universe/UniverseStation.php
+++ b/src/Models/Universe/UniverseStation.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Models\Universe;
 
 use Illuminate\Database\Eloquent\Model;
+use Seat\Eveapi\Models\Contracts\ContractDetail;
 use Seat\Eveapi\Models\Sde\SolarSystem;
 
 /**
@@ -35,6 +36,16 @@ class UniverseStation extends Model
      * Those stations might be returned by ESI on some endpoints (ie: corporation infos) - however, they don't exist.
      */
     const FAKE_STATION_ID = [60000001];
+
+    /**
+     * https://github.com/esi/esi-docs/blob/master/docs/id_ranges.md.
+     */
+    const STATION_RANGES = [
+        [60000000, 60999999], // NPC Stations
+        [61000000, 63999999], // Outposts
+        [68000000, 68999999], // Station folders
+        [69000000, 69999999], // Outposts folders
+    ];
 
     /**
      * @var bool
@@ -50,6 +61,22 @@ class UniverseStation extends Model
      * @var string
      */
     protected $primaryKey = 'station_id';
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
+    public function contracts_from()
+    {
+        return $this->morphMany(ContractDetail::class, 'start_location');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
+    public function contracts_to()
+    {
+        return $this->morphMany(ContractDetail::class, 'end_location');
+    }
 
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/src/Models/Universe/UniverseStructure.php
+++ b/src/Models/Universe/UniverseStructure.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Models\Universe;
 
 use Illuminate\Database\Eloquent\Model;
+use Seat\Eveapi\Models\Contracts\ContractDetail;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\SolarSystem;
 
@@ -66,6 +67,22 @@ class UniverseStructure extends Model
      * @var string
      */
     protected $primaryKey = 'structure_id';
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
+    public function contracts_from()
+    {
+        return $this->morphMany(ContractDetail::class, 'start_location');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
+    public function contracts_to()
+    {
+        return $this->morphMany(ContractDetail::class, 'end_location');
+    }
 
     /**
      * @return \Illuminate\Database\Eloquent\Relations\HasOne

--- a/src/database/migrations/2021_02_07_194402_add_start_location_type_to_contract_details_table.php
+++ b/src/database/migrations/2021_02_07_194402_add_start_location_type_to_contract_details_table.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Seat\Eveapi\Models\Universe\UniverseStation;
+use Seat\Eveapi\Models\Universe\UniverseStructure;
+
+/**
+ * Class AddStartLocationTypeToContractDetailsTable.
+ */
+class AddStartLocationTypeToContractDetailsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('contract_details', function (Blueprint $table) {
+            $table->string('start_location_type')->nullable()->after('start_location_id');
+        });
+
+        // set stations
+        DB::table('contract_details')
+            ->whereBetween('start_location_id', [60000000, 60999999])
+            ->orWhereBetween('start_location_id', [61000000, 63999999])
+            ->orWhereBetween('start_location_id', [68000000, 68999999])
+            ->orWhereBetween('start_location_id', [69000000, 69999999])
+            ->update([
+                'start_location_type' => UniverseStation::class,
+            ]);
+
+        // set structures
+        DB::table('contract_details')
+            ->whereNotNull('start_location_id')
+            ->whereNotBetween('start_location_id', [60000000, 60999999])
+            ->whereNotBetween('start_location_id', [61000000, 63999999])
+            ->whereNotBetween('start_location_id', [68000000, 68999999])
+            ->whereNotBetween('start_location_id', [69000000, 69999999])
+            ->update([
+                'start_location_type' => UniverseStructure::class,
+            ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('contract_details', function (Blueprint $table) {
+            $table->dropColumn('start_location_type');
+        });
+    }
+}

--- a/src/database/migrations/2021_02_07_194957_add_end_location_type_to_contract_details_table.php
+++ b/src/database/migrations/2021_02_07_194957_add_end_location_type_to_contract_details_table.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Seat\Eveapi\Models\Universe\UniverseStation;
+use Seat\Eveapi\Models\Universe\UniverseStructure;
+
+/**
+ * Class AddEndLocationTypeToContractDetailsTable.
+ */
+class AddEndLocationTypeToContractDetailsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('contract_details', function (Blueprint $table) {
+            $table->string('end_location_type')->nullable()->after('end_location_id');
+        });
+
+        // set stations
+        DB::table('contract_details')
+            ->whereBetween('end_location_id', [60000000, 60999999])
+            ->orWhereBetween('end_location_id', [61000000, 63999999])
+            ->orWhereBetween('end_location_id', [68000000, 68999999])
+            ->orWhereBetween('end_location_id', [69000000, 69999999])
+            ->update([
+                'end_location_type' => UniverseStation::class,
+            ]);
+
+        // set structures
+        DB::table('contract_details')
+            ->whereNotNull('end_location_id')
+            ->whereNotBetween('end_location_id', [60000000, 60999999])
+            ->whereNotBetween('end_location_id', [61000000, 63999999])
+            ->whereNotBetween('end_location_id', [68000000, 68999999])
+            ->whereNotBetween('end_location_id', [69000000, 69999999])
+            ->update([
+                'end_location_type' => UniverseStructure::class,
+            ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('contract_details', function (Blueprint $table) {
+            $table->dropColumn('end_location_type');
+        });
+    }
+}


### PR DESCRIPTION
**BREAKING CHANGE:** `start_location` and `end_location` from `ContractDetail` are now using `morphTo` and can either return an `UniverseStructure` or a `UniverseStation` object depending on situation.

Closes: eveseat/seat#756