### PR TITLE
Maintenance tables add

### DIFF
--- a/src/Jobs/Maintenance.php
+++ b/src/Jobs/Maintenance.php
@@ -98,7 +98,7 @@ class Maintenance implements ShouldQueue
         EsiStatus::where('created_at', '<', carbon('now')->subWeek(1))->delete();
 
         // ask database to rebuild index in order to properly reduce their space usage on drive
-        DB::statement('OPTIMIZE TABLE failed_jobs, server_status, esi_status');
+        DB::statement('OPTIMIZE TABLE failed_jobs, server_status, esi_status, character_assets, character_wallet journals, contract_details');
     }
 
     private function cleanup_characters()

--- a/src/Jobs/Maintenance.php
+++ b/src/Jobs/Maintenance.php
@@ -98,7 +98,14 @@ class Maintenance implements ShouldQueue
         EsiStatus::where('created_at', '<', carbon('now')->subWeek(1))->delete();
 
         // ask database to rebuild index in order to properly reduce their space usage on drive
-        DB::statement('OPTIMIZE TABLE failed_jobs, server_status, esi_status, character_assets, character_wallet_journals, contract_details');
+        // optimize status and failed tables
+        DB::statement('OPTIMIZE TABLE failed_jobs, server_status, esi_status');
+
+        // optimize character tables
+        DB::statement('OPTIMIZE TABLE character_assets, character_fitting_items, character_wallet_journals, character_wallet_transactions');
+
+        // optimize contract tables
+        DB::statement('OPTIMIZE TABLE contract_details, contract_items');
     }
 
     private function cleanup_characters()

--- a/src/Jobs/Maintenance.php
+++ b/src/Jobs/Maintenance.php
@@ -98,7 +98,7 @@ class Maintenance implements ShouldQueue
         EsiStatus::where('created_at', '<', carbon('now')->subWeek(1))->delete();
 
         // ask database to rebuild index in order to properly reduce their space usage on drive
-        DB::statement('OPTIMIZE TABLE failed_jobs, server_status, esi_status, character_assets, character_wallet journals, contract_details');
+        DB::statement('OPTIMIZE TABLE failed_jobs, server_status, esi_status, character_assets, character_wallet_journals, contract_details');
     }
 
     private function cleanup_characters()


### PR DESCRIPTION
I chose these tables after comparing table data length against table size. 

character_assets = DB size: 80MB | Data Length: 33MB
character_fitting_items = DB size: 77MB | Data Length: 31MB
character_wallet_journals = DB size: 164MB | Data Length: 80MB
character_wallet_transactions = DB size: 54MB | Data Length: 26MB
contract_details = DB size: 85MB | Data Length: 54MB
contract_items = DB size: 56MB | Data Length: 39MB

This is comparing against my database of ~450 active tokens, larger databases likely have a greater difference of DB/DL sizes.