### PR TITLE
fix: remove automatic alliance member population

### DIFF
--- a/src/Commands/Esi/Update/PublicInfo.php
+++ b/src/Commands/Esi/Update/PublicInfo.php
@@ -26,7 +26,6 @@ use Illuminate\Console\Command;
 use Seat\Eveapi\Bus\Character;
 use Seat\Eveapi\Bus\Corporation;
 use Seat\Eveapi\Jobs\Universe\Names;
-use Seat\Eveapi\Models\Alliances\AllianceMember;
 use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
 

--- a/src/Commands/Esi/Update/PublicInfo.php
+++ b/src/Commands/Esi/Update/PublicInfo.php
@@ -64,9 +64,5 @@ class PublicInfo extends Command
         CorporationInfo::all()->each(function ($corporation) {
             (new Corporation($corporation->corporation_id))->fire();
         });
-
-        AllianceMember::doesntHave('corporation')->each(function ($member) {
-            (new Corporation($member->corporation_id))->fire();
-        });
     }
 }


### PR DESCRIPTION
This removes the automatic creation of CorporationInfo jobs for missing AllianceMembers due to the increased load this can present.