### PR TITLE
Update market history rate limiting - take 2

### DIFF
--- a/src/Commands/Esi/Update/Prices.php
+++ b/src/Commands/Esi/Update/Prices.php
@@ -23,7 +23,6 @@
 namespace Seat\Eveapi\Commands\Esi\Update;
 
 use Illuminate\Console\Command;
-use Seat\Eveapi\Jobs\AbstractJob;
 use Seat\Eveapi\Jobs\Market\History;
 use Seat\Eveapi\Jobs\Market\Prices as PricesJob;
 use Seat\Eveapi\Models\Sde\InvType;
@@ -64,7 +63,7 @@ class Prices extends Command
             ->pluck('typeID');
 
         //this is a guess that's only valid in the best case. In reality, we will probably be a bit slower.
-        $batch_processing_duration = (int)(History::ENDPOINT_RATE_LIMIT_WINDOW / History::ENDPOINT_RATE_LIMIT_CALLS * self::HISTORY_BATCH_SIZE);
+        $batch_processing_duration = (int) (History::ENDPOINT_RATE_LIMIT_WINDOW / History::ENDPOINT_RATE_LIMIT_CALLS * self::HISTORY_BATCH_SIZE);
         $types->chunk(self::HISTORY_BATCH_SIZE)->each(function ($chunk, $index) use ($batch_processing_duration) {
             $ids = $chunk->toArray();
             History::dispatch($ids)->delay($index * $batch_processing_duration);

--- a/src/Commands/Esi/Update/Prices.php
+++ b/src/Commands/Esi/Update/Prices.php
@@ -23,6 +23,7 @@
 namespace Seat\Eveapi\Commands\Esi\Update;
 
 use Illuminate\Console\Command;
+use Seat\Eveapi\Jobs\AbstractJob;
 use Seat\Eveapi\Jobs\Market\History;
 use Seat\Eveapi\Jobs\Market\Prices as PricesJob;
 use Seat\Eveapi\Models\Sde\InvType;
@@ -48,25 +49,25 @@ class Prices extends Command
      */
     protected $description = 'Schedule updater jobs which will collect market price stats.';
 
+    const HISTORY_BATCH_SIZE = 1000;
+
     /**
      * Execute the console command.
      */
     public function handle()
     {
+        PricesJob::dispatch();
+
         // collect all items which can be sold on the market.
         $types = InvType::whereNotNull('marketGroupID')
             ->where('published', true)
-            ->select('typeID')
-            ->inRandomOrder()
-            ->limit(60 * 300)//60 minutes between default schedule invocation, 300 jobs per minute
-            ->get();
+            ->pluck('typeID');
 
-        PricesJob::dispatch();
-
-        // build small batch of a maximum of 200 entries to avoid long running job.
-        $types->chunk(50)->each(function ($chunk) {
-            $ids = $chunk->pluck('typeID')->toArray();
-            History::dispatch($ids)->delay(rand(20, 300));
+        //this is a guess that's only valid in the best case. In reality, we will probably be a bit slower.
+        $batch_processing_duration = (int)(History::ENDPOINT_RATE_LIMIT_WINDOW / History::ENDPOINT_RATE_LIMIT_CALLS * self::HISTORY_BATCH_SIZE);
+        $types->chunk(self::HISTORY_BATCH_SIZE)->each(function ($chunk, $index) use ($batch_processing_duration) {
+            $ids = $chunk->toArray();
+            History::dispatch($ids)->delay($index * $batch_processing_duration);
         });
     }
 }

--- a/src/Jobs/AbstractJob.php
+++ b/src/Jobs/AbstractJob.php
@@ -41,6 +41,11 @@ abstract class AbstractJob implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     /**
+     * The duration in seconds how long a job is allowed to execute.
+     */
+    public const JOB_EXECUTION_TIMEOUT = 60*60; //1 hour
+
+    /**
      * Execute the job.
      *
      * @return void
@@ -91,6 +96,8 @@ abstract class AbstractJob implements ShouldQueue
      */
     public function retryUntil()
     {
-        return now()->addSeconds(3600);
+        // using self::JOB_EXECUTION_TIMEOUT makes it that you can't override the constant in class that inherit from AbstractJob.
+        // see https://stackoverflow.com/questions/13613594/overriding-class-constants-vs-properties
+        return now()->addSeconds(static::JOB_EXECUTION_TIMEOUT);
     }
 }

--- a/src/Jobs/AbstractJob.php
+++ b/src/Jobs/AbstractJob.php
@@ -43,7 +43,7 @@ abstract class AbstractJob implements ShouldQueue
     /**
      * The duration in seconds how long a job is allowed to execute.
      */
-    public const JOB_EXECUTION_TIMEOUT = 60*60; //1 hour
+    public const JOB_EXECUTION_TIMEOUT = 60 * 60; //1 hour
 
     /**
      * Execute the job.
@@ -83,10 +83,10 @@ abstract class AbstractJob implements ShouldQueue
     public function failed(Exception $exception)
     {
         // Analytics. Report only the Exception class and message.
-        dispatch((new Analytics((new AnalyticsContainer)
+        dispatch(new Analytics((new AnalyticsContainer)
             ->set('type', 'exception')
             ->set('exd', get_class($exception) . ':' . $exception->getMessage())
-            ->set('exf', 1))))->onQueue('default');
+            ->set('exf', 1)))->onQueue('default');
     }
 
     /**

--- a/src/Jobs/Market/History.php
+++ b/src/Jobs/Market/History.php
@@ -44,14 +44,14 @@ class History extends EsiBase
      *
      * @var int
      */
-    const ENDPOINT_RATE_LIMIT_WINDOW = 61; // to be on the safe side, we set it to 61 rather than 60
+    const ENDPOINT_RATE_LIMIT_WINDOW = 60; // to be on the safe side, we set it to 61 rather than 60
 
     /**
      * Describes how many calls can be made in the timespan described in ENDPOINT_RATE_LIMIT_WINDOW.
      *
      * @var int
      */
-    const ENDPOINT_RATE_LIMIT_CALLS = 300;
+    const ENDPOINT_RATE_LIMIT_CALLS = 280;
 
     /**
      * @var string

--- a/src/Jobs/Market/History.php
+++ b/src/Jobs/Market/History.php
@@ -37,7 +37,7 @@ class History extends EsiBase
     const THE_FORGE = 10000002;
 
     // override the default from AbstractJob
-    public const JOB_EXECUTION_TIMEOUT = 60*60*24; //1 day
+    public const JOB_EXECUTION_TIMEOUT = 60 * 60 * 24; //1 day
 
     /**
      * Describes how long the rate limit window lasts in seconds before resetting.

--- a/src/Jobs/Market/History.php
+++ b/src/Jobs/Market/History.php
@@ -36,6 +36,23 @@ class History extends EsiBase
 {
     const THE_FORGE = 10000002;
 
+    // override the default from AbstractJob
+    public const JOB_EXECUTION_TIMEOUT = 60*60*24; //1 day
+
+    /**
+     * Describes how long the rate limit window lasts in seconds before resetting.
+     *
+     * @var int
+     */
+    const ENDPOINT_RATE_LIMIT_WINDOW = 61; // to be on the safe side, we set it to 61 rather than 60
+
+    /**
+     * Describes how many calls can be made in the timespan described in ENDPOINT_RATE_LIMIT_WINDOW.
+     *
+     * @var int
+     */
+    const ENDPOINT_RATE_LIMIT_CALLS = 300;
+
     /**
      * @var string
      */
@@ -83,7 +100,7 @@ class History extends EsiBase
 
         while(count($this->type_ids) > 0) {
             //don't go quite to the limit, maybe ccp_round() is involved somewhere along
-            Redis::throttle('market-history-throttle')->allow(300)->every(61)->then(function () use ($region_id) {
+            Redis::throttle('market-history-throttle')->allow(self::ENDPOINT_RATE_LIMIT_CALLS)->every(self::ENDPOINT_RATE_LIMIT_WINDOW)->then(function () use ($region_id) {
                 $type_id = array_shift($this->type_ids);
 
                 $this->query_string = [


### PR DESCRIPTION
* Since the default schedule is once per day and faster doesn't make sense, I increased the timeout to 1 day.
* We now use delay to spread them a bit more efficiently