### PR TITLE
allow null as refresh token

### DIFF
--- a/src/Jobs/Market/Orders.php
+++ b/src/Jobs/Market/Orders.php
@@ -129,6 +129,6 @@ class Orders extends EsiBase
         MarketOrder::where('updated_at', '<=', $job_start_time)->delete();
 
         // This is a public job, but we require a token. since we only have public citadels on the order endpoint, we can use any character
-        $structure_batch->submitJobs(null);
+        $structure_batch->submitJobs();
     }
 }

--- a/src/Jobs/Universe/Structures/StructureBatch.php
+++ b/src/Jobs/Universe/Structures/StructureBatch.php
@@ -41,7 +41,7 @@ class StructureBatch
         $this->structures[$structure_id] = true;
     }
 
-    public function submitJobs(?RefreshToken $token)
+    public function submitJobs(?RefreshToken $token = null)
     {
         // sort by whether it is a citadel or station
         [$stations, $citadels] = collect($this->structures)
@@ -75,7 +75,7 @@ class StructureBatch
         // submit batch
         if($jobs->isEmpty()) return;
         Bus::batch($jobs->toArray())
-            ->name('Stations/Citadels')
+            ->name('Structures')
             ->dispatch();
     }
 }


### PR DESCRIPTION
* Use null as refresh token in the market orders job
* add null check so we don't schedule citadels
* rename job batch