### PR TITLE
fix: reduce amount of type resolved by prices job

### DIFF
--- a/src/Jobs/Market/History.php
+++ b/src/Jobs/Market/History.php
@@ -37,14 +37,14 @@ class History extends EsiBase
     const THE_FORGE = 10000002;
 
     // override the default from AbstractJob
-    public const JOB_EXECUTION_TIMEOUT = 60 * 60 * 24; //1 day
+    public const JOB_EXECUTION_TIMEOUT = 60 * 60 * 24; // 1 day
 
     /**
      * Describes how long the rate limit window lasts in seconds before resetting.
      *
      * @var int
      */
-    const ENDPOINT_RATE_LIMIT_WINDOW = 60; // to be on the safe side, we set it to 61 rather than 60
+    const ENDPOINT_RATE_LIMIT_WINDOW = 60;
 
     /**
      * Describes how many calls can be made in the timespan described in ENDPOINT_RATE_LIMIT_WINDOW.


### PR DESCRIPTION
US hosted server have a wide ping compared to EU against ESI (average 1 request every 2 seconds) Base on this, reduce batch size to 200 (20% of previous value) Also increase delay between job - preventing funnel usage