### PR TITLE
refactor(jobs): add data-mapping classes to handle esi <-> eloquent mapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "eveseat/services": "^4.1",
     "guzzlehttp/guzzle": "^6.3",
     "doctrine/dbal": "^2.9",
+    "softcreatr/jsonpath": "^0.7",
     "ext-json": "*",
     "ext-posix": "*",
     "ext-redis": "*"

--- a/src/Bus/Character.php
+++ b/src/Bus/Character.php
@@ -50,6 +50,7 @@ use Seat\Eveapi\Jobs\Location\Character\Ship;
 use Seat\Eveapi\Jobs\Mail\Labels as MailLabels;
 use Seat\Eveapi\Jobs\Mail\MailingLists;
 use Seat\Eveapi\Jobs\Mail\Mails;
+use Seat\Eveapi\Jobs\Market\Character\History;
 use Seat\Eveapi\Jobs\Market\Character\Orders;
 use Seat\Eveapi\Jobs\PlanetaryInteraction\Character\Planets;
 use Seat\Eveapi\Jobs\Skills\Character\Attributes;
@@ -157,6 +158,7 @@ class Character extends Bus
 
         // collect financial information
         $this->jobs->add(new Orders($this->token));
+        $this->jobs->add(new History($this->token));
         $this->jobs->add(new Planets($this->token));
         $this->jobs->add(new Balance($this->token));
         $this->jobs->add(new Journal($this->token));

--- a/src/Bus/Corporation.php
+++ b/src/Bus/Corporation.php
@@ -51,6 +51,7 @@ use Seat\Eveapi\Jobs\Industry\Corporation\Jobs;
 use Seat\Eveapi\Jobs\Industry\Corporation\Mining\Extractions;
 use Seat\Eveapi\Jobs\Industry\Corporation\Mining\ObserverDetails;
 use Seat\Eveapi\Jobs\Industry\Corporation\Mining\Observers;
+use Seat\Eveapi\Jobs\Market\Corporation\History;
 use Seat\Eveapi\Jobs\Market\Corporation\Orders;
 use Seat\Eveapi\Jobs\PlanetaryInteraction\Corporation\CustomsOfficeLocations;
 use Seat\Eveapi\Jobs\PlanetaryInteraction\Corporation\CustomsOffices;
@@ -153,6 +154,7 @@ class Corporation extends Bus
 
         // collect financial information
         $this->jobs->add(new Orders($this->corporation_id, $this->token));
+        $this->jobs->add(new History($this->corporation_id, $this->token));
         $this->jobs->add(new Shareholders($this->corporation_id, $this->token));
         $this->jobs->add(new Balances($this->corporation_id, $this->token));
         $this->jobs->add(new Journals($this->corporation_id, $this->token));

--- a/src/Jobs/Alliances/Info.php
+++ b/src/Jobs/Alliances/Info.php
@@ -91,7 +91,7 @@ class Info extends EsiBase
         InfoMapping::make($model, $info, [
             'alliance_id' => function () {
                 return $this->alliance_id;
-            }
+            },
         ])->save();
     }
 

--- a/src/Jobs/Alliances/Info.php
+++ b/src/Jobs/Alliances/Info.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Alliances;
 
 use Seat\Eveapi\Jobs\EsiBase;
