### PR TITLE
Feature: Load market order data

### DIFF
--- a/src/Commands/Esi/Update/Prices.php
+++ b/src/Commands/Esi/Update/Prices.php
@@ -24,6 +24,7 @@ namespace Seat\Eveapi\Commands\Esi\Update;
 
 use Illuminate\Console\Command;
 use Seat\Eveapi\Jobs\Market\History;
+use Seat\Eveapi\Jobs\Market\OrderAggregates;
 use Seat\Eveapi\Jobs\Market\Orders;
 use Seat\Eveapi\Jobs\Market\Prices as PricesJob;
 use Seat\Eveapi\Models\Sde\InvType;
@@ -54,20 +55,22 @@ class Prices extends Command
      */
     public function handle()
     {
-        // collect all items which can be sold on the market.
-//        $types = InvType::whereNotNull('marketGroupID')
-//            ->where('published', true)
-//            ->select('typeID')
-//            ->get();
-//
-//        //PricesJob::dispatch();
-//
-//        // build small batch of a maximum of 200 entries to avoid long running job.
-//        $types->chunk(50)->each(function ($chunk) {
-//            $ids = $chunk->pluck('typeID')->toArray();
-//            History::dispatch($ids)->delay(rand(20, 300));
-//        });
+        //collect all items which can be sold on the market.
+        $types = InvType::whereNotNull('marketGroupID')
+            ->where('published', true)
+            ->select('typeID')
+            ->get();
 
-        Orders::dispatchNow();
+        PricesJob::dispatch();
+
+        // build small batch of a maximum of 200 entries to avoid long running job.
+        $types->chunk(50)->each(function ($chunk) {
+            $ids = $chunk->pluck('typeID')->toArray();
+            History::dispatch($ids)->delay(rand(20, 300));
+        });
+
+        Orders::withChain([
+            new OrderAggregates()
+        ])->dispatch();
     }
 }

--- a/src/Commands/Esi/Update/Prices.php
+++ b/src/Commands/Esi/Update/Prices.php
@@ -24,6 +24,7 @@ namespace Seat\Eveapi\Commands\Esi\Update;
 
 use Illuminate\Console\Command;
 use Seat\Eveapi\Jobs\Market\History;
+use Seat\Eveapi\Jobs\Market\Orders;
 use Seat\Eveapi\Jobs\Market\Prices as PricesJob;
 use Seat\Eveapi\Models\Sde\InvType;
 
@@ -54,17 +55,19 @@ class Prices extends Command
     public function handle()
     {
         // collect all items which can be sold on the market.
-        $types = InvType::whereNotNull('marketGroupID')
-            ->where('published', true)
-            ->select('typeID')
-            ->get();
+//        $types = InvType::whereNotNull('marketGroupID')
+//            ->where('published', true)
+//            ->select('typeID')
+//            ->get();
+//
+//        //PricesJob::dispatch();
+//
+//        // build small batch of a maximum of 200 entries to avoid long running job.
+//        $types->chunk(50)->each(function ($chunk) {
+//            $ids = $chunk->pluck('typeID')->toArray();
+//            History::dispatch($ids)->delay(rand(20, 300));
+//        });
 
-        PricesJob::dispatch();
-
-        // build small batch of a maximum of 200 entries to avoid long running job.
-        $types->chunk(50)->each(function ($chunk) {
-            $ids = $chunk->pluck('typeID')->toArray();
-            History::dispatch($ids)->delay(rand(20, 300));
-        });
+        Orders::dispatchNow();
     }
 }

--- a/src/Commands/Esi/Update/Prices.php
+++ b/src/Commands/Esi/Update/Prices.php
@@ -55,7 +55,7 @@ class Prices extends Command
      */
     public function handle()
     {
-        //collect all items which can be sold on the market.
+        // collect all items which can be sold on the market.
         $types = InvType::whereNotNull('marketGroupID')
             ->where('published', true)
             ->select('typeID')

--- a/src/Commands/Esi/Update/Prices.php
+++ b/src/Commands/Esi/Update/Prices.php
@@ -70,7 +70,7 @@ class Prices extends Command
         });
 
         Orders::withChain([
-            new OrderAggregates()
+            new OrderAggregates(),
         ])->dispatch();
     }
 }

