### PR TITLE
fix(jobs): Use Cache facade to get key prefix instead of hardcoded

### DIFF
--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -164,7 +164,7 @@ abstract class EsiBase extends AbstractJob
     /**
      * @return int|null
      */
-    public function getRateLimitKeyTtl():? int
+    public function getRateLimitKeyTtl(): ?int
     {
         return Cache::get(self::RATE_LIMIT_KEY);
     }

--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -163,9 +163,9 @@ abstract class EsiBase extends AbstractJob
     }
 
     /**
-     * @return int|null
+     * @return int
      */
-    public function getRateLimitKeyTtl(): ?int
+    public function getRateLimitKeyTtl(): int
     {
         return Redis::ttl(Cache::getPrefix() . self::RATE_LIMIT_KEY);
     }

--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -24,6 +24,7 @@ namespace Seat\Eveapi\Jobs;
 
 use Exception;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Redis;
 use Seat\Eseye\Containers\EsiAuthentication;
 use Seat\Eseye\Containers\EsiResponse;
 use Seat\Eseye\Exceptions\RequestFailedException;
@@ -166,7 +167,7 @@ abstract class EsiBase extends AbstractJob
      */
     public function getRateLimitKeyTtl(): ?int
     {
-        return Cache::get(self::RATE_LIMIT_KEY);
+        return Redis::ttl(Cache::getPrefix() . self::RATE_LIMIT_KEY);
     }
 
     /**

--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -23,7 +23,7 @@
 namespace Seat\Eveapi\Jobs;
 
 use Exception;
-use Illuminate\Support\Facades\Redis;
+use Illuminate\Support\Facades\Cache;
 use Seat\Eseye\Containers\EsiAuthentication;
 use Seat\Eseye\Containers\EsiResponse;
 use Seat\Eseye\Exceptions\RequestFailedException;
@@ -162,12 +162,11 @@ abstract class EsiBase extends AbstractJob
     }
 
     /**
-     * @return mixed
+     * @return int|null
      */
-    public function getRateLimitKeyTtl()
+    public function getRateLimitKeyTtl():? int
     {
-
-        return Redis::ttl('seat:' . self::RATE_LIMIT_KEY);
+        return Cache::get(self::RATE_LIMIT_KEY);
     }
 
     /**


### PR DESCRIPTION
The key name should not be hardcoded. Because a complete key name contains a prefix, and this prefix is not necessarily `seat`, it depends on the config [0].

As an impact, CheckEsiRateLimit middleware may not work. Since EsiBase::getRateLimitKeyTtl() always returns -2, EsiBase::incrementEsiRateLimit() will always set the cache to 1. Ultimately, CheckEsiRateLimit middleware will not do anything even if the error rate has actually been reached.

[0] `Illuminate\Cache\CacheManager::getPrefix()`