### PR TITLE
Refactor batchable trait location

### DIFF
--- a/src/Jobs/AbstractAllianceJob.php
+++ b/src/Jobs/AbstractAllianceJob.php
@@ -31,7 +31,6 @@ use Illuminate\Bus\Batchable;
  */
 abstract class AbstractAllianceJob extends EsiBase
 {
-    use Batchable;
 
     /**
      * @var int The alliance ID to which the job is related.

--- a/src/Jobs/AbstractAllianceJob.php
+++ b/src/Jobs/AbstractAllianceJob.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of SeAT
  *
- * Copyright (C) 2015 to 2022 Leon Jacobs
+ * Copyright (C) 2015 to present Leon Jacobs
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,8 +21,6 @@
  */
 
 namespace Seat\Eveapi\Jobs;
-
-use Illuminate\Bus\Batchable;
 
 /**
  * Class AbstractAllianceJob.

--- a/src/Jobs/AbstractCharacterJob.php
+++ b/src/Jobs/AbstractCharacterJob.php
@@ -31,7 +31,6 @@ use Illuminate\Bus\Batchable;
  */
 abstract class AbstractCharacterJob extends EsiBase
 {
-    use Batchable;
 
     /**
      * @var int The character ID to which this job is related.

--- a/src/Jobs/AbstractCharacterJob.php
+++ b/src/Jobs/AbstractCharacterJob.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of SeAT
  *
- * Copyright (C) 2015 to 2022 Leon Jacobs
+ * Copyright (C) 2015 to present Leon Jacobs
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,8 +21,6 @@
  */
 
 namespace Seat\Eveapi\Jobs;
-
-use Illuminate\Bus\Batchable;
 
 /**
  * Class AbstractCharacterJob.

--- a/src/Jobs/AbstractCorporationJob.php
+++ b/src/Jobs/AbstractCorporationJob.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of SeAT
  *
- * Copyright (C) 2015 to 2022 Leon Jacobs
+ * Copyright (C) 2015 to present Leon Jacobs
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/Jobs/AbstractCorporationJob.php
+++ b/src/Jobs/AbstractCorporationJob.php
@@ -22,8 +22,6 @@
 
 namespace Seat\Eveapi\Jobs;
 
-use Illuminate\Bus\Batchable;
-
 /**
  * Class AbstractCorporationJob.
  *
@@ -31,7 +29,6 @@ use Illuminate\Bus\Batchable;
  */
 abstract class AbstractCorporationJob extends EsiBase
 {
-    use Batchable;
 
     /**
      * @var int The corporation ID to which the job is related.

--- a/src/Jobs/AbstractJob.php
+++ b/src/Jobs/AbstractJob.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of SeAT
  *
- * Copyright (C) 2015 to 2022 Leon Jacobs
+ * Copyright (C) 2015 to present Leon Jacobs
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/Jobs/AbstractJob.php
+++ b/src/Jobs/AbstractJob.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Eveapi\Jobs;
 
+use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -38,7 +39,7 @@ use Throwable;
  */
 abstract class AbstractJob implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, Batchable;
 
     /**
      * The duration in seconds how long a job is allowed to execute.


### PR DESCRIPTION
* Some public jobs like killmails can't be batched, because they are missing the `Batchable` trait. This PR moves batchable from character, corporation and alliance job classes to a common ancestor that also includes the public jobs