+use Seat\Eveapi\Mapping\Alliances\InfoMapping;
 use Seat\Eveapi\Models\Alliances\Alliance;
 
 /**
@@ -83,17 +84,15 @@ class Info extends EsiBase
         if ($info->isCachedLoad() && Alliance::find($this->alliance_id))
             return;
 
-        Alliance::updateOrCreate([
+        $model = Alliance::firstOrNew([
             'alliance_id' => $this->alliance_id,
-        ], [
-            'name'                    => $info->name,
-            'creator_id'              => $info->creator_id,
-            'creator_corporation_id'  => $info->creator_corporation_id,
-            'ticker'                  => $info->ticker,
-            'executor_corporation_id' => $info->executor_corporation_id ?? null,
-            'date_founded'            => carbon($info->date_founded),
-            'faction_id'              => $info->faction_id ?? null,
         ]);
+
+        InfoMapping::make($model, $info, [
+            'alliance_id' => function () {
+                return $this->alliance_id;
+            }
+        ])->save();
     }
 
     /**

--- a/src/Jobs/Assets/Character/Assets.php
+++ b/src/Jobs/Assets/Character/Assets.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Assets\Character;
 
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
+use Seat\Eveapi\Mapping\Assets\AssetMapping;
 use Seat\Eveapi\Models\Assets\CharacterAsset;
 use Seat\Eveapi\Models\RefreshToken;
 
@@ -99,18 +100,15 @@ class Assets extends AbstractAuthCharacterJob
 
             collect($assets)->each(function ($asset) {
 
-                CharacterAsset::updateOrCreate(
-                    ['item_id' => $asset->item_id],
-                    [
-                        'character_id'  => $this->getCharacterId(),
-                        'type_id'       => $asset->type_id,
-                        'quantity'      => $asset->quantity,
-                        'location_id'   => $asset->location_id,
-                        'location_type' => $asset->location_type,
-                        'location_flag' => $asset->location_flag,
-                        'is_singleton'  => $asset->is_singleton,
-                    ]
-                );
+                $model = CharacterAsset::firstOrNew([
+                    'item_id' => $asset->item_id,
+                ]);
+
+                AssetMapping::make($model, $asset, [
+                    'character_id' => function () {
+                        return $this->getCharacterId();
+                    },
+                ])->save();
 
                 // Update the list of known item_id's which should be
                 // excluded from the database cleanup later.

--- a/src/Jobs/Calendar/Detail.php
+++ b/src/Jobs/Calendar/Detail.php
@@ -94,7 +94,7 @@ class Detail extends AbstractAuthCharacterJob
                 CalendarDetailMapping::make($model, $detail, [
                     'event_id' => function () use ($event_id) {
                         return $event_id;
-                    }
+                    },
                 ])->save();
 
             } catch (RequestFailedException $e) {

--- a/src/Jobs/Calendar/Events.php
+++ b/src/Jobs/Calendar/Events.php
@@ -102,7 +102,7 @@ class Events extends AbstractAuthCharacterJob
                 CalendarEventMapping::make($model, $event, [
                     'character_id' => function () {
                         return $this->getCharacterId();
-                    }
+                    },
                 ])->save();
             });
 

--- a/src/Jobs/Character/AgentsResearch.php
+++ b/src/Jobs/Character/AgentsResearch.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Character;
 
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
+use Seat\Eveapi\Mapping\Industry\AgentResearchMapping;
 use Seat\Eveapi\Models\Character\CharacterAgentResearch;
 
 /**
@@ -76,14 +77,15 @@ class AgentsResearch extends AbstractAuthCharacterJob
 
         collect($agents_research)->each(function ($agent_research) {
 
-            CharacterAgentResearch::firstOrNew([
+            $model = CharacterAgentResearch::firstOrNew([
                 'character_id' => $this->getCharacterId(),
                 'agent_id'     => $agent_research->agent_id,
-            ])->fill([
-                'skill_type_id'    => $agent_research->skill_type_id,
-                'started_at'       => carbon($agent_research->started_at),
-                'points_per_day'   => $agent_research->points_per_day,
-                'remainder_points' => $agent_research->remainder_points,
+            ]);
+
+            AgentResearchMapping::make($model, $agent_research, [
+                'character_id' => function () {
+                    return $this->getCharacterId();
+                },
             ])->save();
         });
 

--- a/src/Jobs/Character/Info.php
+++ b/src/Jobs/Character/Info.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Character;
 
 use Seat\Eveapi\Jobs\AbstractCharacterJob;
+use Seat\Eveapi\Mapping\Characters\InfoMapping;
 use Seat\Eveapi\Models\Character\CharacterInfo;
 
 /**
@@ -67,15 +68,14 @@ class Info extends AbstractCharacterJob
 
         if ($character_info->isCachedLoad() && CharacterInfo::find($this->getCharacterId())) return;
 
-        CharacterInfo::firstOrNew(['character_id' => $this->getCharacterId()])->fill([
-            'name'            => $character_info->name,
-            'description'     => $character_info->optional('description'),
-            'birthday'        => $character_info->birthday,
-            'gender'          => $character_info->gender,
-            'race_id'         => $character_info->race_id,
-            'bloodline_id'    => $character_info->bloodline_id,
-            'ancestry_id'    => $character_info->optional('ancestry_id'),
-            'security_status' => $character_info->optional('security_status'),
+        $model = CharacterInfo::firstOrNew([
+            'character_id' => $this->getCharacterId(),
+        ]);
+
+        InfoMapping::make($model, $character_info, [
+            'character_id' => function () {
+                return $this->getCharacterId();
+            },
         ])->save();
     }
 }

--- a/src/Jobs/Character/Medals.php
+++ b/src/Jobs/Character/Medals.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Character;
 
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
+use Seat\Eveapi\Mapping\Characters\MedalsMapping;
 use Seat\Eveapi\Models\Character\CharacterMedal;
 
 /**
@@ -75,18 +76,18 @@ class Medals extends AbstractAuthCharacterJob
 
         collect($medals)->each(function ($medal) {
 
-            CharacterMedal::firstOrNew([
+            $model = CharacterMedal::firstOrNew([
                 'character_id' => $this->getCharacterId(),
                 'medal_id'     => $medal->medal_id,
-            ])->fill([
-                'title'          => $medal->title,
-                'description'    => $medal->description,
-                'corporation_id' => $medal->corporation_id,
-                'issuer_id'      => $medal->issuer_id,
-                'date'           => carbon($medal->date),
-                'reason'         => $medal->reason,
-                'status'         => $medal->status,
-                'graphics'       => json_encode($medal->graphics),
+            ]);
+
+            MedalsMapping::make($model, $medal, [
+                'character_id' => function () {
+                    return $this->getCharacterId();
+                },
+                'graphics' => function () use ($medal) {
+                    return json_encode($medal->graphics);
+                },
             ])->save();
         });
     }

--- a/src/Jobs/Character/Notifications.php
+++ b/src/Jobs/Character/Notifications.php
@@ -87,7 +87,7 @@ class Notifications extends AbstractAuthCharacterJob
                 },
                 'is_read' => function () use ($notification) {
                     return isset($notification->is_read) ? $notification->is_read : false;
-                }
+                },
             ])->save();
         });
     }

--- a/src/Jobs/Corporation/ContainerLogs.php
+++ b/src/Jobs/Corporation/ContainerLogs.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Corporation;
 
 use Seat\Eveapi\Jobs\AbstractAuthCorporationJob;
+use Seat\Eveapi\Mapping\Assets\ContainerLogsMapping;
 use Seat\Eveapi\Models\Corporation\CorporationContainerLog;
 
 /**
@@ -86,21 +87,16 @@ class ContainerLogs extends AbstractAuthCorporationJob
 
             collect($logs)->each(function ($log) {
 
-                CorporationContainerLog::firstOrNew([
+                $model = CorporationContainerLog::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
                     'container_id'   => $log->container_id,
                     'logged_at'      => carbon($log->logged_at),
-                ])->fill([
-                    'container_type_id'  => $log->container_type_id,
-                    'character_id'       => $log->character_id,
-                    'location_id'        => $log->location_id,
-                    'action'             => $log->action,
-                    'location_flag'      => $log->location_flag,
-                    'password_type'      => $log->password_type ?? null,
-                    'type_id'            => $log->type_id ?? null,
-                    'quantity'           => $log->quantity ?? null,
-                    'old_config_bitmask' => $log->old_config_bitmask ?? null,
-                    'new_config_bitmask' => $log->new_config_bitmask ?? null,
+                ]);
+
+                ContainerLogsMapping::make($model, $log, [
+                    'corporation_id' => function () {
+                        return $this->getCorporationId();
+                    },
                 ])->save();
 
             });

--- a/src/Jobs/Corporation/Info.php
+++ b/src/Jobs/Corporation/Info.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Corporation;
 
 use Seat\Eveapi\Jobs\AbstractCorporationJob;
+use Seat\Eveapi\Mapping\Corporations\InfoMapping;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
 
 /**
@@ -65,23 +66,14 @@ class Info extends AbstractCorporationJob
 
         if ($corporation->isCachedLoad() && CorporationInfo::find($this->getCorporationId())) return;
 
-        CorporationInfo::firstOrNew([
+        $model = CorporationInfo::firstOrNew([
             'corporation_id' => $this->getCorporationId(),
-        ])->fill([
-            'name'            => $corporation->name,
-            'ticker'          => $corporation->ticker,
-            'member_count'    => $corporation->member_count,
-            'ceo_id'          => $corporation->ceo_id,
-            'alliance_id'     => $corporation->alliance_id ?? null,
-            'description'     => $corporation->description ?? null,
-            'tax_rate'        => $corporation->tax_rate,
-            'date_founded'    => property_exists($corporation, 'date_founded') ?
-                carbon($corporation->date_founded) : null,
-            'creator_id'      => $corporation->creator_id,
-            'url'             => $corporation->url ?? null,
-            'faction_id'      => $corporation->faction_id ?? null,
-            'home_station_id' => $corporation->home_station_id ?? null,
-            'shares'          => $corporation->shares ?? null,
+        ]);
+
+        InfoMapping::make($model, $corporation, [
+            'corporation_id' => function () {
+                return $this->getCorporationId();
+            },
         ])->save();
     }
 }

--- a/src/Jobs/Corporation/StarbaseDetails.php
+++ b/src/Jobs/Corporation/StarbaseDetails.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Corporation;
 
 use Seat\Eveapi\Jobs\AbstractAuthCorporationJob;
+use Seat\Eveapi\Mapping\Structures\StarbaseDetailMapping;
 use Seat\Eveapi\Models\Corporation\CorporationStarbase;
 use Seat\Eveapi\Models\Corporation\CorporationStarbaseDetail;
 use Seat\Eveapi\Models\Corporation\CorporationStarbaseFuel;
@@ -102,23 +103,18 @@ class StarbaseDetails extends AbstractAuthCorporationJob
                     'starbase_id'    => $starbase->starbase_id,
                 ]);
 
-                CorporationStarbaseDetail::firstOrNew([
+                $model = CorporationStarbaseDetail::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
                     'starbase_id'    => $starbase->starbase_id,
-                ])->fill([
-                    'fuel_bay_view'                            => $detail->fuel_bay_view,
-                    'fuel_bay_take'                            => $detail->fuel_bay_take,
-                    'anchor'                                   => $detail->anchor,
-                    'unanchor'                                 => $detail->unanchor,
-                    'online'                                   => $detail->online,
-                    'offline'                                  => $detail->offline,
-                    'allow_corporation_members'                => $detail->allow_corporation_members,
-                    'allow_alliance_members'                   => $detail->allow_alliance_members,
-                    'use_alliance_standings'                   => $detail->use_alliance_standings,
-                    'attack_standing_threshold'                => $detail->attack_standing_threshold ?? null,
-                    'attack_security_status_threshold'         => $detail->attack_security_status_threshold ?? null,
-                    'attack_if_other_security_status_dropping' => $detail->attack_if_other_security_status_dropping,
-                    'attack_if_at_war'                         => $detail->attack_if_at_war,
+                ]);
+
+                StarbaseDetailMapping::make($model, $detail, [
+                    'corporation_id' => function () {
+                        return $this->getCorporationId();
+                    },
+                    'starbase_id' => function () use ($starbase) {
+                        return $starbase->starbase_id;
+                    },
                 ])->save();
 
                 if (property_exists($detail, 'fuels'))

--- a/src/Jobs/Corporation/Starbases.php
+++ b/src/Jobs/Corporation/Starbases.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Corporation;
 
 use Seat\Eveapi\Jobs\AbstractAuthCorporationJob;
+use Seat\Eveapi\Mapping\Structures\StarbaseMapping;
 use Seat\Eveapi\Models\Corporation\CorporationStarbase;
 use Seat\Eveapi\Models\RefreshToken;
 
@@ -105,20 +106,15 @@ class Starbases extends AbstractAuthCorporationJob
 
             collect($starbases)->each(function ($starbase) {
 
-                CorporationStarbase::firstOrNew([
+                $model = CorporationStarbase::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
                     'starbase_id'    => $starbase->starbase_id,
-                ])->fill([
-                    'moon_id'          => $starbase->moon_id ?? null,
-                    'onlined_since'    => property_exists($starbase, 'onlined_since') ?
-                        carbon($starbase->onlined_since) : null,
-                    'reinforced_until' => property_exists($starbase, 'reinforced_until') ?
-                        carbon($starbase->reinforced_until) : null,
-                    'state'            => $starbase->state ?? null,
-                    'type_id'          => $starbase->type_id,
-                    'system_id'        => $starbase->system_id,
-                    'unanchor_at'      => property_exists($starbase, 'unanchor_at') ?
-                        carbon($starbase->unanchor_at) : null,
+                ]);
+
+                StarbaseMapping::make($model, $starbase, [
+                    'corporation_id' => function () {
+                        return $this->getCorporationId();
+                    },
                 ])->save();
 
                 $this->known_starbases->push($starbase->starbase_id);

--- a/src/Jobs/Corporation/Structures.php
+++ b/src/Jobs/Corporation/Structures.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Corporation;
 
 use Seat\Eveapi\Jobs\AbstractAuthCorporationJob;
+use Seat\Eveapi\Mapping\Structures\CorporationStructureMapping;
 use Seat\Eveapi\Models\Corporation\CorporationStructure;
 use Seat\Eveapi\Models\Corporation\CorporationStructureService;
 use Seat\Eveapi\Models\RefreshToken;
@@ -124,29 +125,11 @@ class Structures extends AbstractAuthCorporationJob
                 // Persist the structure only if it doesn't already exists
                 if (! $model->exists) $model->save();
 
-                CorporationStructure::firstOrNew([
+                $model = CorporationStructure::firstOrNew([
                     'structure_id'   => $structure->structure_id,
-                ])->fill([
-                    'corporation_id'         => $structure->corporation_id,
-                    'type_id'                => $structure->type_id,
-                    'system_id'              => $structure->system_id,
-                    'profile_id'             => $structure->profile_id,
-                    'fuel_expires'           => property_exists($structure, 'fuel_expires') ?
-                        carbon($structure->fuel_expires) : null,
-                    'state_timer_start'      => property_exists($structure, 'state_timer_start') ?
-                        carbon($structure->state_timer_start) : null,
-                    'state_timer_end'        => property_exists($structure, 'state_timer_end') ?
-                        carbon($structure->state_timer_end) : null,
-                    'unanchors_at'           => property_exists($structure, 'unanchors_at') ?
-                        carbon($structure->unanchors_at) : null,
-                    'state'                  => $structure->state,
-                    'reinforce_weekday'      => $structure->reinforce_weekday ?? null,
-                    'reinforce_hour'         => $structure->reinforce_hour,
-                    'next_reinforce_weekday' => $structure->next_reinforce_weekday ?? null,
-                    'next_reinforce_hour'    => $structure->next_reinforce_hour ?? null,
-                    'next_reinforce_apply'   => property_exists($structure, 'next_reinforce_apply') ?
-                        carbon($structure->next_reinforce_apply) : null,
-                ])->save();
+                ]);
+
+                CorporationStructureMapping::make($model, $structure)->save();
 
                 if (property_exists($structure, 'services')) {
 

--- a/src/Jobs/Industry/Character/Jobs.php
+++ b/src/Jobs/Industry/Character/Jobs.php
@@ -92,7 +92,7 @@ class Jobs extends AbstractAuthCharacterJob
                 },
                 'station_id' => function () use ($job) {
                     return $job->station_id;
-                }
+                },
             ])->save();
         });
     }

--- a/src/Jobs/Industry/Character/Jobs.php
+++ b/src/Jobs/Industry/Character/Jobs.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Industry\Character;
 
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
+use Seat\Eveapi\Mapping\Industry\JobMapping;
 use Seat\Eveapi\Models\Industry\CharacterIndustryJob;
 
 /**
@@ -80,33 +81,18 @@ class Jobs extends AbstractAuthCharacterJob
 
         collect($industry_jobs)->each(function ($job) {
 
-            CharacterIndustryJob::firstOrNew([
+            $model = CharacterIndustryJob::firstOrNew([
                 'character_id' => $this->getCharacterId(),
                 'job_id'       => $job->job_id,
-            ])->fill([
-                'installer_id'           => $job->installer_id,
-                'facility_id'            => $job->facility_id,
-                'station_id'             => $job->station_id,
-                'activity_id'            => $job->activity_id,
-                'blueprint_id'           => $job->blueprint_id,
-                'blueprint_type_id'      => $job->blueprint_type_id,
-                'blueprint_location_id'  => $job->blueprint_location_id,
-                'output_location_id'     => $job->output_location_id,
-                'runs'                   => $job->runs,
-                'cost'                   => $job->cost ?? null,
-                'licensed_runs'          => $job->licensed_runs ?? null,
-                'probability'            => $job->probability ?? null,
-                'product_type_id'        => $job->product_type_id ?? null,
-                'status'                 => $job->status,
-                'duration'               => $job->duration,
-                'start_date'             => carbon($job->start_date),
-                'end_date'               => carbon($job->end_date),
-                'pause_date'             => property_exists($job, 'pause_date') ?
-                    carbon($job->pause_date) : null,
-                'completed_date'         => property_exists($job, 'completed_date') ?
-                    carbon($job->completed_date) : null,
-                'completed_character_id' => $job->completed_character_id ?? null,
-                'successful_runs'        => $job->successful_runs ?? null,
+            ]);
+
+            JobMapping::make($model, $job, [
+                'character_id' => function () {
+                    return $this->getCharacterId();
+                },
+                'station_id' => function () use ($job) {
+                    return $job->station_id;
+                }
             ])->save();
         });
     }

--- a/src/Jobs/Industry/Corporation/Jobs.php
+++ b/src/Jobs/Industry/Corporation/Jobs.php
@@ -105,7 +105,7 @@ class Jobs extends AbstractAuthCorporationJob
                     },
                     'location_id' => function () use ($job) {
                         return $job->location_id;
-                    }
+                    },
                 ])->save();
             });
 

--- a/src/Jobs/Industry/Corporation/Jobs.php
+++ b/src/Jobs/Industry/Corporation/Jobs.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Industry\Corporation;
 
 use Seat\Eveapi\Jobs\AbstractAuthCorporationJob;
+use Seat\Eveapi\Mapping\Industry\JobMapping;
 use Seat\Eveapi\Models\Industry\CorporationIndustryJob;
 
 /**
@@ -93,33 +94,18 @@ class Jobs extends AbstractAuthCorporationJob
 
             collect($industry_jobs)->each(function ($job) {
 
-                CorporationIndustryJob::firstOrNew([
+                $model = CorporationIndustryJob::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
                     'job_id'         => $job->job_id,
-                ])->fill([
-                    'installer_id'           => $job->installer_id,
-                    'facility_id'            => $job->facility_id,
-                    'location_id'            => $job->location_id,
-                    'activity_id'            => $job->activity_id,
-                    'blueprint_id'           => $job->blueprint_id,
-                    'blueprint_type_id'      => $job->blueprint_type_id,
-                    'blueprint_location_id'  => $job->blueprint_location_id,
-                    'output_location_id'     => $job->output_location_id,
-                    'runs'                   => $job->runs,
-                    'cost'                   => $job->cost ?? null,
-                    'licensed_runs'          => $job->licensed_runs ?? null,
-                    'probability'            => $job->probability ?? null,
-                    'product_type_id'        => $job->product_type_id ?? null,
-                    'status'                 => $job->status,
-                    'duration'               => $job->duration,
-                    'start_date'             => carbon($job->start_date),
-                    'end_date'               => carbon($job->end_date),
-                    'pause_date'             => property_exists($job, 'pause_date') ?
-                        carbon($job->pause_date) : null,
-                    'completed_date'         => property_exists($job, 'completed_date') ?
-                        carbon($job->completed_date) : null,
-                    'completed_character_id' => $job->completed_character_id ?? null,
-                    'successful_runs'        => $job->successful_runs ?? null,
+                ]);
+
+                JobMapping::make($model, $job, [
+                    'corporation_id' => function () {
+                        return $this->getCorporationId();
+                    },
+                    'location_id' => function () use ($job) {
+                        return $job->location_id;
+                    }
                 ])->save();
             });
 

--- a/src/Jobs/Industry/Corporation/Mining/Extractions.php
+++ b/src/Jobs/Industry/Corporation/Mining/Extractions.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Industry\Corporation\Mining;
 
 use Seat\Eveapi\Jobs\AbstractAuthCorporationJob;
+use Seat\Eveapi\Mapping\Industry\ExtractionMapping;
 use Seat\Eveapi\Models\Industry\CorporationIndustryMiningExtraction;
 
 /**
@@ -79,14 +80,14 @@ class Extractions extends AbstractAuthCorporationJob
 
         collect($mining_extractions)->each(function ($extraction) {
 
-            CorporationIndustryMiningExtraction::firstOrNew([
+            $model = CorporationIndustryMiningExtraction::firstOrNew([
                 'moon_id' => $extraction->moon_id,
-            ])->fill([
-                'corporation_id'        => $this->getCorporationId(),
-                'structure_id'          => $extraction->structure_id,
-                'extraction_start_time' => carbon($extraction->extraction_start_time),
-                'chunk_arrival_time'    => carbon($extraction->chunk_arrival_time),
-                'natural_decay_time'    => carbon($extraction->natural_decay_time),
+            ]);
+
+            ExtractionMapping::make($model, $extraction, [
+                'corporation_id' => function () {
+                    return $this->getCorporationId();
+                },
             ])->save();
         });
     }

--- a/src/Jobs/Market/Character/History.php
+++ b/src/Jobs/Market/Character/History.php
@@ -27,7 +27,7 @@ use Seat\Eveapi\Mapping\Financial\OrderMapping;
 use Seat\Eveapi\Models\Market\CharacterOrder;
 
 /**
- * Class History
+ * Class History.
  * @package Seat\Eveapi\Jobs\Market\Character
  */
 class History extends AbstractAuthCharacterJob

