### PR TITLE
fix(jobs): address requests throttling issue

### DIFF
--- a/src/Commands/Esi/Update/Prices.php
+++ b/src/Commands/Esi/Update/Prices.php
@@ -48,27 +48,23 @@ class Prices extends Command
      */
     protected $description = 'Schedule updater jobs which will collect market price stats.';
 
-    const HISTORY_BATCH_SIZE = 250;
-
     /**
      * Execute the console command.
      */
     public function handle()
     {
-        PricesJob::dispatch();
-
         // collect all items which can be sold on the market.
         $types = InvType::whereNotNull('marketGroupID')
             ->where('published', true)
             ->select('typeID');
 
-        //this is a guess that's only valid in the best case. In reality, we will probably be a bit slower.
-        $batch_processing_duration = (int) (History::ENDPOINT_RATE_LIMIT_WINDOW / History::ENDPOINT_RATE_LIMIT_CALLS * self::HISTORY_BATCH_SIZE);
+        $jobs = collect();
 
-        $types->chunk(self::HISTORY_BATCH_SIZE, function ($chunk, $index) use ($batch_processing_duration) {
-            $ids = $chunk->pluck('typeID')->toArray();
-
-            History::dispatch($ids)->delay(now()->addMinutes($index)->addSeconds($batch_processing_duration));
+        $types->chunk(History::ENDPOINT_RATE_LIMIT_CALLS, function ($chunk) use ($jobs) {
+            $type_ids = $chunk->pluck('typeID')->toArray();
+            $jobs->add((new History($type_ids))->delay(now()->addMinute()));
         });
+
+        PricesJob::withChain($jobs->toArray())->dispatch();
     }
 }

--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -471,21 +471,21 @@ abstract class EsiBase extends AbstractJob
                 $this->token->save();
             }
 
-            throw new TemporaryEsiOutageException($response->error(), $response->getErrorCode());
+            throw new TemporaryEsiOutageException($response->error(), $response->getErrorCode(), $exception);
         }
 
         // If the token can't login and we get an HTTP 400 together with
         // and error message stating that this is an invalid_token, remove
         // the token from SeAT.
         if ($response->getErrorCode() == 400 && in_array($response->error(), self::PERMANENT_INVALID_TOKEN_MESSAGES))
-            throw new PermanentInvalidTokenException($response->error(), $response->getErrorCode());
+            throw new PermanentInvalidTokenException($response->error(), $response->getErrorCode(), $exception);
 
         if (($response->getErrorCode() == 503 && $response->error() == 'The datasource tranquility is temporarily unavailable') ||
             ($response->getErrorCode() == 504 && $response->error() == 'Timeout contacting tranquility'))
-            throw new UnavailableEveServersException($response->error(), $response->getErrorCode());
+            throw new UnavailableEveServersException($response->error(), $response->getErrorCode(), $exception);
 
         if ($response->getErrorCode() >= 500)
-            throw new TemporaryEsiOutageException($response->error(), $response->getErrorCode());
+            throw new TemporaryEsiOutageException($response->error(), $response->getErrorCode(), $exception);
 
         // Rethrow the exception
         throw $exception;

--- a/src/Jobs/Market/History.php
+++ b/src/Jobs/Market/History.php
@@ -51,7 +51,7 @@ class History extends EsiBase
      *
      * @var int
      */
-    const ENDPOINT_RATE_LIMIT_CALLS = 280;
+    const ENDPOINT_RATE_LIMIT_CALLS = 100;
 
     /**
      * @var string

--- a/src/Jobs/Market/History.php
+++ b/src/Jobs/Market/History.php
@@ -24,6 +24,7 @@ namespace Seat\Eveapi\Jobs\Market;
 
 use Illuminate\Support\Facades\Redis;
 use Seat\Eseye\Exceptions\RequestFailedException;
+use Seat\Eveapi\Exception\TemporaryEsiOutageException;
 use Seat\Eveapi\Jobs\EsiBase;
 use Seat\Eveapi\Models\Market\Price;
 
@@ -74,6 +75,18 @@ class History extends EsiBase
     protected $tags = ['public', 'market'];
 
     /**
+     * Override base attempts limit and allow the job to be retried up to 100 times.
+     * This value is tied to the amount of requests which should be done against ESI
+     * in order to process a complete batch.
+     *
+     * Everytime a TemporaryOutageException is thrown, we will release the job back
+     * in the queue. Every release is counting as an attempts.
+     *
+     * @var int
+     */
+    public $tries = 100;
+
+    /**
      * @var array
      */
     private $type_ids;
