### PR TITLE
Rotating Refresh Tokens

### DIFF
--- a/src/Jobs/AbstractAuthAllianceJob.php
+++ b/src/Jobs/AbstractAuthAllianceJob.php
@@ -71,7 +71,7 @@ abstract class AbstractAuthAllianceJob extends AbstractAllianceJob
             new CheckTokenVersion,
             new IgnoreNpcCorporation,
             new RequireCorporationRole,
-            (new WithoutOverlapping($this->getToken()->character_id))->releaseAfter(20)->expireAfter(1500),
+            (new WithoutOverlapping($this->getToken()->character_id))->releaseAfter(10)->expireAfter(1500),
         ]);
     }
 }

--- a/src/Jobs/AbstractAuthAllianceJob.php
+++ b/src/Jobs/AbstractAuthAllianceJob.php
@@ -26,6 +26,7 @@ use Seat\Eveapi\Jobs\Middleware\CheckTokenScope;
 use Seat\Eveapi\Jobs\Middleware\CheckTokenVersion;
 use Seat\Eveapi\Jobs\Middleware\IgnoreNpcCorporation;
 use Seat\Eveapi\Jobs\Middleware\RequireCorporationRole;
+use Seat\Eveapi\Jobs\Middleware\WithoutOverlapping;
 use Seat\Eveapi\Models\RefreshToken;
 
 /**
@@ -70,6 +71,7 @@ abstract class AbstractAuthAllianceJob extends AbstractAllianceJob
             new CheckTokenVersion,
             new IgnoreNpcCorporation,
             new RequireCorporationRole,
+            (new WithoutOverlapping($this->getToken()->character_id))->releaseAfter(20)->expireAfter(1500),
         ]);
     }
 }

--- a/src/Jobs/AbstractAuthCharacterJob.php
+++ b/src/Jobs/AbstractAuthCharacterJob.php
@@ -24,6 +24,7 @@ namespace Seat\Eveapi\Jobs;
 
 use Seat\Eveapi\Jobs\Middleware\CheckTokenScope;
 use Seat\Eveapi\Jobs\Middleware\CheckTokenVersion;
+use Seat\Eveapi\Jobs\Middleware\WithoutOverlapping;
 use Seat\Eveapi\Models\RefreshToken;
 
 /**
@@ -58,6 +59,7 @@ abstract class AbstractAuthCharacterJob extends AbstractCharacterJob
         return array_merge(parent::middleware(), [
             new CheckTokenScope,
             new CheckTokenVersion,
+            (new WithoutOverlapping($this->getToken()->character_id))->releaseAfter(20)->expireAfter(1500),
         ]);
     }
 }

--- a/src/Jobs/AbstractAuthCharacterJob.php
+++ b/src/Jobs/AbstractAuthCharacterJob.php
@@ -59,7 +59,7 @@ abstract class AbstractAuthCharacterJob extends AbstractCharacterJob
         return array_merge(parent::middleware(), [
             new CheckTokenScope,
             new CheckTokenVersion,
-            (new WithoutOverlapping($this->getToken()->character_id))->releaseAfter(20)->expireAfter(1500),
+            (new WithoutOverlapping($this->getToken()->character_id))->releaseAfter(10)->expireAfter(1500),
         ]);
     }
 }

--- a/src/Jobs/AbstractAuthCorporationJob.php
+++ b/src/Jobs/AbstractAuthCorporationJob.php
@@ -77,7 +77,7 @@ abstract class AbstractAuthCorporationJob extends AbstractCorporationJob
             new CheckTokenVersion,
             new IgnoreNpcCorporation,
             new RequireCorporationRole,
-            (new WithoutOverlapping($this->getToken()->character_id))->releaseAfter(20)->expireAfter(1500),
+            (new WithoutOverlapping($this->getToken()->character_id))->releaseAfter(10)->expireAfter(1500),
         ]);
     }
 

--- a/src/Jobs/AbstractAuthCorporationJob.php
+++ b/src/Jobs/AbstractAuthCorporationJob.php
@@ -28,6 +28,7 @@ use Seat\Eveapi\Jobs\Middleware\CheckTokenScope;
 use Seat\Eveapi\Jobs\Middleware\CheckTokenVersion;
 use Seat\Eveapi\Jobs\Middleware\IgnoreNpcCorporation;
 use Seat\Eveapi\Jobs\Middleware\RequireCorporationRole;
+use Seat\Eveapi\Jobs\Middleware\WithoutOverlapping;
 use Seat\Eveapi\Models\Character\CharacterAffiliation;
 use Seat\Eveapi\Models\Corporation\CorporationMemberTracking;
 use Seat\Eveapi\Models\RefreshToken;
@@ -76,6 +77,7 @@ abstract class AbstractAuthCorporationJob extends AbstractCorporationJob
             new CheckTokenVersion,
             new IgnoreNpcCorporation,
             new RequireCorporationRole,
+            (new WithoutOverlapping($this->getToken()->character_id))->releaseAfter(20)->expireAfter(1500),
         ]);
     }
 

--- a/src/Jobs/Middleware/WithoutOverlapping.php
+++ b/src/Jobs/Middleware/WithoutOverlapping.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2021 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+ /*
+  * This file is sourced from Laravel 8.x while SeAT is using Laravel 6.x
+  * Once SeAT is updated to a later version of Laravel this file should be removed.
+  */
+
+namespace Seat\Eveapi\Jobs\Middleware;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Support\InteractsWithTime;
+
+class WithoutOverlapping
+{
+    use InteractsWithTime;
+
+    /**
+     * The job's unique key used for preventing overlaps.
+     *
+     * @var string
+     */
+    public $key;
+
+    /**
+     * The number of seconds before a job should be available again if no lock was acquired.
+     *
+     * @var \DateTimeInterface|int|null
+     */
+    public $releaseAfter;
+
+    /**
+     * The number of seconds before the lock should expire.
+     *
+     * @var int
+     */
+    public $expiresAfter;
+
+    /**
+     * The prefix of the lock key.
+     *
+     * @var string
+     */
+    public $prefix = 'laravel-queue-overlap:';
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  string  $key
+     * @param  \DateTimeInterface|int|null  $releaseAfter
+     * @param  \DateTimeInterface|int  $expiresAfter
+     * @return void
+     */
+    public function __construct($key = '', $releaseAfter = 0, $expiresAfter = 0)
+    {
+        $this->key = $key;
+        $this->releaseAfter = $releaseAfter;
+        $this->expiresAfter = $this->secondsUntil($expiresAfter);
+    }
+
+    /**
+     * Process the job.
+     *
+     * @param  mixed  $job
+     * @param  callable  $next
+     * @return mixed
+     */
+    public function handle($job, $next)
+    {
+        $lock = Container::getInstance()->make(Cache::class)->lock(
+            $this->getLockKey($job), $this->expiresAfter
+        );
+
+        if ($lock->get()) {
+            try {
+                logger()->error('WOPPER2: Allowing job for ' . strval($job->getToken()->character_id));
+                $next($job);
+            } finally {
+                logger()->error('WOPPER2: Lock Released for for ' . strval($job->getToken()->character_id));
+                $lock->release();
+            }
+        } elseif (! is_null($this->releaseAfter)) {
+            logger()->error('WOPPER2: Postponing job for ' . strval($job->getToken()->character_id));
+            $job->release($this->releaseAfter);
+        }
+    }
+
+    /**
+     * Set the delay (in seconds) to release the job back to the queue.
+     *
+     * @param  int  $releaseAfter
+     * @return $this
+     */
+    public function releaseAfter($releaseAfter)
+    {
+        $this->releaseAfter = $releaseAfter;
+
+        return $this;
+    }
+
+    /**
+     * Do not release the job back to the queue if no lock can be acquired.
+     *
+     * @return $this
+     */
+    public function dontRelease()
+    {
+        $this->releaseAfter = null;
+
+        return $this;
+    }
+
+    /**
+     * Set the maximum number of seconds that can elapse before the lock is released.
+     *
+     * @param  \DateTimeInterface|int  $expiresAfter
+     * @return $this
+     */
+    public function expireAfter($expiresAfter)
+    {
+        $this->expiresAfter = $this->secondsUntil($expiresAfter);
+
+        return $this;
+    }
+
+    /**
+     * Set the prefix of the lock key.
+     *
+     * @param  string  $prefix
+     * @return $this
+     */
+    public function withPrefix(string $prefix)
+    {
+        $this->prefix = $prefix;
+
+        return $this;
+    }
+
+    /**
+     * Get the lock key for the given job.
+     *
+     * @param  mixed  $job
+     * @return string
+     */
+    public function getLockKey($job)
+    {
+        return $this->prefix.get_class($job).':'.$this->key;
+    }
+}

--- a/src/Jobs/Middleware/WithoutOverlapping.php
+++ b/src/Jobs/Middleware/WithoutOverlapping.php
@@ -93,14 +93,11 @@ class WithoutOverlapping
 
         if ($lock->get()) {
             try {
-                logger()->error('WOPPER2: Allowing job for ' . strval($job->getToken()->character_id));
                 $next($job);
             } finally {
-                logger()->error('WOPPER2: Lock Released for for ' . strval($job->getToken()->character_id));
                 $lock->release();
             }
         } elseif (! is_null($this->releaseAfter)) {
-            logger()->error('WOPPER2: Postponing job for ' . strval($job->getToken()->character_id));
             $job->release($this->releaseAfter);
         }
     }
@@ -164,6 +161,6 @@ class WithoutOverlapping
      */
     public function getLockKey($job)
     {
-        return $this->prefix.get_class($job).':'.$this->key;
+        return $this->prefix.':'.$this->key;
     }
 }


### PR DESCRIPTION
This PR will prevent jobs from running concurrently for the same refresh token (based on char_id). This is to remove the risk of refreshing a refresh token multiple times and thus invalidating it in the event of a refresh token rotation.