--- a/src/Jobs/Market/Character/History.php
+++ b/src/Jobs/Market/Character/History.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eveapi\Jobs\Market\Character;
+
+use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
+use Seat\Eveapi\Mapping\Financial\OrderMapping;
+use Seat\Eveapi\Models\Market\CharacterOrder;
+
+/**
+ * Class History
+ * @package Seat\Eveapi\Jobs\Market\Character
+ */
+class History extends AbstractAuthCharacterJob
+{
+    /**
+     * @var string
+     */
+    protected $method = 'get';
+
+    /**
+     * @var string
+     */
+    protected $endpoint = '/characters/{character_id}/orders/history/';
+
+    /**
+     * @var int
+     */
+    protected $version = 'v1';
+
+    /**
+     * @var string
+     */
+    protected $scope = 'esi-markets.read_character_orders.v1';
+
+    /**
+     * @var array
+     */
+    protected $tags = ['character', 'market'];
+
+    /**
+     * @var int
+     */
+    protected $page = 1;
+
+    /**
+     * Execute the job.
+     *
+     * @throws \Throwable
+     */
+    public function handle()
+    {
+        while (true) {
+
+            $orders = $this->retrieve([
+                'character_id' => $this->getCharacterId(),
+            ]);
+
+            if ($orders->isCachedLoad() &&
+                CharacterOrder::where('character_id', $this->getCharacterId())->count() > 0)
+                return;
+
+            collect($orders)->each(function ($order) {
+
+                $model = CharacterOrder::firstOrNew([
+                    'character_id' => $this->getCharacterId(),
+                    'order_id' => $order->order_id,
+                ]);
+
+                OrderMapping::make($model, $order, [
+                    'character_id' => function () {
+                        return $this->getCharacterId();
+                    },
+                    'is_corporation' => function () use ($order) {
+                        return $order->is_corporation;
+                    },
+                    'state' => function () use ($order) {
+                        return $order->state;
+                    },
+                ])->save();
+            });
+
+            if (! $this->nextPage($orders->pages))
+                return;
+        }
+    }
+}

--- a/src/Jobs/Market/Character/Orders.php
+++ b/src/Jobs/Market/Character/Orders.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Market\Character;
 
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
+use Seat\Eveapi\Mapping\Financial\OrderMapping;
 use Seat\Eveapi\Models\Market\CharacterOrder;
 
 /**
@@ -73,23 +74,18 @@ class Orders extends AbstractAuthCharacterJob
 
         collect($orders)->each(function ($order) {
 
-            CharacterOrder::firstOrNew([
+            $model = CharacterOrder::firstOrNew([
                 'character_id' => $this->getCharacterId(),
                 'order_id'     => $order->order_id,
-            ])->fill([
-                'type_id'        => $order->type_id,
-                'region_id'      => $order->region_id,
-                'location_id'    => $order->location_id,
-                'range'          => $order->range,
-                'is_buy_order'   => $order->is_buy_order ?? null,
-                'price'          => $order->price,
-                'volume_total'   => $order->volume_total,
-                'volume_remain'  => $order->volume_remain,
-                'issued'         => carbon($order->issued),
-                'min_volume'     => $order->min_volume ?? null,
-                'duration'       => $order->duration,
-                'is_corporation' => $order->is_corporation,
-                'escrow'         => $order->escrow ?? null,
+            ]);
+
+            OrderMapping::make($model, $order, [
+                'character_id' => function () {
+                    return $this->getCharacterId();
+                },
+                'is_corporation' => function () use ($order) {
+                    return $order->is_corporation;
+                },
             ])->save();
         });
     }

--- a/src/Jobs/Market/Corporation/History.php
+++ b/src/Jobs/Market/Corporation/History.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eveapi\Jobs\Market\Corporation;
+
+use Seat\Eveapi\Jobs\AbstractAuthCorporationJob;
+use Seat\Eveapi\Mapping\Financial\OrderMapping;
+use Seat\Eveapi\Models\Market\CorporationOrder;
+
+/**
+ * Class History
+ * @package Seat\Eveapi\Jobs\Market\Corporation
+ */
+class History extends AbstractAuthCorporationJob
+{
+    /**
+     * @var string
+     */
+    protected $method = 'get';
+
+    /**
+     * @var string
+     */
+    protected $endpoint = '/corporations/{corporation_id}/orders/history/';
+
+    /**
+     * @var int
+     */
+    protected $version = 'v2';
+
+    /**
+     * @var string
+     */
+    protected $scope = 'esi-markets.read_corporation_orders.v1';
+
+    /**
+     * @var array
+     */
+    protected $roles = ['Accountant', 'Trader'];
+
+    /**
+     * @var array
+     */
+    protected $tags = ['corporation', 'market'];
+
+    /**
+     * @var int
+     */
+    protected $page = 1;
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     * @throws \Throwable
+     */
+    public function handle()
+    {
+        while (true) {
+
+            $orders = $this->retrieve([
+                'corporation_id' => $this->getCorporationId(),
+            ]);
+
+            if ($orders->isCachedLoad() &&
+                CorporationOrder::where('corporation_id', $this->getCorporationId())->count() > 0)
+                return;
+
+            collect($orders)->each(function ($order) {
+
+                $model = CorporationOrder::firstOrNew([
+                    'corporation_id' => $this->getCorporationId(),
+                    'order_id'       => $order->order_id,
+                ]);
+
+                OrderMapping::make($model, $order, [
+                    'corporation_id' => function () {
+                        return $this->getCorporationId();
+                    },
+                    'wallet_division' => function () use ($order) {
+                        return $order->wallet_division;
+                    },
+                    'issued_by' => function () use ($order) {
+                        return $order->issued_by;
+                    },
+                    'state' => function () use ($order) {
+                        return $order->state;
+                    },
+                ])->save();
+            });
+
+            if (! $this->nextPage($orders->pages))
+                return;
+        }
+    }
+}

--- a/src/Jobs/Market/Corporation/History.php
+++ b/src/Jobs/Market/Corporation/History.php
@@ -27,7 +27,7 @@ use Seat\Eveapi\Mapping\Financial\OrderMapping;
 use Seat\Eveapi\Models\Market\CorporationOrder;
 
 /**
- * Class History
+ * Class History.
  * @package Seat\Eveapi\Jobs\Market\Corporation
  */
 class History extends AbstractAuthCorporationJob

--- a/src/Jobs/Market/Corporation/Orders.php
+++ b/src/Jobs/Market/Corporation/Orders.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Market\Corporation;
 
 use Seat\Eveapi\Jobs\AbstractAuthCorporationJob;
