### PR TITLE
fixed asset container relation

### DIFF
--- a/src/Models/Assets/CharacterAsset.php
+++ b/src/Models/Assets/CharacterAsset.php
@@ -209,7 +209,7 @@ class CharacterAsset extends Model
     public function container()
     {
 
-        return $this->belongsTo(CharacterAsset::class, 'location_id', 'item_id')
+        return $this->belongsTo(CharacterAsset::class, 'item_id', 'location_id')
             ->withDefault();
     }
 

--- a/src/Models/Assets/CorporationAsset.php
+++ b/src/Models/Assets/CorporationAsset.php
@@ -212,7 +212,7 @@ class CorporationAsset extends Model
     public function container()
     {
 
-        return $this->belongsTo(CorporationAsset::class, 'location_id', 'item_id')
+        return $this->belongsTo(CorporationAsset::class, 'item_id', 'location_id')
             ->withDefault();
     }
 


### PR DESCRIPTION
In the asset models for characters and corporations, the `container` relation does the same thing as the `content` relation, but the `container` relation should get the container item as it's name says and not the contents