### PR TITLE
feat: add relations to alliance and update member corps through public

### DIFF
--- a/src/Commands/Esi/Update/PublicInfo.php
+++ b/src/Commands/Esi/Update/PublicInfo.php
@@ -26,6 +26,7 @@ use Illuminate\Console\Command;
 use Seat\Eveapi\Bus\Character;
 use Seat\Eveapi\Bus\Corporation;
 use Seat\Eveapi\Jobs\Universe\Names;
+use Seat\Eveapi\Models\Alliances\AllianceMember;
 use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
 
@@ -62,6 +63,10 @@ class PublicInfo extends Command
 
         CorporationInfo::all()->each(function ($corporation) {
             (new Corporation($corporation->corporation_id))->fire();
+        });
+
+        AllianceMember::doesntHave('corporation')->each(function ($member){
+            (new Corporation($member->corporation_id))->fire();
         });
     }
 }

--- a/src/Commands/Esi/Update/PublicInfo.php
+++ b/src/Commands/Esi/Update/PublicInfo.php
@@ -65,7 +65,7 @@ class PublicInfo extends Command
             (new Corporation($corporation->corporation_id))->fire();
         });
 
-        AllianceMember::doesntHave('corporation')->each(function ($member){
+        AllianceMember::doesntHave('corporation')->each(function ($member) {
             (new Corporation($member->corporation_id))->fire();
         });
     }

--- a/src/Models/Alliances/Alliance.php
+++ b/src/Models/Alliances/Alliance.php
@@ -23,6 +23,9 @@
 namespace Seat\Eveapi\Models\Alliances;
 
 use Illuminate\Database\Eloquent\Model;
+use Seat\Eveapi\Models\Contacts\AllianceContact;
+use Seat\Eveapi\Models\Corporation\CorporationInfo;
+use Seat\Eveapi\Models\Universe\UniverseName;
 
 /**
  * Class Alliance.
@@ -56,5 +59,85 @@ class Alliance extends Model
     public function setDateFoundedAttribute($value)
     {
         $this->attributes['date_founded'] = is_null($value) ? null : carbon($value);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function executor()
+    {
+        return $this->hasOne(UniverseName::class, 'entity_id', 'executor_corporation_id')
+            ->withDefault([
+                'category'  => 'corporation',
+                'name'      => trans('web::seat.unknown'),
+            ]);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function creator()
+    {
+        return $this->hasOne(UniverseName::class, 'entity_id', 'creator_id')
+            ->withDefault([
+                'category'  => 'character',
+                'name'      => trans('web::seat.unknown'),
+            ]);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function creator_corporation()
+    {
+        return $this->hasOne(UniverseName::class, 'entity_id', 'creator_corporation_id')
+            ->withDefault([
+                'category'  => 'corporation',
+                'name'      => trans('web::seat.unknown'),
+            ]);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function contacts()
+    {
+
+        return $this->hasMany(AllianceContact::class,
+            'alliance_id', 'alliance_id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function members()
+    {
+
+        return $this->hasMany(AllianceMember::class,
+            'alliance_id', 'alliance_id');
+
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
+     */
+    public function corporations()
+    {
+        return $this->hasManyThrough(
+            CorporationInfo::class,
+            AllianceMember::class,
+            'alliance_id',
+            'corporation_id',
+            'alliance_id',
+            'corporation_id'
+        );
+    }
+
+    /**
+     * @return int
+     */
+    public function character_count()
+    {
+        return $this->corporations->sum('member_count');
     }
 }

--- a/src/Models/Alliances/AllianceMember.php
+++ b/src/Models/Alliances/AllianceMember.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Models\Alliances;
 
 use Illuminate\Database\Eloquent\Model;
+use Seat\Eveapi\Models\Corporation\CorporationInfo;
 
 /**
  * Class AllianceMember.
@@ -34,4 +35,20 @@ class AllianceMember extends Model
      * @var bool
      */
     protected static $unguarded = true;
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function alliance()
+    {
+        return $this->hasOne(Alliance::class, 'alliance_id', 'alliance_id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function corporation()
+    {
+        return $this->hasOne(CorporationInfo::class, 'corporation_id', 'corporation_id');
+    }
 }


### PR DESCRIPTION
This adds some relations to the Alliance and AllianceMember models. It also extends the public info job to grab the public CorporationInfo from ESI when missing. 