### PR TITLE
feat: add middleware to check if ESI route is up

### DIFF
--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -32,6 +32,7 @@ use Seat\Eveapi\Exception\PermanentInvalidTokenException;
 use Seat\Eveapi\Exception\TemporaryEsiOutageException;
 use Seat\Eveapi\Exception\UnavailableEveServersException;
 use Seat\Eveapi\Jobs\Middleware\CheckEsiRateLimit;
+use Seat\Eveapi\Jobs\Middleware\CheckEsiRouteStatus;
 use Seat\Eveapi\Jobs\Middleware\CheckEsiStatus;
 use Seat\Eveapi\Jobs\Middleware\CheckServerStatus;
 use Seat\Eveapi\Models\RefreshToken;
@@ -147,6 +148,7 @@ abstract class EsiBase extends AbstractJob
             new CheckEsiStatus,
             new CheckEsiRateLimit,
             new CheckServerStatus,
+            new CheckEsiRouteStatus,
         ];
     }
 
@@ -193,6 +195,14 @@ abstract class EsiBase extends AbstractJob
     public function getScope(): string
     {
         return $this->scope ?: '';
+    }
+
+    /**
+     * @return string
+     */
+    public function getEndpoint(): string
+    {
+        return $this->endpoint;
     }
 
     /**

--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -33,7 +33,6 @@ use Seat\Eveapi\Exception\TemporaryEsiOutageException;
 use Seat\Eveapi\Exception\UnavailableEveServersException;
 use Seat\Eveapi\Jobs\Middleware\CheckEsiRateLimit;
 use Seat\Eveapi\Jobs\Middleware\CheckEsiRouteStatus;
-use Seat\Eveapi\Jobs\Middleware\CheckEsiStatus;
 use Seat\Eveapi\Jobs\Middleware\CheckServerStatus;
 use Seat\Eveapi\Models\RefreshToken;
 use Seat\Services\Helpers\AnalyticsContainer;
@@ -145,7 +144,6 @@ abstract class EsiBase extends AbstractJob
     public function middleware()
     {
         return [
-            new CheckEsiStatus,
             new CheckEsiRateLimit,
             new CheckServerStatus,
             new CheckEsiRouteStatus,

--- a/src/Jobs/Middleware/CheckEsiRouteStatus.php
+++ b/src/Jobs/Middleware/CheckEsiRouteStatus.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2022 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eveapi\Jobs\Middleware;
+
+use Seat\Eveapi\Jobs\EsiBase;
+use Seat\Eveapi\Jobs\Status\Esi;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+
+/**
+ * Class CheckEsiRouteStatus.
+ *
+ * @package Seat\Eveapi\Jobs\Middleware
+ */
+class CheckEsiRouteStatus
+{
+
+    const ROUTE_STATUS_DURATION = 300;
+
+    const ROUTE = "https://esi.evetech.net/status.json?version=latest";
+
+    /**
+     * @param  \Seat\Eveapi\Jobs\EsiBase  $job
+     * @param $next
+     *
+     * @throws \Exception
+     */
+    public function handle($job, $next)
+    {
+        // bypass control if the class is not related to ESI or is the ESI ping job
+        if (is_subclass_of($job, EsiBase::class) && !($job instanceof Esi)) {
+            logger()->debug('middleware: esistatus: checking for ' . $job->getEndpoint());
+            
+            if (! $this->isRouteOnline($job->getEndpoint())) {
+                logger()->warning(
+                    sprintf('ESI route seems to be unavailable. Job %s has been aborted.',
+                        get_class($job)));
+
+                return;
+            }
+        }
+
+        $next($job);
+    }
+
+    /**
+     * @return bool
+     */
+    private function isRouteOnline($endpoint): bool
+    {
+
+        $cacheKey = "esi-route-status:" . $endpoint;
+
+        // Get the latest ESI status.
+        $status = cache()->remember( $cacheKey, self::ROUTE_STATUS_DURATION, function () use ($endpoint){
+            // Need to probe the status endpoint in order to determine if it is up.
+            logger()->debug('middleware: esistatus: probing endpoint ' . $endpoint);
+            try {
+                $client = new Client([
+                    'timeout' => 30,
+                ]);
+
+                $result = $client->get(self::ROUTE);
+                $data = json_decode($result->getBody());
+
+                foreach($data as $path) {
+                    if ($path->route == $endpoint) {
+                        return isset($path->status) ? $path->status : 'invalid';
+                    }
+                }
+
+                return "missing";
+
+           } catch (RequestException $e) {
+                return 'inaccessible';
+           }
+
+        });
+
+        logger()->debug('middleware: esistatus: result for ' . $endpoint . ' is ' . $status);
+
+        // If the status is OK, yay.
+
+        return ($status == 'green' or $status == 'yellow');
+    }
+
+}

--- a/src/Jobs/Middleware/CheckEsiRouteStatus.php
+++ b/src/Jobs/Middleware/CheckEsiRouteStatus.php
@@ -22,10 +22,10 @@
 
 namespace Seat\Eveapi\Jobs\Middleware;
 
+use Seat\Eseye\Exceptions\RequestFailedException;
 use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Jobs\Status\Esi;
 
-use Seat\Eseye\Exceptions\RequestFailedException;
 /**
  * Class CheckEsiRouteStatus.
  *
@@ -36,7 +36,7 @@ class CheckEsiRouteStatus
 
     const ROUTE_STATUS_DURATION = 300;
 
-    const ROUTE = "https://esi.evetech.net/status.json?version=latest";
+    const ROUTE = 'https://esi.evetech.net/status.json?version=latest';
 
     /**
      * @param  \Seat\Eveapi\Jobs\EsiBase  $job
@@ -47,9 +47,9 @@ class CheckEsiRouteStatus
     public function handle($job, $next)
     {
         // bypass control if the class is not related to ESI or is the ESI ping job
-        if (is_subclass_of($job, EsiBase::class) && !($job instanceof Esi)) {
+        if (is_subclass_of($job, EsiBase::class) && ! ($job instanceof Esi)) {
             logger()->debug('middleware: esistatus: checking for ' . $job->getEndpoint());
-            
+
             if (! $this->isRouteOnline($job->getEndpoint())) {
                 logger()->warning(
                     sprintf('ESI route seems to be unavailable. Job %s has been aborted.',
@@ -68,10 +68,10 @@ class CheckEsiRouteStatus
     private function isRouteOnline($endpoint): bool
     {
 
-        $cacheKey = "esi-route-status:" . $endpoint;
+        $cacheKey = 'esi-route-status:' . $endpoint;
 
         // Get the latest ESI status.
-        $status = cache()->remember( $cacheKey, self::ROUTE_STATUS_DURATION, function () use ($endpoint){
+        $status = cache()->remember($cacheKey, self::ROUTE_STATUS_DURATION, function () use ($endpoint) {
             // Need to probe the status endpoint in order to determine if it is up.
             logger()->debug('middleware: esistatus: probing endpoint ' . $endpoint);
             try {
@@ -87,7 +87,7 @@ class CheckEsiRouteStatus
                     }
                 }
 
-                return "missing";
+                return 'missing';
 
            } catch (RequestFailedException $e) {
                 return 'inaccessible';
@@ -99,7 +99,6 @@ class CheckEsiRouteStatus
 
         // If the status is OK, yay.
 
-        return ($status == 'green' or $status == 'yellow');
+        return $status == 'green' or $status == 'yellow';
     }
-
 }


### PR DESCRIPTION
This middleware will check the esi status and only allow a request if the route is present, and reporting a status of green or yellow.