### PR TITLE
feat: corporation public info pull and cleanup

### DIFF
--- a/src/Commands/Esi/Update/PublicInfo.php
+++ b/src/Commands/Esi/Update/PublicInfo.php
@@ -65,9 +65,9 @@ class PublicInfo extends Command
             (new Corporation($corporation->corporation_id))->fire();
         });
 
-        Alliance::has('corporations.characters.refresh_token')->each(function($alliance){
-            $alliance->members->each(function ($member){
-                if (!$member->corporation()->exists()){
+        Alliance::has('corporations.characters.refresh_token')->each(function ($alliance) {
+            $alliance->members->each(function ($member) {
+                if (! $member->corporation()->exists()){
                     (new Corporation($member->corporation_id))->fire();
                 }
             });

--- a/src/Commands/Esi/Update/PublicInfo.php
+++ b/src/Commands/Esi/Update/PublicInfo.php
@@ -26,6 +26,7 @@ use Illuminate\Console\Command;
 use Seat\Eveapi\Bus\Character;
 use Seat\Eveapi\Bus\Corporation;
 use Seat\Eveapi\Jobs\Universe\Names;
+use Seat\Eveapi\Models\Alliances\Alliance;
 use Seat\Eveapi\Models\Character\CharacterInfo;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
 
@@ -62,6 +63,14 @@ class PublicInfo extends Command
 
         CorporationInfo::all()->each(function ($corporation) {
             (new Corporation($corporation->corporation_id))->fire();
+        });
+
+        Alliance::has('corporations.characters.refresh_token')->each(function($alliance){
+            $alliance->members->each(function ($member){
+                if (!$member->corporation()->exists()){
+                    (new Corporation($member->corporation_id))->fire();
+                }
+            });
         });
     }
 }

--- a/src/Jobs/Maintenance.php
+++ b/src/Jobs/Maintenance.php
@@ -109,7 +109,7 @@ class Maintenance implements ShouldQueue
     {
 
         // Need to find all corps that dont have a reason to be kept (no chars with tokens and not part of an alliance that has an active member)
-        Alliance::doesntHave('corporations.characters.refresh_token')->each(function($alliance){
+        Alliance::doesntHave('corporations.characters.refresh_token')->each(function ($alliance) {
             $alliance->corporations()->whereNotBetween('corporation_id', [1000000, 1999999])->delete();
         });
 


### PR DESCRIPTION
This PR will pull public CorpInfo for all AllianceMembers where the Alliance has at least one member corporation.

The maintenance job will also clean up corporations that have no active tokens, and are not a member of an alliance with active tokens.