+use Seat\Eveapi\Mapping\Financial\OrderMapping;
 use Seat\Eveapi\Models\Market\CorporationOrder;
 
 /**
@@ -86,24 +87,21 @@ class Orders extends AbstractAuthCorporationJob
 
             collect($orders)->each(function ($order) {
 
-                CorporationOrder::firstOrNew([
+                $model = CorporationOrder::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
                     'order_id'       => $order->order_id,
-                ])->fill([
-                    'type_id'         => $order->type_id,
-                    'region_id'       => $order->region_id,
-                    'location_id'     => $order->location_id,
-                    'range'           => $order->range,
-                    'is_buy_order'    => $order->is_buy_order ?? null,
-                    'price'           => $order->price,
-                    'volume_total'    => $order->volume_total,
-                    'volume_remain'   => $order->volume_remain,
-                    'issued'          => carbon($order->issued),
-                    'issued_by'       => $order->issued_by,
-                    'min_volume'      => $order->min_volume ?? null,
-                    'wallet_division' => $order->wallet_division ?? null,
-                    'duration'        => $order->duration ?? null,
-                    'escrow'          => $order->escrow ?? null,
+                ]);
+
+                OrderMapping::make($model, $order, [
+                    'corporation_id' => function () {
+                        return $this->getCorporationId();
+                    },
+                    'wallet_division' => function () use ($order) {
+                        return $order->wallet_division;
+                    },
+                    'issued_by' => function () use ($order) {
+                        return $order->issued_by;
+                    },
                 ])->save();
             });
 

--- a/src/Jobs/PlanetaryInteraction/Corporation/CustomsOffices.php
+++ b/src/Jobs/PlanetaryInteraction/Corporation/CustomsOffices.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\PlanetaryInteraction\Corporation;
 
 use Seat\Eveapi\Jobs\AbstractAuthCorporationJob;
+use Seat\Eveapi\Mapping\Structures\CustomsOfficeMapping;
 use Seat\Eveapi\Models\PlanetaryInteraction\CorporationCustomsOffice;
 use Seat\Eveapi\Models\RefreshToken;
 
@@ -105,23 +106,15 @@ class CustomsOffices extends AbstractAuthCorporationJob
 
             collect($customs_offices)->each(function ($customs_office) {
 
-                CorporationCustomsOffice::firstOrNew([
+                $model = CorporationCustomsOffice::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
                     'office_id'      => $customs_office->office_id,
-                ])->fill([
-                    'system_id'                   => $customs_office->system_id,
-                    'reinforce_exit_start'        => $customs_office->reinforce_exit_start,
-                    'reinforce_exit_end'          => $customs_office->reinforce_exit_end,
-                    'corporation_tax_rate'        => $customs_office->corporation_tax_rate ?? null,
-                    'allow_alliance_access'       => $customs_office->allow_alliance_access,
-                    'alliance_tax_rate'           => $customs_office->alliance_tax_rate ?? null,
-                    'allow_access_with_standings' => $customs_office->allow_access_with_standings,
-                    'standing_level'              => $customs_office->standing_level ?? null,
-                    'excellent_standing_tax_rate' => $customs_office->excellent_standing_tax_rate ?? null,
-                    'good_standing_tax_rate'      => $customs_office->good_standing_tax_rate ?? null,
-                    'neutral_standing_tax_rate'   => $customs_office->neutral_standing_tax_rate ?? null,
-                    'bad_standing_tax_rate'       => $customs_office->bad_standing_tax_rate ?? null,
-                    'terrible_standing_tax_rate'  => $customs_office->terrible_standing_tax_rate ?? null,
+                ]);
+
+                CustomsOfficeMapping::make($model, $customs_office, [
+                    'corporation_id' => function () {
+                        return $this->getCorporationId();
+                    },
                 ])->save();
 
                 $this->known_structures->push($customs_office->office_id);

--- a/src/Jobs/Skills/Character/Attributes.php
+++ b/src/Jobs/Skills/Character/Attributes.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Skills\Character;
 
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
+use Seat\Eveapi\Mapping\Characters\CharacterAttributesMapping;
 use Seat\Eveapi\Models\Skills\CharacterAttribute;
 
 /**
@@ -69,20 +70,14 @@ class Attributes extends AbstractAuthCharacterJob
 
         if ($attributes->isCachedLoad() && CharacterAttribute::find($this->getCharacterId())) return;
 
-        CharacterAttribute::firstOrNew([
+        $model = CharacterAttribute::firstOrNew([
             'character_id' => $this->getCharacterId(),
-        ])->fill([
-            'charisma'                    => $attributes->charisma,
-            'intelligence'                => $attributes->intelligence,
-            'memory'                      => $attributes->memory,
-            'perception'                  => $attributes->perception,
-            'willpower'                   => $attributes->willpower,
-            'bonus_remaps'                => property_exists($attributes, 'bonus_remaps') ?
-                $attributes->bonus_remaps : null,
-            'last_remap_date'             => property_exists($attributes, 'last_remap_date') ?
-                carbon($attributes->last_remap_date) : null,
-            'accrued_remap_cooldown_date' => property_exists($attributes, 'accrued_remap_cooldown_date') ?
-                carbon($attributes->accrued_remap_cooldown_date) : null,
+        ]);
+
+        CharacterAttributesMapping::make($model, $attributes, [
+            'character_id' => function () {
+                return $this->getCharacterId();
+            },
         ])->save();
     }
 }

--- a/src/Jobs/Skills/Character/Queue.php
+++ b/src/Jobs/Skills/Character/Queue.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Skills\Character;
 
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
+use Seat\Eveapi\Mapping\Characters\SkillQueueMapping;
 use Seat\Eveapi\Models\Skills\CharacterSkillQueue;
 
 /**
@@ -80,22 +81,15 @@ class Queue extends AbstractAuthCharacterJob
 
         collect($skill_queue)->each(function ($skill) {
 
-            CharacterSkillQueue::firstOrNew([
+            $model = CharacterSkillQueue::firstOrNew([
                 'character_id' => $this->getCharacterId(),
                 'queue_position'    => $skill->queue_position,
-            ])->fill([
-                'skill_id'     => $skill->skill_id,
-                'finish_date'       => property_exists($skill, 'finish_date') ?
-                    carbon($skill->finish_date) : null,
-                'start_date'        => property_exists($skill, 'start_date') ?
-                    carbon($skill->start_date) : null,
-                'finished_level'    => $skill->finished_level,
-                'training_start_sp' => property_exists($skill, 'training_start_sp') ?
-                    $skill->training_start_sp : null,
-                'level_end_sp'      => property_exists($skill, 'level_end_sp') ?
-                    $skill->level_end_sp : null,
-                'level_start_sp'    => property_exists($skill, 'level_start_sp') ?
-                    $skill->level_start_sp : null,
+            ]);
+
+            SkillQueueMapping::make($model, $skill, [
+                'character_id' => function () {
+                    return $this->getCharacterId();
+                },
             ])->save();
 
             if ($skill->queue_position > $this->greatest_position)

--- a/src/Jobs/Skills/Character/Skills.php
+++ b/src/Jobs/Skills/Character/Skills.php
@@ -87,7 +87,7 @@ class Skills extends AbstractAuthCharacterJob
 
             $model = CharacterSkill::firstOrNew([
                 'character_id' => $this->getCharacterId(),
-                'skill_id' => $character_skill->skill_id
+                'skill_id' => $character_skill->skill_id,
             ]);
 
             SkillMapping::make($model, $character_skill, [

--- a/src/Jobs/Skills/Character/Skills.php
+++ b/src/Jobs/Skills/Character/Skills.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Skills\Character;
 
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
+use Seat\Eveapi\Mapping\Characters\SkillMapping;
 use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Eveapi\Models\Character\CharacterInfoSkill;
 use Seat\Eveapi\Models\Character\CharacterSkill;
@@ -74,7 +75,9 @@ class Skills extends AbstractAuthCharacterJob
 
         CharacterInfo::firstOrCreate(['character_id' => $this->getCharacterId()]);
 
-        CharacterInfoSkill::firstOrNew(['character_id' => $this->getCharacterId()])->fill([
+        CharacterInfoSkill::firstOrNew([
+            'character_id' => $this->getCharacterId(),
+        ])->fill([
             'total_sp'       => $character_skills->total_sp,
             'unallocated_sp' => property_exists($character_skills, 'unallocated_sp') ?
                 $character_skills->unallocated_sp : 0,
@@ -82,10 +85,16 @@ class Skills extends AbstractAuthCharacterJob
 
         collect($character_skills->skills)->each(function ($character_skill) {
 
-            CharacterSkill::updateOrCreate(
-                ['character_id' => $this->getCharacterId(), 'skill_id' => $character_skill->skill_id],
-                ['skillpoints_in_skill' => $character_skill->skillpoints_in_skill, 'trained_skill_level' => $character_skill->trained_skill_level, 'active_skill_level' => $character_skill->active_skill_level]
-            );
+            $model = CharacterSkill::firstOrNew([
+                'character_id' => $this->getCharacterId(),
+                'skill_id' => $character_skill->skill_id
+            ]);
+
+            SkillMapping::make($model, $character_skill, [
+                'character_id' => function () {
+                    return $this->getCharacterId();
+                },
+            ])->save();
         });
 
         // delete skills which have been removed

--- a/src/Jobs/Sovereignty/Structures.php
+++ b/src/Jobs/Sovereignty/Structures.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Sovereignty;
 
 use Seat\Eveapi\Jobs\EsiBase;
+use Seat\Eveapi\Mapping\Structures\SovereigntyStructureMapping;
 use Seat\Eveapi\Models\Sovereignty\SovereigntyStructure;
 
 /**
@@ -64,17 +65,14 @@ class Structures extends EsiBase
 
         collect($structures)->each(function ($structure) {
 
-            SovereigntyStructure::firstOrNew([
+            $model = SovereigntyStructure::firstOrNew([
                 'structure_id' => $structure->structure_id,
-            ])->fill([
-                'structure_type_id'             => $structure->structure_type_id,
-                'alliance_id'                   => $structure->alliance_id,
-                'solar_system_id'               => $structure->solar_system_id,
-                'vulnerability_occupancy_level' => $structure->vulnerability_occupancy_level ?? null,
-                'vulnerable_start_time'         => property_exists($structure, 'vulnerable_start_time') ?
-                    carbon($structure->vulnerable_start_time) : null,
-                'vulnerable_end_time'           => property_exists($structure, 'vulnerable_end_time') ?
-                    carbon($structure->vulnerable_end_time) : null,
+            ]);
+
+            SovereigntyStructureMapping::make($model, $structure, [
+                'structure_id' => function () use ($structure) {
+                    return $structure->structure_id;
+                },
             ])->save();
 
         });

--- a/src/Jobs/Universe/CharacterStructures.php
+++ b/src/Jobs/Universe/CharacterStructures.php
@@ -24,6 +24,7 @@ namespace Seat\Eveapi\Jobs\Universe;
 
 use Seat\Eseye\Exceptions\RequestFailedException;
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
+use Seat\Eveapi\Mapping\Structures\UniverseStructureMapping;
 use Seat\Eveapi\Models\Assets\CharacterAsset;
 use Seat\Eveapi\Models\Universe\UniverseStructure;
 
@@ -75,17 +76,15 @@ class CharacterStructures extends AbstractAuthCharacterJob implements IStructure
                     'structure_id' => $structure_id,
                 ]);
 
-                UniverseStructure::updateOrCreate([
+                $model = UniverseStructure::firstOrNew([
                     'structure_id' => $structure_id,
-                ], [
-                    'name'            => $structure->name,
-                    'owner_id'        => $structure->owner_id,
-                    'solar_system_id' => $structure->solar_system_id,
-                    'x'               => $structure->position->x,
-                    'y'               => $structure->position->y,
-                    'z'               => $structure->position->z,
-                    'type_id'         => $structure->type_id ?? null,
                 ]);
+
+                UniverseStructureMapping::make($model, $structure, [
+                    'structure_id' => function () use ($structure_id) {
+                        return $structure_id;
+                    },
+                ])->save();
 
             } catch (RequestFailedException $e) {
                 logger()->error('Unable to retrieve structure information.', [

--- a/src/Jobs/Universe/CorporationStructures.php
+++ b/src/Jobs/Universe/CorporationStructures.php
@@ -24,6 +24,7 @@ namespace Seat\Eveapi\Jobs\Universe;
 
 use Seat\Eseye\Exceptions\RequestFailedException;
 use Seat\Eveapi\Jobs\AbstractAuthCorporationJob;
+use Seat\Eveapi\Mapping\Structures\UniverseStructureMapping;
 use Seat\Eveapi\Models\Assets\CorporationAsset;
 use Seat\Eveapi\Models\Corporation\CorporationStructure;
 use Seat\Eveapi\Models\Universe\UniverseStructure;
@@ -81,17 +82,15 @@ class CorporationStructures extends AbstractAuthCorporationJob implements IStruc
                     'structure_id' => $structure_id,
                 ]);
 
-                UniverseStructure::updateOrCreate([
+                $model = UniverseStructure::firstOrNew([
                     'structure_id' => $structure_id,
-                ], [
-                    'name'            => $structure->name,
-                    'owner_id'        => $structure->owner_id,
-                    'solar_system_id' => $structure->solar_system_id,
-                    'x'               => $structure->position->x,
-                    'y'               => $structure->position->y,
-                    'z'               => $structure->position->z,
-                    'type_id'         => $structure->type_id ?? null,
                 ]);
+
+                UniverseStructureMapping::make($model, $structure, [
+                    'structure_id' => function () use ($structure_id) {
+                        return $structure_id;
+                    },
+                ])->save();
 
             } catch (RequestFailedException $e) {
                 logger()->error('Unable to retrieve structure information.', [

--- a/src/Jobs/Universe/Stations.php
+++ b/src/Jobs/Universe/Stations.php
@@ -24,6 +24,7 @@ namespace Seat\Eveapi\Jobs\Universe;
 
 use Seat\Eseye\Containers\EsiResponse;
 use Seat\Eveapi\Jobs\EsiBase;
+use Seat\Eveapi\Mapping\Structures\UniverseStationMapping;
 use Seat\Eveapi\Models\Universe\UniverseStation;
 use Seat\Eveapi\Models\Universe\UniverseStationService;
 
@@ -88,21 +89,14 @@ class Stations extends EsiBase
     private function updateStructure(EsiResponse $structure)
     {
 
-        UniverseStation::firstOrNew([
+        $model = UniverseStation::firstOrNew([
             'station_id' => $structure->station_id,
-        ])->fill([
-            'type_id'                    => $structure->type_id,
-            'name'                       => $structure->name,
-            'owner'                      => $structure->owner ?? null,
-            'race_id'                    => $structure->race_id ?? null,
-            'x'                          => $structure->position->x,
-            'y'                          => $structure->position->y,
-            'z'                          => $structure->position->z,
-            'system_id'                  => $structure->system_id,
-            'reprocessing_efficiency'    => $structure->reprocessing_efficiency,
-            'reprocessing_stations_take' => $structure->reprocessing_stations_take,
-            'max_dockable_ship_volume'   => $structure->max_dockable_ship_volume,
-            'office_rental_cost'         => $structure->office_rental_cost,
+        ]);
+
+        UniverseStationMapping::make($model, $structure, [
+            'station_id' => function () use ($structure) {
+                return $structure->station_id;
+            },
         ])->save();
 
         collect($structure->services)->each(function ($service) use ($structure) {

--- a/src/Jobs/Wallet/Character/Journal.php
+++ b/src/Jobs/Wallet/Character/Journal.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Wallet\Character;
 
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
+use Seat\Eveapi\Mapping\Financial\WalletJournalMapping;
 use Seat\Eveapi\Models\Wallet\CharacterWalletJournal;
 
 /**
@@ -123,22 +124,10 @@ class Journal extends AbstractAuthCharacterJob
                 if ($journal_entry->exists)
                     return;
 
-                $journal_entry->fill([
-                    'character_id'    => $this->getCharacterId(),
-                    'id'              => $entry->id,                         // changed from ref_id to id into v4
-                    'date'            => carbon($entry->date),
-                    'ref_type'        => $entry->ref_type,
-                    'first_party_id'  => $entry->first_party_id ?? null,
-                    'second_party_id' => $entry->second_party_id ?? null,
-                    'amount'          => $entry->amount ?? null,
-                    'balance'         => $entry->balance ?? null,
-                    'reason'          => $entry->reason ?? null,
-                    'tax_receiver_id' => $entry->tax_receiver_id ?? null,
-                    'tax'             => $entry->tax ?? null,
-                    // appears in version 4
-                    'description'     => $entry->description,
-                    'context_id'      => $entry->context_id ?? null,
-                    'context_id_type' => $entry->context_id_type ?? null,
+                WalletJournalMapping::make($journal_entry, $entry, [
+                    'character_id' => function () {
+                        return $this->getCharacterId();
+                    },
                 ])->save();
 
             });

--- a/src/Jobs/Wallet/Character/Transactions.php
+++ b/src/Jobs/Wallet/Character/Transactions.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Jobs\Wallet\Character;
 
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
+use Seat\Eveapi\Mapping\Financial\WalletTransactionMapping;
 use Seat\Eveapi\Models\Wallet\CharacterWalletTransaction;
 
 /**
@@ -61,7 +62,7 @@ class Transactions extends AbstractAuthCharacterJob
      *
      * @var int
      */
