### PR TITLE
fix: character events consumption

### DIFF
--- a/src/Jobs/Calendar/Events.php
+++ b/src/Jobs/Calendar/Events.php
@@ -108,7 +108,7 @@ class Events extends AbstractAuthCharacterJob
                 ])->save();
             });
 
-            $this->from_id = $response->min('event_id') - 1;
+            $this->from_id = $response->max('event_id');
         }
     }
 }


### PR DESCRIPTION
as per ESI documentation:
> Get 50 event summaries from the calendar. If no from_event ID is given, the resource will return the next 50 chronological event summaries from now. If a from_event ID is specified, it will return the next 50 chronological event summaries from after that event

when `from_event` is provided with `0` - the oldest available event and its next 49 events are returned.

as a result, current implementation is looping infinitely since the returned value is always the oldest.

this update is not documented but might be related to endpoint version bump between v1 and v2

provided changes are using last returned event with highest value as a next page source. also removing the event value manipulation which was subtracting 1 from the returned value since its invalid and temper with ESI response.