### PR TITLE
Rate limit market history for safety reasons

### DIFF
--- a/src/Commands/Esi/Update/Prices.php
+++ b/src/Commands/Esi/Update/Prices.php
@@ -57,6 +57,8 @@ class Prices extends Command
         $types = InvType::whereNotNull('marketGroupID')
             ->where('published', true)
             ->select('typeID')
+            ->inRandomOrder()
+            ->limit(60*10)//60 minutes between default schedule invocation, 10 jobs per minute
             ->get();
 
         PricesJob::dispatch();

--- a/src/Commands/Esi/Update/Prices.php
+++ b/src/Commands/Esi/Update/Prices.php
@@ -58,7 +58,7 @@ class Prices extends Command
             ->where('published', true)
             ->select('typeID')
             ->inRandomOrder()
-            ->limit(60*10)//60 minutes between default schedule invocation, 10 jobs per minute
+            ->limit(60 * 10)//60 minutes between default schedule invocation, 10 jobs per minute
             ->get();
 
         PricesJob::dispatch();

--- a/src/Jobs/Market/History.php
+++ b/src/Jobs/Market/History.php
@@ -25,6 +25,7 @@ namespace Seat\Eveapi\Jobs\Market;
 use Seat\Eseye\Exceptions\RequestFailedException;
 use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\Market\Price;
+use Illuminate\Support\Facades\Redis;
 
 /**
  * Class History.
@@ -80,47 +81,54 @@ class History extends EsiBase
     {
         $region_id = setting('market_prices_region_id', true) ?: self::THE_FORGE;
 
-        foreach ($this->type_ids as $type_id) {
+        while(count($this->type_ids)>0) {
+            //don't go quite to the limit, maybe ccp_round() is involved somewhere along
+            Redis::throttle('market-history-throttle')->allow(10)->every(61)->then(function () use ($region_id) {
+                $type_id = array_shift($this->type_ids);
 
-            $this->query_string = [
-                'type_id' => $type_id,
-            ];
-
-            try {
-                // for each subsequent item, request ESI order stats using region in settings (The Forge is default).
-                $prices = $this->retrieve([
-                    'region_id' => $region_id,
-                ]);
-
-                if ($prices->isCachedLoad() && Price::count() > 0) return;
-
-                // search the more recent entry in returned history.
-                $price = collect($prices)->where('order_count', '>', 0)
-                    ->sortByDesc('date')
-                    ->first();
-
-                if (is_null($price)) {
-                    $price = (object) [
-                        'average'     => 0.0,
-                        'highest'     => 0.0,
-                        'lowest'      => 0.0,
-                        'order_count' => 0,
-                        'volume'      => 0,
-                    ];
-                }
-
-                Price::updateOrCreate([
+                $this->query_string = [
                     'type_id' => $type_id,
-                ], [
-                    'average'     => $price->average,
-                    'highest'     => $price->highest,
-                    'lowest'      => $price->lowest,
-                    'order_count' => $price->order_count,
-                    'volume'      => $price->volume,
-                ]);
-            } catch (RequestFailedException $e) {
-                logger()->error($e->getMessage());
-            }
+                ];
+
+                try {
+                    // for each subsequent item, request ESI order stats using region in settings (The Forge is default).
+                    $prices = $this->retrieve([
+                        'region_id' => $region_id,
+                    ]);
+
+                    if ($prices->isCachedLoad() && Price::count() > 0) return;
+
+                    // search the more recent entry in returned history.
+                    $price = collect($prices)->where('order_count', '>', 0)
+                        ->sortByDesc('date')
+                        ->first();
+
+                    if (is_null($price)) {
+                        $price = (object) [
+                            'average'     => 0.0,
+                            'highest'     => 0.0,
+                            'lowest'      => 0.0,
+                            'order_count' => 0,
+                            'volume'      => 0,
+                        ];
+                    }
+
+                    Price::updateOrCreate([
+                        'type_id' => $type_id,
+                    ], [
+                        'average'     => $price->average,
+                        'highest'     => $price->highest,
+                        'lowest'      => $price->lowest,
+                        'order_count' => $price->order_count,
+                        'volume'      => $price->volume,
+                    ]);
+                } catch (RequestFailedException $e) {
+                    logger()->error($e->getMessage());
+                }
+            }, function () {
+                // Could not obtain lock...
+                return $this->release(10);
+            });
         }
     }
 }

--- a/src/Jobs/Market/History.php
+++ b/src/Jobs/Market/History.php
@@ -22,10 +22,10 @@
 
 namespace Seat\Eveapi\Jobs\Market;
 
+use Illuminate\Support\Facades\Redis;
 use Seat\Eseye\Exceptions\RequestFailedException;
 use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\Market\Price;
-use Illuminate\Support\Facades\Redis;
 
 /**
  * Class History.
@@ -81,7 +81,7 @@ class History extends EsiBase
     {
         $region_id = setting('market_prices_region_id', true) ?: self::THE_FORGE;
 
-        while(count($this->type_ids)>0) {
+        while(count($this->type_ids) > 0) {
             //don't go quite to the limit, maybe ccp_round() is involved somewhere along
             Redis::throttle('market-history-throttle')->allow(10)->every(61)->then(function () use ($region_id) {
                 $type_id = array_shift($this->type_ids);


### PR DESCRIPTION
The market history endpoint is supposed to come back up on next monday. On the Eve Partners Discord, there has been some info about how it will come back that I'm not allowed to share. This PR ensures we comply with the new changes and don't run into any issues. After the endpoint is back up, we should search for a better solution than this implementation, but if we do nothing, we will potentially generate one error for every market tradeable item.