### PR TITLE
fix: bump character info endpoint to v5

### DIFF
--- a/src/Jobs/Character/Info.php
+++ b/src/Jobs/Character/Info.php
@@ -28,7 +28,7 @@ use Seat\Eveapi\Models\Character\CharacterInfo;
 
 /**
  * Class Info.
- * 
+ *
  * @package Seat\Eveapi\Jobs\Character
  */
 class Info extends AbstractCharacterJob
@@ -57,7 +57,7 @@ class Info extends AbstractCharacterJob
      * Execute the job.
      *
      * @return void
-     * 
+     *
      * @throws \Exception
      * @throws \Throwable
      */

--- a/src/Jobs/Character/Info.php
+++ b/src/Jobs/Character/Info.php
@@ -28,6 +28,7 @@ use Seat\Eveapi\Models\Character\CharacterInfo;
 
 /**
  * Class Info.
+ * 
  * @package Seat\Eveapi\Jobs\Character
  */
 class Info extends AbstractCharacterJob
@@ -56,6 +57,7 @@ class Info extends AbstractCharacterJob
      * Execute the job.
      *
      * @return void
+     * 
      * @throws \Exception
      * @throws \Throwable
      */

--- a/src/Jobs/Character/Info.php
+++ b/src/Jobs/Character/Info.php
@@ -45,7 +45,7 @@ class Info extends AbstractCharacterJob
     /**
      * @var int
      */
-    protected $version = 'v4';
+    protected $version = 'v5';
 
     /**
      * @var array

--- a/src/Mapping/Characters/InfoMapping.php
+++ b/src/Mapping/Characters/InfoMapping.php
@@ -26,6 +26,7 @@ use Seat\Eveapi\Mapping\DataMapping;
 
 /**
  * Class InfoMapping.
+ * 
  * @package Seat\Eveapi\Mapping\Characters
  */
 class InfoMapping extends DataMapping

--- a/src/Mapping/Characters/InfoMapping.php
+++ b/src/Mapping/Characters/InfoMapping.php
@@ -26,7 +26,7 @@ use Seat\Eveapi\Mapping\DataMapping;
 
 /**
  * Class InfoMapping.
- * 
+ *
  * @package Seat\Eveapi\Mapping\Characters
  */
 class InfoMapping extends DataMapping

--- a/src/Mapping/Characters/InfoMapping.php
+++ b/src/Mapping/Characters/InfoMapping.php
@@ -40,8 +40,7 @@ class InfoMapping extends DataMapping
         'gender'          => 'gender',
         'race_id'         => 'race_id',
         'bloodline_id'    => 'bloodline_id',
-        'ancestry_id'     => 'ancestry_id',
         'security_status' => 'security_status',
-        'title' => 'title',
+        'title'           => 'title',
     ];
 }


### PR DESCRIPTION
Only change is the drop of `ancestry_id` from the ESI result. Leaving it in the DB for historical purposes, but it will forever be null from now on.