-    protected $from_id = PHP_INT_MAX;
+    protected $from_id = 0;
 
     /**
      * Execute the job.
@@ -102,16 +103,13 @@ class Transactions extends AbstractAuthCharacterJob
                 if ($transaction_entry->exists)
                     return;
 
-                $transaction_entry->fill([
-                    'date'           => carbon($transaction->date),
-                    'type_id'        => $transaction->type_id,
-                    'location_id'    => $transaction->location_id,
-                    'unit_price'     => $transaction->unit_price,
-                    'quantity'       => $transaction->quantity,
-                    'client_id'      => $transaction->client_id,
-                    'is_buy'         => $transaction->is_buy,
-                    'is_personal'    => $transaction->is_personal,
-                    'journal_ref_id' => $transaction->journal_ref_id,
+                WalletTransactionMapping::make($transaction_entry, $transaction, [
+                    'character_id' => function () {
+                        return $this->getCharacterId();
+                    },
+                    'is_personal' => function () use ($transaction) {
+                        return $transaction->is_personal;
+                    },
                 ])->save();
             });
 

--- a/src/Mapping/Alliances/InfoMapping.php
+++ b/src/Mapping/Alliances/InfoMapping.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Alliances;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class InfoMapping.
+ * @package Seat\Eveapi\Mapping\Alliances
+ */
+class InfoMapping extends DataMapping
+{
+    /**
+     * @var string[]
+     */
+    protected static $mapping = [
+        'name' => 'name',
+        'creator_id' => 'creator_id',
+        'creator_corporation_id' => 'creator_corporation_id',
+        'ticker' => 'ticker',
+        'executor_corporation_id' => 'executor_corporation_id',
+        'date_founded' => 'date_founded',
+        'faction_id' => 'faction_id',
+    ];
+}

--- a/src/Mapping/Alliances/InfoMapping.php
+++ b/src/Mapping/Alliances/InfoMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Alliances;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Assets/AssetMapping.php
+++ b/src/Mapping/Assets/AssetMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Assets;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Assets/AssetMapping.php
+++ b/src/Mapping/Assets/AssetMapping.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Assets;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class AssetMapping.
+ * @package Seat\Eveapi\Mapping\Assets
+ */
+class AssetMapping extends DataMapping
+{
+    /**
+     * @var string[]
+     */
+    protected static $mapping = [
+        'item_id' => 'item_id',
+        'type_id' => 'type_id',
+        'quantity' => 'quantity',
+        'location_id' => 'location_id',
+        'location_type' => 'location_type',
+        'location_flag' => 'location_flag',
+        'is_singleton' => 'is_singleton',
+    ];
+}

--- a/src/Mapping/Assets/ContainerLogsMapping.php
+++ b/src/Mapping/Assets/ContainerLogsMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Assets;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Assets/ContainerLogsMapping.php
+++ b/src/Mapping/Assets/ContainerLogsMapping.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Assets;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class ContainerLogsMapping.
+ * @package Seat\Eveapi\Mapping\Assets
+ */
+class ContainerLogsMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'container_id'       => 'container_id',
+        'logged_at'          => 'logged_at',
+        'container_type_id'  => 'container_type_id',
+        'character_id'       => 'character_id',
+        'location_id'        => 'location_id',
+        'action'             => 'action',
+        'location_flag'      => 'location_flag',
+        'password_type'      => 'password_type',
+        'type_id'            => 'type_id',
+        'quantity'           => 'quantity',
+        'old_config_bitmask' => 'old_config_bitmask',
+        'new_config_bitmask' => 'new_config_bitmask',
+    ];
+}

--- a/src/Mapping/Characters/CalendarDetailMapping.php
+++ b/src/Mapping/Characters/CalendarDetailMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Characters;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Characters/CalendarDetailMapping.php
+++ b/src/Mapping/Characters/CalendarDetailMapping.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Characters;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class CalendarDetailMapping.
+ * @package Seat\Eveapi\Mapping\Characters
+ */
+class CalendarDetailMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'owner_id' => 'owner_id',
+        'owner_name' => 'owner_name',
+        'duration' => 'duration',
+        'text' => 'text',
+        'owner_type' => 'owner_type',
+    ];
+}

--- a/src/Mapping/Characters/CalendarEventMapping.php
+++ b/src/Mapping/Characters/CalendarEventMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Characters;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Characters/CalendarEventMapping.php
+++ b/src/Mapping/Characters/CalendarEventMapping.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Characters;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class CalendarEventMapping.
+ * @package Seat\Eveapi\Mapping\Characters
+ */
+class CalendarEventMapping extends DataMapping
+{
+    /**
+     * @var string[]
+     */
+    protected static $mapping = [
+        'event_id'       => 'event_id',
+        'event_date'     => 'event_date',
+        'title'          => 'title',
+        'importance'     => 'importance',
+        'event_response' => 'event_response',
+    ];
+}

--- a/src/Mapping/Characters/CharacterAttributesMapping.php
+++ b/src/Mapping/Characters/CharacterAttributesMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Characters;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Characters/CharacterAttributesMapping.php
+++ b/src/Mapping/Characters/CharacterAttributesMapping.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Characters;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class CharacterAttributesMapping.
+ * @package Seat\Eveapi\Mapping\Characters
+ */
+class CharacterAttributesMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'charisma'                    => 'charisma',
+        'intelligence'                => 'intelligence',
+        'memory'                      => 'memory',
+        'perception'                  => 'perception',
+        'willpower'                   => 'willpower',
+        'bonus_remaps'                => 'bonus_remaps',
+        'last_remap_date'             => 'last_remap_date',
+        'accrued_remap_cooldown_date' => 'accrued_remap_cooldown_date',
+    ];
+}

--- a/src/Mapping/Characters/InfoMapping.php
+++ b/src/Mapping/Characters/InfoMapping.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Characters;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class InfoMapping.
+ * @package Seat\Eveapi\Mapping\Characters
+ */
+class InfoMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'name'            => 'name',
+        'description'     => 'description',
+        'birthday'        => 'birthday',
+        'gender'          => 'gender',
+        'race_id'         => 'race_id',
+        'bloodline_id'    => 'bloodline_id',
+        'ancestry_id'     => 'ancestry_id',
+        'security_status' => 'security_status',
+    ];
+}

--- a/src/Mapping/Characters/InfoMapping.php
+++ b/src/Mapping/Characters/InfoMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Characters;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Characters/MedalsMapping.php
+++ b/src/Mapping/Characters/MedalsMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Characters;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Characters/MedalsMapping.php
+++ b/src/Mapping/Characters/MedalsMapping.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Characters;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class MedalsMapping.
+ * @package Seat\Eveapi\Mapping\Characters
+ */
+class MedalsMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'medal_id'       => 'medal_id',
+        'title'          => 'title',
+        'description'    => 'description',
+        'corporation_id' => 'corporation_id',
+        'issuer_id'      => 'issuer_id',
+        'date'           => 'date',
+        'reason'         => 'reason',
+        'status'         => 'status',
+    ];
+}

--- a/src/Mapping/Characters/NotificationMapping.php
+++ b/src/Mapping/Characters/NotificationMapping.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Characters;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class NotificationMapping.
+ * @package Seat\Eveapi\Mapping\Characters
+ */
+class NotificationMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'notification_id' => 'notification_id',
+        'type'            => 'type',
+        'sender_id'       => 'sender_id',
+        'sender_type'     => 'sender_type',
+        'timestamp'       => 'timestamp',
+        'is_read'         => 'is_read',
+        'text'            => 'text',
+    ];
+}

--- a/src/Mapping/Characters/NotificationMapping.php
+++ b/src/Mapping/Characters/NotificationMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Characters;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Characters/SkillMapping.php
+++ b/src/Mapping/Characters/SkillMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Characters;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Characters/SkillMapping.php
+++ b/src/Mapping/Characters/SkillMapping.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Characters;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class SkillMapping.
+ * @package Seat\Eveapi\Mapping\Characters
+ */
+class SkillMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'skill_id'             => 'skill_id',
+        'skillpoints_in_skill' => 'skillpoints_in_skill',
+        'trained_skill_level'  => 'trained_skill_level',
+        'active_skill_level'   => 'active_skill_level',
+    ];
+}

--- a/src/Mapping/Characters/SkillQueueMapping.php
+++ b/src/Mapping/Characters/SkillQueueMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Characters;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Characters/SkillQueueMapping.php
+++ b/src/Mapping/Characters/SkillQueueMapping.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Characters;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class SkillQueueMapping.
+ * @package Seat\Eveapi\Mapping\Characters
+ */
+class SkillQueueMapping extends DataMapping
+{
+    /**
+     * @var string[]
+     */
+    protected static $mapping = [
+        'skill_id'          => 'skill_id',
+        'queue_position'    => 'queue_position',
+        'finish_date'       => 'finish_date',
+        'start_date'        => 'start_date',
+        'finished_level'    => 'finished_level',
+        'training_start_sp' => 'training_start_sp',
+        'level_end_sp'      => 'level_end_sp',
+        'level_start_sp'    => 'level_start_sp',
+    ];
+}

--- a/src/Mapping/Corporations/InfoMapping.php
+++ b/src/Mapping/Corporations/InfoMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Corporations;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Corporations/InfoMapping.php
+++ b/src/Mapping/Corporations/InfoMapping.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Corporations;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class InfoMapping.
+ * @package Seat\Eveapi\Mapping\Corporations
+ */
+class InfoMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'name'            => 'name',
+        'ticker'          => 'ticker',
+        'member_count'    => 'member_count',
+        'ceo_id'          => 'ceo_id',
+        'alliance_id'     => 'alliance_id',
+        'description'     => 'description',
+        'tax_rate'        => 'tax_rate',
+        'date_founded'    => 'date_founded',
+        'creator_id'      => 'creator_id',
+        'url'             => 'url',
+        'faction_id'      => 'faction_id',
+        'home_station_id' => 'home_station_id',
+        'shares'          => 'shares',
+    ];
+}

