### PR TITLE
fix(jobs): do not cast start/end reinforcement from pocos

### DIFF
--- a/src/Models/PlanetaryInteraction/CorporationCustomsOffice.php
+++ b/src/Models/PlanetaryInteraction/CorporationCustomsOffice.php
@@ -48,22 +48,6 @@ class CorporationCustomsOffice extends Model
     public $incrementing = false;
 
     /**
-     * @param $value
-     */
-    public function setReinforceExitStartAttribute($value)
-    {
-        $this->attributes['reinforce_exit_start'] = is_null($value) ? null : carbon($value);
-    }
-
-    /**
-     * @param $value
-     */
-    public function setReinforceExitEndAttribute($value)
-    {
-        $this->attributes['reinforce_exit_end'] = is_null($value) ? null : carbon($value);
-    }
-
-    /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function planet()


### PR DESCRIPTION
reinforce_exit_start and reinforce_exit_end properties from Customs Offices have been cast from integer to date - which prevent data to be stored into the database.