### PR TITLE
refactor: split public jobs in dedicated commands

### DIFF
--- a/src/Commands/Esi/Update/Insurances.php
+++ b/src/Commands/Esi/Update/Insurances.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of SeAT
  *
- * Copyright (C) 2015 to 2020 Leon Jacobs
+ * Copyright (C) 2015 to 2021 Leon Jacobs
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,45 +23,35 @@
 namespace Seat\Eveapi\Commands\Esi\Update;
 
 use Illuminate\Console\Command;
-use Seat\Eveapi\Bus\Character;
-use Seat\Eveapi\Bus\Corporation;
-use Seat\Eveapi\Jobs\Universe\Names;
-use Seat\Eveapi\Models\Character\CharacterInfo;
-use Seat\Eveapi\Models\Corporation\CorporationInfo;
+use Seat\Eveapi\Jobs\Fittings\Insurances as InsurancesJob;
 
 /**
- * Class PublicInfo.
+ * Class Insurances.
  * @package Seat\Eveapi\Commands\Esi\Update
  */
-class PublicInfo extends Command
+class Insurances extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'esi:update:public';
+    protected $signature = 'esi:update:insurances';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Schedule updater jobs for public information';
+    protected $description = 'Schedule updater jobs for insurances information';
 
     /**
      * Execute the console command.
      */
     public function handle()
     {
-        Names::dispatch();
+        InsurancesJob::dispatch();
 
-        CharacterInfo::doesntHave('refresh_token')->each(function ($character) {
-            (new Character($character->character_id))->fire();
-        });
-
-        CorporationInfo::all()->each(function ($corporation) {
-            (new Corporation($corporation->corporation_id))->fire();
-        });
+        $this->info('A new insurance job has been queued.');
     }
 }

--- a/src/Commands/Esi/Update/Prices.php
+++ b/src/Commands/Esi/Update/Prices.php
@@ -25,6 +25,7 @@ namespace Seat\Eveapi\Commands\Esi\Update;
 use Illuminate\Console\Command;
 use Seat\Eveapi\Jobs\Market\History;
 use Seat\Eveapi\Models\Sde\InvType;
+use Seat\Eveapi\Jobs\Market\Prices as PricesJob;
 
 /**
  * Class Prices.
@@ -57,6 +58,8 @@ class Prices extends Command
             ->where('published', true)
             ->select('typeID')
             ->get();
+
+        PricesJob::dispatch();
 
         // build small batch of a maximum of 200 entries to avoid long running job.
         $types->chunk(50)->each(function ($chunk) {

--- a/src/Commands/Esi/Update/Sovereignty.php
+++ b/src/Commands/Esi/Update/Sovereignty.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of SeAT
  *
- * Copyright (C) 2015 to 2020 Leon Jacobs
+ * Copyright (C) 2015 to 2021 Leon Jacobs
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,45 +23,37 @@
 namespace Seat\Eveapi\Commands\Esi\Update;
 
 use Illuminate\Console\Command;
-use Seat\Eveapi\Bus\Character;
-use Seat\Eveapi\Bus\Corporation;
-use Seat\Eveapi\Jobs\Universe\Names;
-use Seat\Eveapi\Models\Character\CharacterInfo;
-use Seat\Eveapi\Models\Corporation\CorporationInfo;
+use Seat\Eveapi\Jobs\Sovereignty\Map;
+use Seat\Eveapi\Jobs\Sovereignty\Structures;
 
 /**
- * Class PublicInfo.
+ * Class Sovereignty.
  * @package Seat\Eveapi\Commands\Esi\Update
  */