--- a/src/Mapping/DataMapping.php
+++ b/src/Mapping/DataMapping.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Seat\Eveapi\Mapping;
+
+use Closure;
+use Flow\JSONPath\JSONPath;
+use Flow\JSONPath\JSONPathException;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class DataMapping.
+ * @package Seat\Eveapi\Mapping
+ */
+abstract class DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        // target model property => source data field
+    ];
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param $data
+     * @param array $overrides
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public static function make(Model $model, $data, array $overrides = []): Model
+    {
+        // merge both mapping and overrides to build final mapping rules
+        $rules = array_merge(static::$mapping, $overrides);
+
+        // prepare a JSON Query navigator
+        $json_path = new JSONPath($data);
+
+        // loop over rules and apply data mapping
+        foreach ($rules as $model_field => $source_field) {
+
+            // if source field is a closure, apply its business logic
+            if ($source_field instanceof Closure) {
+                $model->{$model_field} = $source_field();
+            } else {
+                try {
+                    $model->{$model_field} = $json_path->find($source_field)->first();
+                } catch (JSONPathException $e) {
+                    $model->{$model_field} = null;
+
+                    logger()->error($e->getMessage(), $e->getTrace());
+                }
+            }
+        }
+
+        return $model;
+    }
+}

--- a/src/Mapping/DataMapping.php
+++ b/src/Mapping/DataMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping;
 
 use Closure;

--- a/src/Mapping/Financial/OrderMapping.php
+++ b/src/Mapping/Financial/OrderMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Financial;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Financial/OrderMapping.php
+++ b/src/Mapping/Financial/OrderMapping.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Financial;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class OrderMapping.
+ * @package Seat\Eveapi\Mapping\Financial
+ */
+class OrderMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'order_id'        => 'order_id',
+        'type_id'         => 'type_id',
+        'region_id'       => 'region_id',
+        'location_id'     => 'location_id',
+        'range'           => 'range',
+        'is_buy_order'    => 'is_buy_order',
+        'price'           => 'price',
+        'volume_total'    => 'volume_total',
+        'volume_remain'   => 'volume_remain',
+        'issued'          => 'issued',
+        'min_volume'      => 'min_volume',
+        'duration'        => 'duration',
+        'escrow'          => 'escrow',
+    ];
+}

--- a/src/Mapping/Financial/WalletJournalMapping.php
+++ b/src/Mapping/Financial/WalletJournalMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Financial;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Financial/WalletJournalMapping.php
+++ b/src/Mapping/Financial/WalletJournalMapping.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Financial;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class WalletJournalMapping.
+ * @package Seat\Eveapi\Mapping\Financial
+ */
+class WalletJournalMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'id'              => 'id',                         // changed from ref_id to id into v4
+        'date'            => 'date',
+        'ref_type'        => 'ref_type',
+        'first_party_id'  => 'first_party_id',
+        'second_party_id' => 'second_party_id',
+        'amount'          => 'amount',
+        'balance'         => 'balance',
+        'reason'          => 'reason',
+        'tax_receiver_id' => 'tax_receiver_id',
+        'tax'             => 'tax',
+        // appears in version 4
+        'description'     => 'description',
+        'context_id'      => 'context_id',
+        'context_id_type' => 'context_id_type',
+    ];
+}

--- a/src/Mapping/Financial/WalletTransactionMapping.php
+++ b/src/Mapping/Financial/WalletTransactionMapping.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Financial;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class WalletTransactionMapping.
+ * @package Seat\Eveapi\Mapping\Financial
+ */
+class WalletTransactionMapping extends DataMapping
+{
+    /**
+     * @var string[]
+     */
+    protected static $mapping = [
+        'transaction_id' => 'transaction_id',
+        'date'           => 'date',
+        'type_id'        => 'type_id',
+        'location_id'    => 'location_id',
+        'unit_price'     => 'unit_price',
+        'quantity'       => 'quantity',
+        'client_id'      => 'client_id',
+        'is_buy'         => 'is_buy',
+        'journal_ref_id' => 'journal_ref_id',
+    ];
+}

--- a/src/Mapping/Financial/WalletTransactionMapping.php
+++ b/src/Mapping/Financial/WalletTransactionMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Financial;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Industry/AgentResearchMapping.php
+++ b/src/Mapping/Industry/AgentResearchMapping.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Industry;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class AgentResearchMapping.
+ * @package Seat\Eveapi\Mapping\Industry
+ */
+class AgentResearchMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'agent_id'         => 'agent_id',
+        'skill_type_id'    => 'skill_type_id',
+        'started_at'       => 'started_at',
+        'points_per_day'   => 'points_per_day',
+        'remainder_points' => 'remainder_points',
+    ];
+}

--- a/src/Mapping/Industry/AgentResearchMapping.php
+++ b/src/Mapping/Industry/AgentResearchMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Industry;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Industry/BlueprintMapping.php
+++ b/src/Mapping/Industry/BlueprintMapping.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Industry;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class BlueprintMapping.
+ * @package Seat\Eveapi\Mapping\Industry
+ */
+class BlueprintMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'item_id'             => 'item_id',
+        'type_id'             => 'type_id',
+        'location_flag'       => 'location_flag',
+        'location_id'         => 'location_id',
+        'quantity'            => 'quantity',
+        'time_efficiency'     => 'time_efficiency',
+        'material_efficiency' => 'material_efficiency',
+        'runs'                => 'runs',
+    ];
+}

--- a/src/Mapping/Industry/BlueprintMapping.php
+++ b/src/Mapping/Industry/BlueprintMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Industry;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Industry/ExtractionMapping.php
+++ b/src/Mapping/Industry/ExtractionMapping.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Industry;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class ExtractionMapping.
+ * @package Seat\Eveapi\Mapping\Industry
+ */
+class ExtractionMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'moon_id'               => 'moon_id',
+        'structure_id'          => 'structure_id',
+        'extraction_start_time' => 'extraction_start_time',
+        'chunk_arrival_time'    => 'chunk_arrival_time',
+        'natural_decay_time'    => 'natural_decay_time',
+    ];
+}

--- a/src/Mapping/Industry/ExtractionMapping.php
+++ b/src/Mapping/Industry/ExtractionMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Industry;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Industry/JobMapping.php
+++ b/src/Mapping/Industry/JobMapping.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Industry;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class JobMapping.
+ * @package Seat\Eveapi\Mapping\Industry
+ */
+class JobMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'job_id'                 => 'job_id',
+        'installer_id'           => 'installer_id',
+        'facility_id'            => 'facility_id',
+        'activity_id'            => 'activity_id',
+        'blueprint_id'           => 'blueprint_id',
+        'blueprint_type_id'      => 'blueprint_type_id',
+        'blueprint_location_id'  => 'blueprint_location_id',
+        'output_location_id'     => 'output_location_id',
+        'runs'                   => 'runs',
+        'cost'                   => 'cost',
+        'licensed_runs'          => 'licensed_runs',
+        'probability'            => 'probability',
+        'product_type_id'        => 'product_type_id',
+        'status'                 => 'status',
+        'duration'               => 'duration',
+        'start_date'             => 'start_date',
+        'end_date'               => 'end_date',
+        'pause_date'             => 'pause_date',
+        'completed_date'         => 'completed_date',
+        'completed_character_id' => 'completed_character_id',
+        'successful_runs'        => 'successful_runs',
+    ];
+}

--- a/src/Mapping/Industry/JobMapping.php
+++ b/src/Mapping/Industry/JobMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Industry;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Killmails/AttackerMapping.php
+++ b/src/Mapping/Killmails/AttackerMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Killmails;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Killmails/AttackerMapping.php
+++ b/src/Mapping/Killmails/AttackerMapping.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Killmails;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class AttackerMapping.
+ * @package Seat\Eveapi\Mapping\Killmails
+ */
+class AttackerMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'character_id'    => 'character_id',
+        'corporation_id'  => 'corporation_id',
+        'alliance_id'     => 'alliance_id',
+        'faction_id'      => 'faction_id',
+        'security_status' => 'security_status',
+        'final_blow'      => 'final_blow',
+        'damage_done'     => 'damage_done',
+        'ship_type_id'    => 'ship_type_id',
+        'weapon_type_id'  => 'weapon_type_id',
+    ];
+}

--- a/src/Mapping/Killmails/VictimMapping.php
+++ b/src/Mapping/Killmails/VictimMapping.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Killmails;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class VictimMapping.
+ * @package Seat\Eveapi\Mapping\Killmails
+ */
+class VictimMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'character_id'   => 'character_id',
+        'corporation_id' => 'corporation_id',
+        'alliance_id'    => 'alliance_id',
+        'faction_id'     => 'faction_id',
+        'damage_taken'   => 'damage_taken',
+        'ship_type_id'   => 'ship_type_id',
+        'x'              => 'position.x',
+        'y'              => 'position.y',
+        'z'              => 'position.z',
+    ];
+}

--- a/src/Mapping/Killmails/VictimMapping.php
+++ b/src/Mapping/Killmails/VictimMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Killmails;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Structures/CorporationStructureMapping.php
+++ b/src/Mapping/Structures/CorporationStructureMapping.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Structures;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class CorporationStructureMapping.
+ * @package Seat\Eveapi\Mapping\Structures
+ */
+class CorporationStructureMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'structure_id'           => 'structure_id',
+        'corporation_id'         => 'corporation_id',
+        'type_id'                => 'type_id',
+        'system_id'              => 'system_id',
+        'profile_id'             => 'profile_id',
+        'fuel_expires'           => 'fuel_expires',
+        'state_timer_start'      => 'state_timer_start',
+        'state_timer_end'        => 'state_timer_end',
+        'unanchors_at'           => 'unanchors_at',
+        'state'                  => 'state',
+        'reinforce_weekday'      => 'reinforce_weekday',
+        'reinforce_hour'         => 'reinforce_hour',
+        'next_reinforce_weekday' => 'next_reinforce_weekday',
+        'next_reinforce_hour'    => 'next_reinforce_hour',
+        'next_reinforce_apply'   => 'next_reinforce_apply',
+    ];
+}

--- a/src/Mapping/Structures/CorporationStructureMapping.php
+++ b/src/Mapping/Structures/CorporationStructureMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Structures;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Structures/CustomsOfficeMapping.php
+++ b/src/Mapping/Structures/CustomsOfficeMapping.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Structures;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class CustomsOfficeMapping.
+ * @package Seat\Eveapi\Mapping\Structures
+ */
+class CustomsOfficeMapping extends DataMapping
+{
+    /**
+     * @var string[]
+     */
+    protected static $mapping = [
+        'office_id'                   => 'office_id',
+        'system_id'                   => 'system_id',
+        'reinforce_exit_start'        => 'reinforce_exit_start',
+        'reinforce_exit_end'          => 'reinforce_exit_end',
+        'corporation_tax_rate'        => 'corporation_tax_rate',
+        'allow_alliance_access'       => 'allow_alliance_access',
+        'alliance_tax_rate'           => 'alliance_tax_rate',
+        'allow_access_with_standings' => 'allow_access_with_standings',
+        'standing_level'              => 'standing_level',
+        'excellent_standing_tax_rate' => 'excellent_standing_tax_rate',
+        'good_standing_tax_rate'      => 'good_standing_tax_rate',
+        'neutral_standing_tax_rate'   => 'neutral_standing_tax_rate',
+        'bad_standing_tax_rate'       => 'bad_standing_tax_rate',
+        'terrible_standing_tax_rate'  => 'terrible_standing_tax_rate',
+    ];
+}