--- a/src/Jobs/Market/OrderAggregates.php
+++ b/src/Jobs/Market/OrderAggregates.php
@@ -37,10 +37,10 @@ class OrderAggregates extends AbstractJob
 
     public function handle()
     {
-        //the time only needs to be loaded once instead of every time in the loop
+        // the time only needs to be loaded once instead of every time in the loop
         $now = carbon();
 
-        //update sell orders
+        // update sell orders
         MarketOrder::selectRaw('type_id, MIN(price) as sell_price')
             ->groupBy('type_id')
             ->where('is_buy_order', false)
@@ -62,15 +62,15 @@ class OrderAggregates extends AbstractJob
                 );
             });
 
-        //update buy orders
+        // update buy orders
         MarketOrder::selectRaw('type_id, MAX(price) as buy_price')
             ->groupBy('type_id')
             ->where('is_buy_order', true)
             ->chunk(1000, function ($types) use ($now) {
                 $types = $types->map(function ($type) use ($now) {
                     return [
-                        'type_id'=>$type->type_id,
-                        'buy_price'=>$type->buy_price,
+                        'type_id' => $type->type_id,
+                        'buy_price' => $type->buy_price,
                         'created_at'     => $now,
                         'updated_at'     => $now,
                     ];

--- a/src/Jobs/Market/OrderAggregates.php
+++ b/src/Jobs/Market/OrderAggregates.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2023 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eveapi\Jobs\Market;
+
+use Seat\Eveapi\Jobs\AbstractJob;
+use Seat\Eveapi\Models\Market\MarketOrder;
+use Illuminate\Support\Facades\DB;
+use Seat\Eveapi\Models\Market\Price;
+
+/**
+ * Class OrderAggregates.
+ *
+ * @package Seat\Eveapi\Jobs\Market
+ */
+class OrderAggregates extends AbstractJob
+{
+    protected $tags = ["market","orders"];
+
+    public function handle()
+    {
+        $now = carbon();
+
+        MarketOrder::selectRaw("type_id, MIN(price) as sell_price")
+            ->groupBy("type_id")
+            ->where("is_buy_order",false)
+            ->chunk(500, function ($types) use ($now) {
+                $types = $types->map(function ($type) use ($now) {
+                    return [
+                        "type_id"=>$type->type_id,
+                        "sell_price"=>$type->sell_price,
+                        'created_at'     => $now,
+                        'updated_at'     => $now,
+                    ];
+                });
+
+                Price::upsert($types->toArray(),
+                    [
+                        "type_id",
+                        "sell_price",
+                    ]
+                );
+            });
+
+        MarketOrder::selectRaw("type_id, MAX(price) as buy_price")
+            ->groupBy("type_id")
+            ->where("is_buy_order",true)
+            ->chunk(500, function ($types) use ($now) {
+                $types = $types->map(function ($type) use ($now) {
+                    return [
+                        "type_id"=>$type->type_id,
+                        "buy_price"=>$type->buy_price,
+                        'created_at'     => $now,
+                        'updated_at'     => $now,
+                    ];
+                });
+
+                Price::upsert($types->toArray(),
+                    [
+                        "type_id",
+                        "buy_price",
+                        'updated_at',
+                    ]
+                );
+            });
+    }
+}

--- a/src/Jobs/Market/OrderAggregates.php
+++ b/src/Jobs/Market/OrderAggregates.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of SeAT
  *
- * Copyright (C) 2015 to 2023 Leon Jacobs
+ * Copyright (C) 2015 to 2022 Leon Jacobs
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,7 +24,6 @@ namespace Seat\Eveapi\Jobs\Market;
 
 use Seat\Eveapi\Jobs\AbstractJob;
 use Seat\Eveapi\Models\Market\MarketOrder;
-use Illuminate\Support\Facades\DB;
 use Seat\Eveapi\Models\Market\Price;
 
 /**
@@ -34,7 +33,7 @@ use Seat\Eveapi\Models\Market\Price;
  */
 class OrderAggregates extends AbstractJob
 {
-    protected $tags = ["market","orders"];
+    protected $tags = ['market', 'orders'];
 
     public function handle()
     {
@@ -42,14 +41,14 @@ class OrderAggregates extends AbstractJob
         $now = carbon();
 
         //update sell orders
-        MarketOrder::selectRaw("type_id, MIN(price) as sell_price")
-            ->groupBy("type_id")
-            ->where("is_buy_order",false)
+        MarketOrder::selectRaw('type_id, MIN(price) as sell_price')
+            ->groupBy('type_id')
+            ->where('is_buy_order', false)
             ->chunk(1000, function ($types) use ($now) {
                 $types = $types->map(function ($type) use ($now) {
                     return [
-                        "type_id"=>$type->type_id,
-                        "sell_price"=>$type->sell_price,
+                        'type_id'=>$type->type_id,
+                        'sell_price'=>$type->sell_price,
                         'created_at'     => $now,
                         'updated_at'     => $now,
                     ];
@@ -57,21 +56,21 @@ class OrderAggregates extends AbstractJob
 
                 Price::upsert($types->toArray(),
                     [
-                        "type_id",
-                        "sell_price",
+                        'type_id',
+                        'sell_price',
                     ]
                 );
             });
 
         //update buy orders
-        MarketOrder::selectRaw("type_id, MAX(price) as buy_price")
-            ->groupBy("type_id")
-            ->where("is_buy_order",true)
+        MarketOrder::selectRaw('type_id, MAX(price) as buy_price')
+            ->groupBy('type_id')
+            ->where('is_buy_order', true)
             ->chunk(1000, function ($types) use ($now) {
                 $types = $types->map(function ($type) use ($now) {
                     return [
-                        "type_id"=>$type->type_id,
-                        "buy_price"=>$type->buy_price,
+                        'type_id'=>$type->type_id,
+                        'buy_price'=>$type->buy_price,
                         'created_at'     => $now,
                         'updated_at'     => $now,
                     ];
@@ -79,8 +78,8 @@ class OrderAggregates extends AbstractJob
 
                 Price::upsert($types->toArray(),
                     [
-                        "type_id",
-                        "buy_price",
+                        'type_id',
+                        'buy_price',
                         'updated_at',
                     ]
                 );

--- a/src/Jobs/Market/Orders.php
+++ b/src/Jobs/Market/Orders.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2023 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eveapi\Jobs\Market;
+
+use Seat\Eveapi\Jobs\EsiBase;
+use Seat\Eveapi\Models\Market\MarketOrder;
+use Seat\Eveapi\Models\Market\Price;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Class Prices.
+ *
+ * @package Seat\Eveapi\Jobs\Market
+ */
+class Orders extends EsiBase
+{
+    const THE_FORGE = 10000002;
+
+    /**
+     * @var string
+     */
+    protected $method = 'get';
+
+    /**
+     * @var string
+     */
+    protected $endpoint = '/markets/{region_id}/orders/';
+
+    /**
+     * @var string
+     */
+    protected $version = 'v1';
+
+    /**
+     * @var array
+     */
+    protected $tags = ['public', 'market'];
+
+    /**
+     * Execute the job.
+     *
+     * @throws \Throwable
+     */
+    public function handle()
+    {
+        // this job need a ton of memory. temporarily unlock memory limit as a hack fix
+        ini_set('memory_limit', -1);
+
+        $count = MarketOrder::count();
+
+        while (false) {
+            $orders = $this->retrieve(["region_id" => setting('market_prices_region_id', true) ?: self::THE_FORGE]);
+
+            if ($orders->isCachedLoad() && $count > 0) return;
+
+            collect($orders)->chunk(1000)->each(function ($chunk) {
+                $records = $chunk->map(function ($order) {
+                    return [
+                        'order_id' => $order->order_id,
+                        'duration' => $order->duration,
+                        'is_buy_order' => $order->is_buy_order,
+                        'issued' => carbon($order->issued),
+                        'location_id' => $order->location_id,
+                        'min_volume' => $order->min_volume,
+                        'price' => $order->price,
+                        'range' => $order->range,
+                        'system_id' => $order->system_id,
+                        'type_id' => $order->type_id,
+                        'volume_remaining' => $order->volume_remain,
+                        'volume_total' => $order->volume_total
+                    ];
+                });
+
+                MarketOrder::upsert($records->toArray(), [
+                    'order_id',
+                ]);
+            });
+
+            if (! $this->nextPage($orders->pages)) break;
+        }
+
+        MarketOrder::whereRaw("ADDDATE(issued,INTERVAL duration DAY) < CURRENT_DATE()")->delete();
+    }
+}

--- a/src/Jobs/Market/Orders.php
+++ b/src/Jobs/Market/Orders.php
@@ -72,7 +72,7 @@ class Orders extends EsiBase
             // if the orders are cached, skip this
             //if ($orders->isCachedLoad() && $count > 0) return;
 
-            // map the ESI format to the database format, insert updated_at and created_at times
+            // map the ESI format to the database format
             // if the batch size is increased to 1000, it crashed
             collect($orders)->chunk(100)->each(function ($chunk) {
                 // map the ESI format to the database format
@@ -110,7 +110,6 @@ class Orders extends EsiBase
                     'type_id',
                     'volume_remaining',
                     'volume_total',
-                    'updated_at',
                     'expiry',
                 ]);
             });

--- a/src/Jobs/Market/Orders.php
+++ b/src/Jobs/Market/Orders.php
@@ -69,9 +69,6 @@ class Orders extends EsiBase
             //retrieve one page of market orders
             $orders = $this->retrieve(['region_id' => $region_id]);
 
-            // if the orders are cached, skip this
-            //if ($orders->isCachedLoad() && $count > 0) return;
-
             // map the ESI format to the database format
             // if the batch size is increased to 1000, it crashed
             collect($orders)->chunk(100)->each(function ($chunk) {

--- a/src/Jobs/Market/Orders.php
+++ b/src/Jobs/Market/Orders.php
@@ -81,6 +81,7 @@ class Orders extends EsiBase
                 //map the ESI format to the database format
                 $records = $chunk->map(function ($order) use ($now) {
                     $issued = carbon($order->issued);
+
                     return [
                         'order_id' => $order->order_id,
                         'duration' => $order->duration,
@@ -115,7 +116,7 @@ class Orders extends EsiBase
                     'volume_remaining',
                     'volume_total',
                     'updated_at',
-                    'expiry'
+                    'expiry',
                 ]);
             });
 

--- a/src/Jobs/Market/Orders.php
+++ b/src/Jobs/Market/Orders.php
@@ -67,14 +67,15 @@ class Orders extends EsiBase
         ini_set('memory_limit', -1);
 
         $count = MarketOrder::count();
+        $now = carbon();
 
-        while (false) {
+        while (true) {
             $orders = $this->retrieve(["region_id" => setting('market_prices_region_id', true) ?: self::THE_FORGE]);
 
             if ($orders->isCachedLoad() && $count > 0) return;
 
-            collect($orders)->chunk(1000)->each(function ($chunk) {
-                $records = $chunk->map(function ($order) {
+            collect($orders)->chunk(1000)->each(function ($chunk) use ($now) {
+                $records = $chunk->map(function ($order) use ($now) {
                     return [
                         'order_id' => $order->order_id,
                         'duration' => $order->duration,
@@ -87,7 +88,9 @@ class Orders extends EsiBase
                         'system_id' => $order->system_id,
                         'type_id' => $order->type_id,
                         'volume_remaining' => $order->volume_remain,
-                        'volume_total' => $order->volume_total
+                        'volume_total' => $order->volume_total,
+                        'updated_at'=>$now,
+                        'created_at'=>$now
                     ];
                 });
 

--- a/src/Jobs/Market/Orders.php
+++ b/src/Jobs/Market/Orders.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of SeAT
  *
- * Copyright (C) 2015 to 2023 Leon Jacobs
+ * Copyright (C) 2015 to 2022 Leon Jacobs
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,9 +22,9 @@
 
 namespace Seat\Eveapi\Jobs\Market;
 
+use Illuminate\Support\Facades\DB;
 use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\Market\MarketOrder;
-use Illuminate\Support\Facades\DB;
 
 /**
  * Class Orders.
@@ -70,7 +70,7 @@ class Orders extends EsiBase
         //load all market data
         while (true) {
             //retrieve one page of market orders
-            $orders = $this->retrieve(["region_id" => $region_id]);
+            $orders = $this->retrieve(['region_id' => $region_id]);
 
             //if the orders are cached, skip this
             if ($orders->isCachedLoad() && $count > 0) return;
@@ -94,7 +94,7 @@ class Orders extends EsiBase
                         'volume_remaining' => $order->volume_remain,
                         'volume_total' => $order->volume_total,
                         'updated_at'=>$now,
-                        'created_at'=>$now
+                        'created_at'=>$now,
                     ];
                 });
 
@@ -112,7 +112,7 @@ class Orders extends EsiBase
                     'type_id',
                     'volume_remaining',
                     'volume_total',
-                    'updated_at'
+                    'updated_at',
                 ]);
             });
 
@@ -122,6 +122,6 @@ class Orders extends EsiBase
 
         // remove old orders
         // if this ever gets changed to retain old orders, add an expiry check in the OrderAggregates job.
-        MarketOrder::whereRaw("ADDDATE(issued,INTERVAL duration DAY) < CURRENT_DATE()")->delete();
+        MarketOrder::whereRaw('ADDDATE(issued,INTERVAL duration DAY) < CURRENT_DATE()')->delete();
     }
 }

--- a/src/Models/Market/MarketOrder.php
+++ b/src/Models/Market/MarketOrder.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2022 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eveapi\Models\Market;
+
+use Illuminate\Database\Eloquent\Model;
+use Seat\Eveapi\Models\Sde\InvType;
+use Seat\Eveapi\Traits\CanUpsertIgnoreReplace;
+
+/**
+ * Class Price.
+ *
+ * @package Seat\Eveapi\Models\Market
+ */
+class MarketOrder extends Model
+{
+
+    use CanUpsertIgnoreReplace;
+
+    /**
+     * @var bool
+     */
+    protected static $unguarded = true;
+
+    /**
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * @var string
+     */
+    protected $primaryKey = 'order_id';
+
+    /**
+     * @var string
+     */
+    protected $table = 'market_orders';
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function type()
+    {
+        return $this->hasOne(InvType::class, 'typeID', 'type_id');
+    }
+}

--- a/src/Models/Market/MarketOrder.php
+++ b/src/Models/Market/MarketOrder.php
@@ -66,6 +66,7 @@ class MarketOrder extends Model
         'issued',
         'expiry',
     ];
+
     /**
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */

--- a/src/Models/Market/MarketOrder.php
+++ b/src/Models/Market/MarketOrder.php
@@ -60,7 +60,7 @@ class MarketOrder extends Model
     protected $table = 'market_orders';
 
     /**
-     * @var boolean
+     * @var bool
      */
     public $timestamps = false;
 

--- a/src/Models/Market/MarketOrder.php
+++ b/src/Models/Market/MarketOrder.php
@@ -60,6 +60,11 @@ class MarketOrder extends Model
     protected $table = 'market_orders';
 
     /**
+     * @var boolean
+     */
+    public $timestamps = false;
+
+    /**
      * @var array
      */
     protected $dates = [

--- a/src/Models/Market/MarketOrder.php
+++ b/src/Models/Market/MarketOrder.php
@@ -60,6 +60,13 @@ class MarketOrder extends Model
     protected $table = 'market_orders';
 
     /**
+     * @var array
+     */
+    protected $dates = [
+        'issued',
+        'expiry',
+    ];
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
     public function type()

--- a/src/Models/Market/MarketOrder.php
+++ b/src/Models/Market/MarketOrder.php
@@ -25,6 +25,8 @@ namespace Seat\Eveapi\Models\Market;
 use Illuminate\Database\Eloquent\Model;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Eveapi\Models\Sde\SolarSystem;
+use Seat\Eveapi\Models\Universe\UniverseStation;
+use Seat\Eveapi\Models\Universe\UniverseStructure;
 use Seat\Eveapi\Traits\CanUpsertIgnoreReplace;
 
 /**
@@ -72,5 +74,21 @@ class MarketOrder extends Model
     {
         return $this->hasOne(SolarSystem::class, 'system_id', 'system_id')
             ->withDefault();
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function structure()
+    {
+        return $this->hasOne(UniverseStructure::class, 'structure_id', 'location_id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function station()
+    {
+        return $this->hasOne(UniverseStation::class, 'station_id', 'location_id');
     }
 }

--- a/src/Models/Market/MarketOrder.php
+++ b/src/Models/Market/MarketOrder.php
@@ -24,6 +24,7 @@ namespace Seat\Eveapi\Models\Market;
 
 use Illuminate\Database\Eloquent\Model;
 use Seat\Eveapi\Models\Sde\InvType;
+use Seat\Eveapi\Models\Sde\SolarSystem;
 use Seat\Eveapi\Traits\CanUpsertIgnoreReplace;
 
 /**
@@ -62,5 +63,14 @@ class MarketOrder extends Model
     public function type()
     {
         return $this->hasOne(InvType::class, 'typeID', 'type_id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function solar_system()
+    {
+        return $this->hasOne(SolarSystem::class, 'system_id', 'system_id')
+            ->withDefault();
     }
 }

--- a/src/database/migrations/2023_02_23_174650_add_market_orders_data.php
+++ b/src/database/migrations/2023_02_23_174650_add_market_orders_data.php
@@ -24,7 +24,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateMarketOrdersTable extends Migration
+class AddMarketOrdersData extends Migration
 {
     /**
      * Run the migrations.
@@ -49,6 +49,11 @@ class CreateMarketOrdersTable extends Migration
             $table->integer("volume_total")->unsigned();
             $table->timestamps();
         });
+
+        Schema::table('market_prices', function (Blueprint $table){
+            $table->decimal("sell_price",30,2)->default(0);
+            $table->decimal("buy_price",30,2)->default(0);
+        });
     }
 
     /**
@@ -59,5 +64,10 @@ class CreateMarketOrdersTable extends Migration
     public function down()
     {
         Schema::drop('market_orders');
+
+        Schema::table('market_prices', function (Blueprint $table){
+            $table->dropColumn('sell_price');
+            $table->dropColumn('buy_price');
+        });
     }
 }

--- a/src/database/migrations/2023_02_23_174650_add_market_orders_data.php
+++ b/src/database/migrations/2023_02_23_174650_add_market_orders_data.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of SeAT
  *
- * Copyright (C) 2015 to 2023 Leon Jacobs
+ * Copyright (C) 2015 to 2022 Leon Jacobs
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,24 +35,24 @@ class AddMarketOrdersData extends Migration
     {
         Schema::create('market_orders', function (Blueprint $table) {
             // just mirror the ESI data
-            $table->bigInteger("order_id")->unsigned()->primary();
+            $table->bigInteger('order_id')->unsigned()->primary();
             $table->smallInteger('duration')->unsigned();
             $table->boolean('is_buy_order');
             $table->dateTime('issued');
             $table->bigInteger('location_id');
             $table->integer('min_volume')->unsigned();
-            $table->decimal("price",30,2);
-            $table->enum("range",[ "station", "region", "solarsystem", "1", "2", "3", "4", "5", "10", "20", "30", "40" ]);
-            $table->bigInteger("system_id")->unsigned();
-            $table->bigInteger("type_id")->unsigned()->index();
-            $table->integer("volume_remaining")->unsigned();
-            $table->integer("volume_total")->unsigned();
+            $table->decimal('price', 30, 2);
+            $table->enum('range', ['station', 'region', 'solarsystem', '1', '2', '3', '4', '5', '10', '20', '30', '40']);
+            $table->bigInteger('system_id')->unsigned();
+            $table->bigInteger('type_id')->unsigned()->index();
+            $table->integer('volume_remaining')->unsigned();
+            $table->integer('volume_total')->unsigned();
             $table->timestamps();
         });
 
-        Schema::table('market_prices', function (Blueprint $table){
-            $table->decimal("sell_price",30,2)->default(0);
-            $table->decimal("buy_price",30,2)->default(0);
+        Schema::table('market_prices', function (Blueprint $table) {
+            $table->decimal('sell_price', 30, 2)->default(0);
+            $table->decimal('buy_price', 30, 2)->default(0);
         });
     }
 
@@ -65,7 +65,7 @@ class AddMarketOrdersData extends Migration
     {
         Schema::drop('market_orders');
 
-        Schema::table('market_prices', function (Blueprint $table){
+        Schema::table('market_prices', function (Blueprint $table) {
             $table->dropColumn('sell_price');
             $table->dropColumn('buy_price');
         });

--- a/src/database/migrations/2023_02_23_174650_add_market_orders_data.php
+++ b/src/database/migrations/2023_02_23_174650_add_market_orders_data.php
@@ -48,7 +48,6 @@ class AddMarketOrdersData extends Migration
             $table->bigInteger('type_id')->unsigned()->index();
             $table->integer('volume_remaining')->unsigned();
             $table->integer('volume_total')->unsigned();
-            $table->timestamps();
         });
 
         Schema::table('market_prices', function (Blueprint $table) {

--- a/src/database/migrations/2023_02_23_174650_add_market_orders_data.php
+++ b/src/database/migrations/2023_02_23_174650_add_market_orders_data.php
@@ -39,6 +39,7 @@ class AddMarketOrdersData extends Migration
             $table->smallInteger('duration')->unsigned();
             $table->boolean('is_buy_order');
             $table->dateTime('issued');
+            $table->dateTime('expiry');
             $table->bigInteger('location_id');
             $table->integer('min_volume')->unsigned();
             $table->decimal('price', 30, 2);

--- a/src/database/migrations/2023_02_23_174650_create_market_orders_table.php
+++ b/src/database/migrations/2023_02_23_174650_create_market_orders_table.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2023 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMarketOrdersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('market_orders', function (Blueprint $table) {
+            // just mirror the ESI data
+            $table->bigInteger("order_id")->unsigned()->primary();
+            $table->smallInteger('duration')->unsigned();
+            $table->boolean('is_buy_order');
+            $table->dateTime('issued');
+            $table->bigInteger('location_id');
+            $table->integer('min_volume')->unsigned();
+            $table->decimal("price",30,2);
+            $table->enum("range",[ "station", "region", "solarsystem", "1", "2", "3", "4", "5", "10", "20", "30", "40" ]);
+            $table->bigInteger("system_id")->unsigned();
+            $table->bigInteger("type_id")->unsigned()->index();
+            $table->integer("volume_remaining")->unsigned();
+            $table->integer("volume_total")->unsigned();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('market_orders');
+    }
+}


### PR DESCRIPTION
Loads all market orders from the Market Prices Region. They are then converted into aggregates for sell and buy prices. This is more precise than the prices from the history and prices endpoint. The choice to keep the raw orders too is to build something like a market browser and just in general enable more innovation with market analysis in seat plugins(Like a tool that notifies you when you get outpriced with your orders, for example).

Right now, nearly all plugins that require precise prices (seat-transport, seat-buypack, seat-alliance-industry) contact evepraisal for their prices instead of using seat-internal prices. Additionally, there have been constant complaints about the inaccurate prices from seat-billing, which uses the existing (incorrect) seat prices.

After loading The Forge orders, the `market_orders` table took up about 80 MB. The Forge is probably the biggest region when it comes to orders. Compared with other tables, it isn't even the largest; a big seat installation will accumulate this amount of data from users regardless.

Before merging, can someone check if I used `Model::upsert` from the trait `Seat\Eveapi\Traits\CanUpsertIgnoreReplace` correctly, especially with regards to `created_at`?

Is it correct to put the aggregates into `market_prices`? The data from the history and prices endpoint is already combined in there, so I think it would make sense to put it there. Additionally, this makes it easier to port code to using other kinds of prices.

I'm targeting this for seat 4 since the release for seat 5 and 6 don't seem to come soon, but I still want to continue with adding functionality for my plugins. Also, I believe a fast, rolling release model that brings new feature to users fast is better than a model where it is stuck in development for a year or more.