-class PublicInfo extends Command
+class Sovereignty extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'esi:update:public';
+    protected $signature = 'esi:update:sovereignty';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Schedule updater jobs for public information';
+    protected $description = 'Schedule updater jobs for insurances information';
 
     /**
      * Execute the console command.
      */
     public function handle()
     {
-        Names::dispatch();
+        Map::dispatch();
+        Structures::dispatch();
 
-        CharacterInfo::doesntHave('refresh_token')->each(function ($character) {
-            (new Character($character->character_id))->fire();
-        });
-
-        CorporationInfo::all()->each(function ($corporation) {
-            (new Corporation($corporation->corporation_id))->fire();
-        });
+        $this->info('New sovereignty jobs have been queued.');
     }
 }

--- a/src/Commands/Esi/Update/Stations.php
+++ b/src/Commands/Esi/Update/Stations.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2021 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eveapi\Commands\Esi\Update;
+
+use Illuminate\Console\Command;
+use Seat\Eveapi\Jobs\Universe\Stations as StationsJob;
+use Seat\Eveapi\Models\Assets\CharacterAsset;
+use Seat\Eveapi\Models\Assets\CorporationAsset;
+use Seat\Eveapi\Models\Contracts\ContractDetail;
+use Seat\Eveapi\Models\Corporation\CorporationInfo;
+use Seat\Eveapi\Models\Universe\UniverseStation;
+
+/**
+ * Class Stations.
+ * @package Seat\Eveapi\Commands\Esi\Update
+ */
+class Stations extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'esi:update:stations';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Schedule updater jobs for stations information';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $stations = collect();
+
+        // NPC stations using HQ
+        CorporationInfo::whereNotIn('home_station_id', UniverseStation::FAKE_STATION_ID)
+            ->select('home_station_id')
+            ->orderBy('home_station_id')
+            ->distinct()
+            ->chunk(100, function ($corporations) use (&$stations) {
+                $stations = $stations->merge($corporations->pluck('home_station_id')->toArray());
+            });
+
+        // NPC stations using character assets
+        CharacterAsset::where('location_type', 'station')
+            ->select('location_id')
+            ->orderBy('location_id')
+            ->distinct()
+            ->chunk(100, function ($assets) use (&$stations) {
+                $stations = $stations->merge($assets->pluck('location_id')->toArray());
+            });
+
+        // NPC stations using corporation assets
+        CorporationAsset::where('location_type', 'station')
+            ->select('location_id')
+            ->orderBy('location_id')
+            ->distinct()
+            ->chunk(100, function ($assets) use (&$stations) {
+                $stations = $stations->merge($assets->pluck('location_id')->toArray());
+            });
+
+        // NPC stations using from contract start locations
+        ContractDetail::where('start_location_type', UniverseStation::class)
+            ->select('start_location_id')
+            ->orderBy('start_location_id')
+            ->distinct()
+            ->chunk(100, function ($locations) use (&$stations) {
+                $stations = $stations->merge($locations->pluck('start_location_id')->toArray());
+            });
+
+        // NPC stations using from contract start locations
+        ContractDetail::where('end_location_type', UniverseStation::class)
+            ->select('end_location_id')
+            ->orderBy('end_location_id')
+            ->distinct()
+            ->chunk(100, function ($locations) use (&$stations) {
+                $stations = $stations->merge($locations->pluck('end_location_id')->toArray());
+            });
+
+        $stations = $stations->unique();
+
+        $stations->chunk(100)->each(function ($chunk) {
+            StationsJob::dispatch($chunk->toArray());
+        });
+    }
+}

--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -31,10 +31,13 @@ use Seat\Eveapi\Commands\Esi\Update\Alliances;
 use Seat\Eveapi\Commands\Esi\Update\Characters;
 use Seat\Eveapi\Commands\Esi\Update\Contracts;
 use Seat\Eveapi\Commands\Esi\Update\Corporations;
+use Seat\Eveapi\Commands\Esi\Update\Insurances;
 use Seat\Eveapi\Commands\Esi\Update\Killmails;
 use Seat\Eveapi\Commands\Esi\Update\Notifications;
 use Seat\Eveapi\Commands\Esi\Update\Prices;
 use Seat\Eveapi\Commands\Esi\Update\PublicInfo;
