### PR TITLE
fix type hints to the correct type

### DIFF
--- a/src/Jobs/AbstractAuthCorporationJob.php
+++ b/src/Jobs/AbstractAuthCorporationJob.php
@@ -22,7 +22,6 @@
 
 namespace Seat\Eveapi\Jobs;
 
-use Exception;
 use Seat\Eseye\Exceptions\RequestFailedException;
 use Seat\Eveapi\Jobs\Middleware\CheckTokenScope;
 use Seat\Eveapi\Jobs\Middleware\CheckTokenVersion;
@@ -32,6 +31,7 @@ use Seat\Eveapi\Jobs\Middleware\WithoutOverlapping;
 use Seat\Eveapi\Models\Character\CharacterAffiliation;
 use Seat\Eveapi\Models\Corporation\CorporationMemberTracking;
 use Seat\Eveapi\Models\RefreshToken;
+use Throwable;
 
 /**
  * Class AbstractAuthenticatedCorporationJob.
@@ -84,11 +84,11 @@ abstract class AbstractAuthCorporationJob extends AbstractCorporationJob
     }
 
     /**
-     * @param  \Exception  $exception
+     * @param  \Throwable  $exception
      *
      * @throws \Exception
      */
-    public function failed(Exception $exception)
+    public function failed(Throwable $exception)
     {
         if (is_a($exception, RequestFailedException::class)) {
             if ($exception->getError() == self::CHARACTER_NOT_IN_CORPORATION) {

--- a/src/Jobs/AbstractJob.php
+++ b/src/Jobs/AbstractJob.php
@@ -22,7 +22,6 @@
 
 namespace Seat\Eveapi\Jobs;
 
-use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -30,6 +29,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Seat\Services\Helpers\AnalyticsContainer;
 use Seat\Services\Jobs\Analytics;
+use Throwable;
 
 /**
  * Class AbstractJob.
@@ -71,11 +71,11 @@ abstract class AbstractJob implements ShouldQueue
      * limiter. This is checked as part of the preflight
      * checks when API calls are made.
      *
-     * @param  \Exception  $exception
+     * @param  \Throwable  $exception
      *
      * @throws \Exception
      */
-    public function failed(Exception $exception)
+    public function failed(Throwable $exception)
     {
         // Analytics. Report only the Exception class and message.
         dispatch((new Analytics((new AnalyticsContainer)

--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -37,6 +37,7 @@ use Seat\Eveapi\Jobs\Middleware\CheckServerStatus;
 use Seat\Eveapi\Models\RefreshToken;
 use Seat\Services\Helpers\AnalyticsContainer;
 use Seat\Services\Jobs\Analytics;
+use Throwable;
 
 /**
  * Class EsiBase.
@@ -212,11 +213,11 @@ abstract class EsiBase extends AbstractJob
     }
 
     /**
-     * @param  \Exception  $exception
+     * @param  \Throwable  $exception
      *
      * @throws \Exception
      */
-    public function failed(Exception $exception)
+    public function failed(Throwable $exception)
     {
         parent::failed($exception);
 


### PR DESCRIPTION
According to the [documentation](https://laravel.com/docs/10.x/queues#cleaning-up-after-failed-jobs), `failed` callbacks should receive a `Throwable` and not an `Exception`.

This also caused tinker to fail executing the job, so I decided to fix it. 