### PR TITLE
MariaDB 10.5 Hotfix

### DIFF
--- a/src/database/migrations/2020_05_31_110243_add_id_column_to_mail_recipients_table.php
+++ b/src/database/migrations/2020_05_31_110243_add_id_column_to_mail_recipients_table.php
@@ -31,9 +31,17 @@ class AddIdColumnToMailRecipientsTable extends Migration
 {
     public function up()
     {
-        Schema::table('mail_recipients', function (Blueprint $table) {
-            $table->bigIncrements('id')->first();
-        });
+        try {
+            Schema::table('mail_recipients', function (Blueprint $table) {
+                $table->bigIncrements('id')->first();
+            });
+        } catch (\Illuminate\Database\QueryException $th) {
+            // This is a fix for mariadb 10.5 causing issues with migrations due to the CHECK(json_valid('labels'))
+            DB::statement('ALTER TABLE mail_recipients MODIFY COLUMN labels longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (JSON_VALID(labels)) AFTER is_read;');
+            Schema::table('mail_recipients', function (Blueprint $table) {
+                $table->bigIncrements('id')->first();
+            });
+        }
     }
 
     public function down()


### PR DESCRIPTION
This patch will issue a non-altering, alter table statement if the column addition fails. This statement will allow the migration to pass. It is unclear at this stage why this works.

Closes eveseat/seat#814