@@ -89,6 +102,34 @@ class History extends EsiBase
     }
 
     /**
+     * Add a tag to the job specifying the number of jobs related to the same batch chain.
+     *
+     * @param $count
+     *
+     * @return \Seat\Eveapi\Jobs\Market\History
+     */
+    public function setTotalBatchCount($count)
+    {
+        $this->tags = array_merge($this->tags, ['batch_size:' . $count]);
+
+        return $this;
+    }
+
+    /**
+     * Add a tag to the job specifying the current job number in the overall batch chain.
+     *
+     * @param $current
+     *
+     * @return \Seat\Eveapi\Jobs\Market\History
+     */
+    public function setCurrentBatchCount($current)
+    {
+        $this->tags = array_merge($this->tags, ['batch_current:' . $current]);
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @throws \Seat\Services\Exceptions\SettingException
@@ -99,8 +140,9 @@ class History extends EsiBase
         $region_id = setting('market_prices_region_id', true) ?: self::THE_FORGE;
 
         while(count($this->type_ids) > 0) {
-            //don't go quite to the limit, maybe ccp_round() is involved somewhere along
-            Redis::throttle('market-history-throttle')->allow(self::ENDPOINT_RATE_LIMIT_CALLS)->every(self::ENDPOINT_RATE_LIMIT_WINDOW)->then(function () use ($region_id) {
+            Redis::throttle('market-history-throttle')->block(0)->allow(self::ENDPOINT_RATE_LIMIT_CALLS)->every(self::ENDPOINT_RATE_LIMIT_WINDOW)->then(function () use ($region_id) {
+                logger()->debug(sprintf('[Jobs][%d] History processing -> Remaining types: %d.', $this->job->getJobId(), count($this->type_ids)));
+
                 $type_id = array_shift($this->type_ids);
 
                 $this->query_string = [
@@ -112,8 +154,6 @@ class History extends EsiBase
                     $prices = $this->retrieve([
                         'region_id' => $region_id,
                     ]);
-
-                    if ($prices->isCachedLoad() && Price::count() > 0) return;
 
                     // search the more recent entry in returned history.
                     $price = collect($prices)->where('order_count', '>', 0)
@@ -139,12 +179,24 @@ class History extends EsiBase
                         'order_count' => $price->order_count,
                         'volume'      => $price->volume,
                     ]);
+                } catch (TemporaryEsiOutageException $e) {
+                    logger()->error(sprintf('[Jobs][%d] History -> ESI is temporarily unavailable - Retry in 120 seconds.', $this->job->getJobId()));
+
+                    if ($e->getPrevious() instanceof RequestFailedException) {
+                        logger()->debug(sprintf('[Jobs][%d] History -> ESI remaining error count: %d', $this->job->getJobId(), $e->getPrevious()->getEsiResponse()->error_limit));
+                    }
+
+                    $this->release(120); // requeue job in next 2 minutes
                 } catch (RequestFailedException $e) {
                     logger()->error($e->getMessage());
                 }
             }, function () {
-                // Could not obtain lock...
-                return $this->release(10);
+
+                // specify callback to catch LimiterTimeoutException thrown by the throttler when limit is reached
+                // we will only log the state for diagnose since it is expected.
+                logger()->debug(sprintf('[Jobs][%d] History throttled -> Remaining types: %d.', $this->job->getJobId(), count($this->type_ids)));
+
+                return true;
             });
         }
     }


### PR DESCRIPTION
ensure history job is throttling ESI requests rather than itself.
chaining all market history jobs are chained all together instead of delaying them in the queue.
this will prevent jobs from the same batch to be queued in parallel and as a result, hitting ESI queries limit.

also catch TemporaryEsiOutageException when it appends and push back the job in the queue.