--- a/src/Mapping/Structures/CustomsOfficeMapping.php
+++ b/src/Mapping/Structures/CustomsOfficeMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Structures;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Structures/SovereigntyStructureMapping.php
+++ b/src/Mapping/Structures/SovereigntyStructureMapping.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Structures;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class SovereigntyStructureMapping.
+ * @package Seat\Eveapi\Mapping\Structures
+ */
+class SovereigntyStructureMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'structure_type_id'             => 'structure_type_id',
+        'alliance_id'                   => 'alliance_id',
+        'solar_system_id'               => 'solar_system_id',
+        'vulnerability_occupancy_level' => 'vulnerability_occupancy_level',
+        'vulnerable_start_time'         => 'vulnerable_start_time',
+        'vulnerable_end_time'           => 'vulnerable_end_time',
+    ];
+}

--- a/src/Mapping/Structures/SovereigntyStructureMapping.php
+++ b/src/Mapping/Structures/SovereigntyStructureMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Structures;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Structures/StarbaseDetailMapping.php
+++ b/src/Mapping/Structures/StarbaseDetailMapping.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Structures;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class StarbaseDetailMapping.
+ * @package Seat\Eveapi\Mapping\Structures
+ */
+class StarbaseDetailMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'fuel_bay_view'                            => 'fuel_bay_view',
+        'fuel_bay_take'                            => 'fuel_bay_take',
+        'anchor'                                   => 'anchor',
+        'unanchor'                                 => 'unanchor',
+        'online'                                   => 'online',
+        'offline'                                  => 'offline',
+        'allow_corporation_members'                => 'allow_corporation_members',
+        'allow_alliance_members'                   => 'allow_alliance_members',
+        'use_alliance_standings'                   => 'use_alliance_standings',
+        'attack_standing_threshold'                => 'attack_standing_threshold',
+        'attack_security_status_threshold'         => 'attack_security_status_threshold',
+        'attack_if_other_security_status_dropping' => 'attack_if_other_security_status_dropping',
+        'attack_if_at_war'                         => 'attack_if_at_war',
+    ];
+}

--- a/src/Mapping/Structures/StarbaseDetailMapping.php
+++ b/src/Mapping/Structures/StarbaseDetailMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Structures;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Structures/StarbaseMapping.php
+++ b/src/Mapping/Structures/StarbaseMapping.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Structures;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class StarbaseMapping.
+ * @package Seat\Eveapi\Mapping\Structures
+ */
+class StarbaseMapping extends DataMapping
+{
+    /**
+     * @var string[]
+     */
+    protected static $mapping = [
+        'starbase_id'      => 'starbase_id',
+        'moon_id'          => 'moon_id',
+        'onlined_since'    => 'onlined_since',
+        'reinforced_until' => 'reinforced_until',
+        'state'            => 'state',
+        'type_id'          => 'type_id',
+        'system_id'        => 'system_id',
+        'unanchor_at'      => 'unanchor_at',
+    ];
+}

--- a/src/Mapping/Structures/StarbaseMapping.php
+++ b/src/Mapping/Structures/StarbaseMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Structures;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Structures/UniverseStationMapping.php
+++ b/src/Mapping/Structures/UniverseStationMapping.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Structures;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class UniverseStationMapping.
+ * @package Seat\Eveapi\Mapping\Structures
+ */
+class UniverseStationMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'type_id'                    => 'type_id',
+        'name'                       => 'name',
+        'owner'                      => 'owner',
+        'race_id'                    => 'race_id',
+        'x'                          => 'position.x',
+        'y'                          => 'position.y',
+        'z'                          => 'position.z',
+        'system_id'                  => 'system_id',
+        'reprocessing_efficiency'    => 'reprocessing_efficiency',
+        'reprocessing_stations_take' => 'reprocessing_stations_take',
+        'max_dockable_ship_volume'   => 'max_dockable_ship_volume',
+        'office_rental_cost'         => 'office_rental_cost',
+    ];
+}

--- a/src/Mapping/Structures/UniverseStationMapping.php
+++ b/src/Mapping/Structures/UniverseStationMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Structures;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Mapping/Structures/UniverseStructureMapping.php
+++ b/src/Mapping/Structures/UniverseStructureMapping.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seat\Eveapi\Mapping\Structures;
+
+use Seat\Eveapi\Mapping\DataMapping;
+
+/**
+ * Class UniverseStructureMapping.
+ * @package Seat\Eveapi\Mapping\Structures
+ */
+class UniverseStructureMapping extends DataMapping
+{
+    /**
+     * @var array
+     */
+    protected static $mapping = [
+        'name'            => 'name',
+        'owner_id'        => 'owner_id',
+        'solar_system_id' => 'solar_system_id',
+        'x'               => 'position.x',
+        'y'               => 'position.y',
+        'z'               => 'position.z',
+        'type_id'         => 'type_id',
+    ];
+}

--- a/src/Mapping/Structures/UniverseStructureMapping.php
+++ b/src/Mapping/Structures/UniverseStructureMapping.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Mapping\Structures;
 
 use Seat\Eveapi\Mapping\DataMapping;

--- a/src/Models/Alliances/Alliance.php
+++ b/src/Models/Alliances/Alliance.php
@@ -49,4 +49,12 @@ class Alliance extends Model
      * @var string
      */
     protected $primaryKey = 'alliance_id';
+
+    /**
+     * @param $value
+     */
+    public function setDateFoundedAttribute($value)
+    {
+        $this->attributes['date_founded'] = is_null($value) ? null : carbon($value);
+    }
 }