+use Seat\Eveapi\Commands\Esi\Update\Sovereignty;
+use Seat\Eveapi\Commands\Esi\Update\Stations;
 use Seat\Eveapi\Commands\Esi\Update\Status as EsiStatus;
 use Seat\Eveapi\Commands\Eve\Update\Sde;
 use Seat\Eveapi\Commands\Eve\Update\Status as EveStatus;
@@ -132,6 +135,9 @@ class EveapiServiceProvider extends AbstractSeatPlugin
             PublicInfo::class,
             Affiliations::class,
             Prices::class,
+            Insurances::class,
+            Stations::class,
+            Sovereignty::class,
             Alliances::class,
             Contracts::class,
             Killmails::class,
@@ -146,7 +152,7 @@ class EveapiServiceProvider extends AbstractSeatPlugin
 
     /**
      * Set the path for migrations which should
-     * be migrated by laravel. More informations:
+     * be migrated by laravel. More information:
      * https://laravel.com/docs/5.5/packages#migrations.
      */
     private function add_migrations()

--- a/src/Jobs/Alliances/Alliances.php
+++ b/src/Jobs/Alliances/Alliances.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\Alliances;
 
+use Seat\Eveapi\Bus\Alliance as AllianceBus;
 use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\Alliances\Alliance;
 
@@ -64,13 +65,8 @@ class Alliances extends EsiBase
 
         collect($alliances)->each(function ($alliance_id) {
 
-            // queue jobs which will take care of this alliance update.
-            Info::withChain([
-                new Members($alliance_id),
-            ])->dispatch($alliance_id)->delay(now()->addSeconds(rand(20, 300)));
-            // in order to prevent ESI to receive massive income of all existing SeAT instances in the world
-            // add a bit of randomize when job can be processed - we use seconds here, so we have more flexibility
-            // https://github.com/eveseat/seat/issues/731
+            // queue update jobs which will pull alliance related data.
+            (new AllianceBus($alliance_id))->fire();
         });
     }
 }

--- a/src/database/seeds/ScheduleSeeder.php
+++ b/src/database/seeds/ScheduleSeeder.php
@@ -124,6 +124,30 @@ class ScheduleSeeder extends Seeder
             'ping_before'       => null,
             'ping_after'        => null,
         ],
+        [   // Insurances Data | Once a day
+            'command'           => 'esi:update:insurances',
+            'expression'        => '0 7 * * *',
+            'allow_overlap'     => false,
+            'allow_maintenance' => false,
+            'ping_before'       => null,
+            'ping_after'        => null,
+        ],
+        [   // Sovereignty Data | Once a day
+            'command'           => 'esi:update:sovereignty',
+            'expression'        => '0 19 * * *',
+            'allow_overlap'     => false,
+            'allow_maintenance' => false,
+            'ping_before'       => null,
+            'ping_after'        => null,
+        ],
+        [   // Stations Data | Once a day
+            'command'           => 'esi:update:stations',
+            'expression'        => '0 1 * * *',
+            'allow_overlap'     => false,
+            'allow_maintenance' => false,
+            'ping_before'       => null,
+            'ping_after'        => null,
+        ],
     ];
 
     /**
@@ -179,6 +203,9 @@ class ScheduleSeeder extends Seeder
                 case 'esi:update:public':
                 case 'esi:update:prices':
                 case 'esi:update:alliances':
+                case 'esi:update:insurances':
+                case 'esi:update:sovereignty':
+                case 'esi:update:stations':
                     $this->schedules[$key]['expression'] = sprintf('%d %d * * *', rand(0, 59), Arr::random($hours));
                     break;
             }


### PR DESCRIPTION
esi:update:public is becoming to big and it lead to various stability issues on large instances.

refactor this command in more granular ones :
- spawn sovereignty, stations and insurances
- merge prices together with history
- merge alliance and use bus