### PR TITLE
fix(jobs): ensure POCOs location are properly resolved

### DIFF
--- a/src/Jobs/PlanetaryInteraction/Corporation/CustomsOfficeLocations.php
+++ b/src/Jobs/PlanetaryInteraction/Corporation/CustomsOfficeLocations.php
@@ -24,6 +24,7 @@ namespace Seat\Eveapi\Jobs\PlanetaryInteraction\Corporation;
 
 use Seat\Eveapi\Jobs\AbstractAuthCorporationJob;
 use Seat\Eveapi\Models\PlanetaryInteraction\CorporationCustomsOffice;
+use Seat\Eveapi\Models\Sde\MapDenormalize;
 use Seat\Eveapi\Traits\Utils;
 
 /**
@@ -97,7 +98,8 @@ class CustomsOfficeLocations extends AbstractAuthCorporationJob
                     $chunk->firstWhere('office_id', $location->item_id)->system_id,
                     $location->position->x,
                     $location->position->y,
-                    $location->position->z
+                    $location->position->z,
+                    MapDenormalize::PLANET
                 );
 
                 CorporationCustomsOffice::firstOrNew([

--- a/src/Models/Sde/MapDenormalize.php
+++ b/src/Models/Sde/MapDenormalize.php
@@ -42,89 +42,75 @@ use Seat\Eveapi\Traits\IsReadOnly;
  *     property="itemID",
  *     description="The entity ID"
  * )
- *
  * @OA\Property(
  *     type="integer",
  *     property="typeID",
  *     description="The type of the entity"
  * )
- *
  * @OA\Property(
  *     type="integer",
  *     property="groupID",
  *     description="The group to which the entity is related"
  * )
- *
  * @OA\Property(
  *     type="integer",
  *     property="solarSystemID",
  *     description="The system to which the entity is attached"
  * )
- *
  * @OA\Property(
  *     type="integer",
  *     property="constellationID",
  *     description="The constellation to which the entity is attached"
  * )
- *
  * @OA\Property(
  *     type="integer",
  *     property="regionID",
  *     description="The region to which the entity is attached"
  * )
- *
  * @OA\Property(
  *     type="integer",
  *     property="orbitID",
  *     description="The orbit to which the entity is depending"
  * )
- *
  * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="x",
  *     description="x position on the map"
  * )
- *
  * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="y",
  *     description="y position on the map"
  * )
- *
  * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="z",
  *     description="z position on the map"
  * )
- *
  * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="radius",
  *     description="The radius of the entity"
  * )
- *
  * @OA\Property(
  *     type="string",
  *     property="itemName",
  *     description="The entity name"
  * )
- *
  * @OA\Property(
  *     type="number",
  *     format="double",
  *     property="security",
  *     description="The security status of the system to which entity is attached"
  * )
- *
  * @OA\Property(
  *     type="integer",
  *     property="celestialIndex",
  * )
- *
  * @OA\Property(
  *     type="integer",
  *     property="orbitIndex"

--- a/src/Models/Sde/MapDenormalize.php
+++ b/src/Models/Sde/MapDenormalize.php
@@ -134,21 +134,23 @@ class MapDenormalize extends Model
 {
     use IsReadOnly;
 
-    const BELT = 9;
+    const REGION = 3;
 
     const CONSTELLATION = 4;
 
-    const MOON = 8;
-
-    const PLANET = 7;
-
-    const REGION = 3;
-
-    const STATION = 15;
+    const SYSTEM = 5;
 
     const SUN = 6;
 
-    const SYSTEM = 5;
+    const PLANET = 7;
+
+    const MOON = 8;
+
+    const BELT = 9;
+
+    const STARGATE = 10;
+
+    const STATION = 15;
 
     const UBIQUITOUS = 2396;
 

--- a/src/Traits/Utils.php
+++ b/src/Traits/Utils.php
@@ -107,7 +107,7 @@ trait Utils
 
             // See: http://math.stackexchange.com/a/42642
             $distance = sqrt(
-                pow(($x - $celestial->x), 2) + pow(($y - $celestial->y), 2) + pow(($z - $celestial->z), 2));
+                pow($x - $celestial->x, 2) + pow($y - $celestial->y, 2) + pow($z - $celestial->z, 2));
 
             // Are we there yet?
             if ($distance < $closest_distance) {

--- a/src/Traits/Utils.php
+++ b/src/Traits/Utils.php
@@ -40,9 +40,10 @@ trait Utils
      * @param  float  $x
      * @param  float  $y
      * @param  float  $z
+     * @param  ?int  $group
      * @return array
      */
-    public function find_nearest_celestial(int $solar_system_id, float $x, float $y, float $z): array
+    public function find_nearest_celestial(int $solar_system_id, float $x, float $y, float $z, ?int $group = null): array
     {
 
         // Querying mapDenormalized with [1] we can see
@@ -77,7 +78,7 @@ trait Utils
         $closest_distance = PHP_INT_MAX;
 
         // As a response, we will return an array with
-        // the closest ID and name from mapDenormallized.
+        // the closest ID and name from mapDenormalize.
         // The default response will be the system this
         // location is in.
         $response = [
@@ -85,10 +86,21 @@ trait Utils
             'map_name' => 'Unknown',
         ];
 
+        $searched_groups = [
+            MapDenormalize::SUN,
+            MapDenormalize::PLANET,
+            MapDenormalize::MOON,
+            MapDenormalize::BELT,
+            MapDenormalize::STARGATE,
+        ];
+
+        if (! is_null($group))
+            $searched_groups = [$group];
+
         $possible_celestials = MapDenormalize::where('solarSystemID', $solar_system_id)
             ->whereNotNull('itemName')
             ->where('x', '<>', '0.0')// Exclude the systems star.
-            ->whereIn('groupID', [6, 7, 8, 9, 10])
+            ->whereIn('groupID', $searched_groups)
             ->get();
 
         foreach ($possible_celestials as $celestial) {


### PR DESCRIPTION
when POCOs are anchored too close from a moon, their location were resolved to the moon instead of the related planet.

Closes eveseat/seat#811