--- a/src/Models/Calendar/CharacterCalendarEvent.php
+++ b/src/Models/Calendar/CharacterCalendarEvent.php
@@ -36,6 +36,14 @@ class CharacterCalendarEvent extends Model
     protected static $unguarded = true;
 
     /**
+     * @param $value
+     */
+    public function setEventDateAttribute($value)
+    {
+        $this->attributes['event_date'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
     public function detail()

--- a/src/Models/Character/CharacterAgentResearch.php
+++ b/src/Models/Character/CharacterAgentResearch.php
@@ -38,6 +38,14 @@ class CharacterAgentResearch extends Model
     protected static $unguarded = true;
 
     /**
+     * @param $value
+     */
+    public function setStartedAtAttribute($value)
+    {
+        $this->attributes['started_at'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
     public function agent()

--- a/src/Models/Character/CharacterMedal.php
+++ b/src/Models/Character/CharacterMedal.php
@@ -35,4 +35,12 @@ class CharacterMedal extends Model
      * @var bool
      */
     protected static $unguarded = true;
+
+    /**
+     * @param $value
+     */
+    public function setDateAttribute($value)
+    {
+        $this->attributes['date'] = is_null($value) ? null : carbon($value);
+    }
 }

--- a/src/Models/Character/CharacterNotification.php
+++ b/src/Models/Character/CharacterNotification.php
@@ -145,6 +145,14 @@ class CharacterNotification extends Model
     }
 
     /**
+     * @param $value
+     */
+    public function setTimestampAttribute($value)
+    {
+        $this->attributes['timestamp'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function recipient()

--- a/src/Models/Corporation/CorporationContainerLog.php
+++ b/src/Models/Corporation/CorporationContainerLog.php
@@ -42,4 +42,12 @@ class CorporationContainerLog extends Model
      * @var array
      */
     protected $primaryKey = ['corporation_id', 'container_id', 'logged_at'];
+
+    /**
+     * @param $value
+     */
+    public function setLoggedAtAttribute($value)
+    {
+        $this->attributes['logged_at'] = is_null($value) ? null : carbon($value);
+    }
 }

--- a/src/Models/Corporation/CorporationInfo.php
+++ b/src/Models/Corporation/CorporationInfo.php
@@ -150,6 +150,14 @@ class CorporationInfo extends Model
     protected $primaryKey = 'corporation_id';
 
     /**
+     * @param $value
+     */
+    public function setDateFoundedAttribute($value)
+    {
+        $this->attributes['date_founded'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
      * @param \Illuminate\Database\Eloquent\Builder $query
      * @return \Illuminate\Database\Eloquent\Builder
      */

--- a/src/Models/Corporation/CorporationStarbase.php
+++ b/src/Models/Corporation/CorporationStarbase.php
@@ -100,6 +100,30 @@ class CorporationStarbase extends Model
     }
 
     /**
+     * @param $value
+     */
+    public function setOnlinedSinceAttribute($value)
+    {
+        $this->attributes['onlined_since'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setReinforcedUntilAttribute($value)
+    {
+        $this->attributes['reinforced_until'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setUnanchorAtAttribute($value)
+    {
+        $this->attributes['unanchor_at'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
     public function detail()

--- a/src/Models/Corporation/CorporationStarbaseDetail.php
+++ b/src/Models/Corporation/CorporationStarbaseDetail.php
@@ -43,5 +43,4 @@ class CorporationStarbaseDetail extends Model
      * @var array
      */
     protected $primaryKey = ['corporation_id', 'starbase_id'];
-
 }

--- a/src/Models/Corporation/CorporationStructure.php
+++ b/src/Models/Corporation/CorporationStructure.php
@@ -54,54 +54,6 @@ class CorporationStructure extends Model
     public $incrementing = false;
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
-     */
-    public function info()
-    {
-
-        return $this->hasOne(UniverseStructure::class, 'structure_id', 'structure_id')
-            ->withDefault([
-                'name' => trans('web::seat.unknown'),
-            ]);
-    }
-
-    /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
-     */
-    public function services()
-    {
-
-        return $this->hasMany(CorporationStructureService::class, 'structure_id', 'structure_id');
-    }
-
-    /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
-     */
-    public function type()
-    {
-
-        return $this->hasOne(InvType::class, 'typeID', 'type_id');
-    }
-
-    /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
-     */
-    public function solar_system()
-    {
-        return $this->hasOne(SolarSystem::class, 'system_id', 'system_id');
-    }
-
-    /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
-     */
-    public function items()
-    {
-
-        return $this->hasMany(CorporationAsset::class,
-            'location_id', 'structure_id');
-    }
-
-    /**
      * @return \Illuminate\Support\Collection
      */
     public function getHighSlotsAttribute()
@@ -213,8 +165,8 @@ class CorporationStructure extends Model
     public function getEstimatedPriceAttribute()
     {
         return $this->type->price->average + $this->items->sum(function ($item) {
-            return $item->type->price->average * $item->quantity;
-        });
+                return $item->type->price->average * $item->quantity;
+            });
     }
 
     /**
@@ -225,6 +177,94 @@ class CorporationStructure extends Model
         return $this->items->sum(function ($item) {
             return $item->type->price->average * $item->quantity;
         });
+    }
+
+    /**
+     * @param $value
+     */
+    public function setFuelExpiresAttribute($value)
+    {
+        $this->attributes['fuel_expires'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setStateTimerStartAttribute($value)
+    {
+        $this->attributes['state_timer_start'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setStateTimerEndAttribute($value)
+    {
+        $this->attributes['state_timer_end'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setUnanchorsAtAttribute($value)
+    {
+        $this->attributes['unanchors_at'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setNextReinforceApplyAttribute($value)
+    {
+        $this->attributes['next_reinforce_apply'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function info()
+    {
+
+        return $this->hasOne(UniverseStructure::class, 'structure_id', 'structure_id')
+            ->withDefault([
+                'name' => trans('web::seat.unknown'),
+            ]);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function services()
+    {
+
+        return $this->hasMany(CorporationStructureService::class, 'structure_id', 'structure_id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function type()
+    {
+
+        return $this->hasOne(InvType::class, 'typeID', 'type_id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function solar_system()
+    {
+        return $this->hasOne(SolarSystem::class, 'system_id', 'system_id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function items()
+    {
+
+        return $this->hasMany(CorporationAsset::class,
+            'location_id', 'structure_id');
     }
 
     /**

--- a/src/Models/Industry/CharacterIndustryJob.php
+++ b/src/Models/Industry/CharacterIndustryJob.php
@@ -205,6 +205,38 @@ class CharacterIndustryJob extends Model
     public $incrementing = false;
 
     /**
+     * @param $value
+     */
+    public function setStartDateAttribute($value)
+    {
+        $this->attributes['start_date'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setPauseDateAttribute($value)
+    {
+        $this->attributes['pause_date'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setEndDateAttribute($value)
+    {
+        $this->attributes['end_date'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setCompletedDateAttribute($value)
+    {
+        $this->attributes['completed_date'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
     public function activity()

--- a/src/Models/Industry/CorporationIndustryJob.php
+++ b/src/Models/Industry/CorporationIndustryJob.php
@@ -205,6 +205,38 @@ class CorporationIndustryJob extends Model
     public $incrementing = false;
 
     /**
+     * @param $value
+     */
+    public function setStartDateAttribute($value)
+    {
+        $this->attributes['start_date'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setPauseDateAttribute($value)
+    {
+        $this->attributes['pause_date'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setEndDateAttribute($value)
+    {
+        $this->attributes['end_date'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setCompletedDateAttribute($value)
+    {
+        $this->attributes['completed_date'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
     public function activity()

--- a/src/Models/Industry/CorporationIndustryMiningExtraction.php
+++ b/src/Models/Industry/CorporationIndustryMiningExtraction.php
@@ -71,6 +71,30 @@ class CorporationIndustryMiningExtraction extends Model
     }
 
     /**
+     * @param $value
+     */
+    public function setExtractionStartTimeAttribute($value)
+    {
+        $this->attributes['extraction_start_time'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setChunkArrivalTimeAttribute($value)
+    {
+        $this->attributes['chunk_arrival_time'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setNaturalDecayTimeAttribute($value)
+    {
+        $this->attributes['natural_decay_time'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function moon()

--- a/src/Models/Market/CharacterOrder.php
+++ b/src/Models/Market/CharacterOrder.php
@@ -147,6 +147,14 @@ class CharacterOrder extends Model
     protected static $unguarded = true;
 
     /**
+     * @param $value
+     */
+    public function setIssuedAttribute($value)
+    {
+        $this->attributes['issued'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
     public function location()

--- a/src/Models/Market/CorporationOrder.php
+++ b/src/Models/Market/CorporationOrder.php
@@ -155,6 +155,14 @@ class CorporationOrder extends Model
     protected static $unguarded = true;
 
     /**
+     * @param $value
+     */
+    public function setIssuedAttribute($value)
+    {
+        $this->attributes['issued'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
     public function location()

--- a/src/Models/PlanetaryInteraction/CorporationCustomsOffice.php
+++ b/src/Models/PlanetaryInteraction/CorporationCustomsOffice.php
@@ -48,6 +48,22 @@ class CorporationCustomsOffice extends Model
     public $incrementing = false;
 
     /**
+     * @param $value
+     */
+    public function setReinforceExitStartAttribute($value)
+    {
+        $this->attributes['reinforce_exit_start'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setReinforceExitEndAttribute($value)
+    {
+        $this->attributes['reinforce_exit_end'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function planet()

--- a/src/Models/Skills/CharacterAttribute.php
+++ b/src/Models/Skills/CharacterAttribute.php
@@ -46,4 +46,19 @@ class CharacterAttribute extends Model
      */
     protected $primaryKey = 'character_id';
 
+    /**
+     * @param $value
+     */
+    public function setLastRemapDateAttribute($value)
+    {
+        $this->attributes['last_remap_date'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setAccruedRemapCooldownDateAttribute($value)
+    {
+        $this->attributes['accrued_remap_cooldown_date'] = is_null($value) ? null : carbon($value);
+    }
 }

--- a/src/Models/Skills/CharacterSkillQueue.php
+++ b/src/Models/Skills/CharacterSkillQueue.php
@@ -97,6 +97,22 @@ class CharacterSkillQueue extends Model
     protected static $unguarded = true;
 
     /**
+     * @param $value
+     */
+    public function setStartDateAttribute($value)
+    {
+        $this->attributes['start_date'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setFinishDateAttribute($value)
+    {
+        $this->attributes['finish_date'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function type()

--- a/src/Models/Sovereignty/SovereigntyStructure.php
+++ b/src/Models/Sovereignty/SovereigntyStructure.php
@@ -45,4 +45,19 @@ class SovereigntyStructure extends Model
      */
     protected $primaryKey = 'structure_id';
 
+    /**
+     * @param $value
+     */
+    public function setVulnerableStartTimeAttribute($value)
+    {
+        $this->attributes['vulnerable_start_time'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @param $value
+     */
+    public function setVulnerableEndTimeAttribute($value)
+    {
+        $this->attributes['vulnerable_end_time'] = is_null($value) ? null : carbon($value);
+    }
 }

--- a/src/Models/Wallet/CharacterWalletJournal.php
+++ b/src/Models/Wallet/CharacterWalletJournal.php
@@ -140,6 +140,14 @@ class CharacterWalletJournal extends Model
     public $incrementing = false;
 
     /**
+     * @param $value
+     */
+    public function setDateAttribute($value)
+    {
+        $this->attributes['date'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function character()

--- a/src/Models/Wallet/CharacterWalletTransaction.php
+++ b/src/Models/Wallet/CharacterWalletTransaction.php
@@ -130,6 +130,14 @@ class CharacterWalletTransaction extends Model
     public $incrementing = true;
 
     /**
+     * @param $value
+     */
+    public function setDateAttribute($value)
+    {
+        $this->attributes['date'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
     public function type()

--- a/src/Models/Wallet/CorporationWalletJournal.php
+++ b/src/Models/Wallet/CorporationWalletJournal.php
@@ -145,12 +145,20 @@ class CorporationWalletJournal extends Model
     /**
      * @var string
      */
-    protected $primaryKey = 'id';
+    protected $primaryKey = 'internal_id';
 
     /**
      * @var bool
      */
     public $incrementing = true;
+
+    /**
+     * @param $value
+     */
+    public function setDateAttribute($value)
+    {
+        $this->attributes['date'] = is_null($value) ? null : carbon($value);
+    }
 
     /**
      * @return \Illuminate\Database\Eloquent\Relations\HasOne

--- a/src/Models/Wallet/CorporationWalletTransaction.php
+++ b/src/Models/Wallet/CorporationWalletTransaction.php
@@ -129,6 +129,14 @@ class CorporationWalletTransaction extends Model
     public $incrementing = true;
 
     /**
+     * @param $value
+     */
+    public function setDateAttribute($value)
+    {
+        $this->attributes['date'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
     public function type()

--- a/src/database/migrations/2021_02_27_212931_rename_id_to_internal_id_into_corporation_wallet_journals.php
+++ b/src/database/migrations/2021_02_27_212931_rename_id_to_internal_id_into_corporation_wallet_journals.php
@@ -25,7 +25,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 /**
- * Class RenameIdToInternalIdIntoCorporationWalletJournals
+ * Class RenameIdToInternalIdIntoCorporationWalletJournals.
  */
 class RenameIdToInternalIdIntoCorporationWalletJournals extends Migration
 {

--- a/src/database/migrations/2021_02_27_212931_rename_id_to_internal_id_into_corporation_wallet_journals.php
+++ b/src/database/migrations/2021_02_27_212931_rename_id_to_internal_id_into_corporation_wallet_journals.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Class RenameIdToInternalIdIntoCorporationWalletJournals
+ */
+class RenameIdToInternalIdIntoCorporationWalletJournals extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('corporation_wallet_journals', function (Blueprint $table) {
+            $table->renameColumn('id', 'internal_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('corporation_wallet_journals', function (Blueprint $table) {
+            $table->renameColumn('internal_id', 'id');
+        });
+    }
+}

--- a/src/database/migrations/2021_02_27_212931_rename_reference_id_to_id_into_corporation_wallet_journals.php
+++ b/src/database/migrations/2021_02_27_212931_rename_reference_id_to_id_into_corporation_wallet_journals.php
@@ -25,7 +25,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 /**
- * Class RenameReferenceIdToIdIntoCorporationWalletJournals
+ * Class RenameReferenceIdToIdIntoCorporationWalletJournals.
  */
 class RenameReferenceIdToIdIntoCorporationWalletJournals extends Migration
 {

--- a/src/database/migrations/2021_02_27_212931_rename_reference_id_to_id_into_corporation_wallet_journals.php
+++ b/src/database/migrations/2021_02_27_212931_rename_reference_id_to_id_into_corporation_wallet_journals.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Class RenameReferenceIdToIdIntoCorporationWalletJournals
+ */
+class RenameReferenceIdToIdIntoCorporationWalletJournals extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('corporation_wallet_journals', function (Blueprint $table) {
+            $table->renameColumn('reference_id', 'id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('corporation_wallet_journals', function (Blueprint $table) {
+            $table->renameColumn('id', 'reference_id');
+        });
+    }
+}

--- a/src/database/migrations/2021_02_28_101934_add_state_to_character_orders_table.php
+++ b/src/database/migrations/2021_02_28_101934_add_state_to_character_orders_table.php
@@ -25,7 +25,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 /**
- * Class AddStateToCharacterOrdersTable
+ * Class AddStateToCharacterOrdersTable.
  */
 class AddStateToCharacterOrdersTable extends Migration
 {

--- a/src/database/migrations/2021_02_28_101934_add_state_to_character_orders_table.php
+++ b/src/database/migrations/2021_02_28_101934_add_state_to_character_orders_table.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Class AddStateToCharacterOrdersTable
+ */
+class AddStateToCharacterOrdersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('character_orders', function (Blueprint $table) {
+            $table->enum('state', ['active', 'cancelled', 'expired'])
+                ->default('active')
+                ->after('escrow');
+
+            $table->index(['character_id', 'state']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('character_orders', function (Blueprint $table) {
+            $table->dropIndex(['character_id', 'state']);
+            $table->dropColumn('state');
+        });
+    }
+}

--- a/src/database/migrations/2021_02_28_102213_add_state_to_corporation_orders_table.php
+++ b/src/database/migrations/2021_02_28_102213_add_state_to_corporation_orders_table.php
@@ -25,7 +25,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 /**
- * Class AddStateToCorporationOrdersTable
+ * Class AddStateToCorporationOrdersTable.
  */
 class AddStateToCorporationOrdersTable extends Migration
 {

--- a/src/database/migrations/2021_02_28_102213_add_state_to_corporation_orders_table.php
+++ b/src/database/migrations/2021_02_28_102213_add_state_to_corporation_orders_table.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Class AddStateToCorporationOrdersTable
+ */
+class AddStateToCorporationOrdersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('corporation_orders', function (Blueprint $table) {
+            $table->enum('state', ['active', 'cancelled', 'expired'])
+                ->default('active')
+                ->after('escrow');
+
+            $table->index(['corporation_id', 'state']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('corporation_orders', function (Blueprint $table) {
+            $table->dropIndex(['corporation_id', 'state']);
+            $table->dropColumn('state');
+        });
+    }
+}

--- a/src/database/migrations/2021_02_28_140407_remove_timestamp_columns_from_killmail_victim_items_table.php
+++ b/src/database/migrations/2021_02_28_140407_remove_timestamp_columns_from_killmail_victim_items_table.php
@@ -25,7 +25,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 /**
- * Class RemoveTimestampColumnsFromKillmailVictimItemsTable
+ * Class RemoveTimestampColumnsFromKillmailVictimItemsTable.
  */
 class RemoveTimestampColumnsFromKillmailVictimItemsTable extends Migration
 {

--- a/src/database/migrations/2021_02_28_140407_remove_timestamp_columns_from_killmail_victim_items_table.php
+++ b/src/database/migrations/2021_02_28_140407_remove_timestamp_columns_from_killmail_victim_items_table.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Class RemoveTimestampColumnsFromKillmailVictimItemsTable
+ */
+class RemoveTimestampColumnsFromKillmailVictimItemsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('killmail_victim_items', function (Blueprint $table) {
+            $table->dropTimestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('killmail_victim_items', function (Blueprint $table) {
+            $table->timestamps();
+        });
+    }
+}


### PR DESCRIPTION
introduce softcreatr/jsonpath dependency to add jsonpath support (used to map complex structure like killmails or structures).

extract most esi response to eloquent model mapping from jobs into class data mappers which storing rules to bind ESI response fields to Eloquent Models fields.

add date attributes setters into model rather than applying complex controls inside the mapping itself.