### PR TITLE
Fixes queue handling for eveapi jobs

### DIFF
--- a/src/Jobs/Character/Notifications.php
+++ b/src/Jobs/Character/Notifications.php
@@ -33,6 +33,8 @@ use Seat\Eveapi\Models\Character\CharacterNotification;
  */
 class Notifications extends AbstractAuthCharacterJob
 {
+    public $queue = 'notifications';
+
     /**
      * @var string
      */

--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -112,7 +112,7 @@ abstract class EsiBase extends AbstractJob
      *
      * @var string
      */
-    protected $scope = 'public';
+    protected $scope = 'public'; // By default, queue all ESI jobs on public queue.
 
     /**
      * The page to retrieve.
@@ -154,9 +154,6 @@ abstract class EsiBase extends AbstractJob
      */
     public function __construct()
     {
-        // By default, queue all ESI jobs on public queue.
-        $this->queue = 'public';
-
         // Attach an ESI Client.
         $this->esi = app()->make(EsiClient::class);
     }

--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -73,7 +73,7 @@ abstract class EsiBase extends AbstractJob
     /**
      * @var string By default, queue all ESI jobs on public queue.
      */
-    public $queue = 'public';
+    public $queue = 'public'; // By default, queue all ESI jobs on public queue.
 
     /**
      * @var int By default, retry all ESI jobs 3 times.
@@ -112,7 +112,7 @@ abstract class EsiBase extends AbstractJob
      *
      * @var string
      */
-    protected $scope = 'public'; // By default, queue all ESI jobs on public queue.
+    protected $scope = 'public';
 
     /**
      * The page to retrieve.


### PR DESCRIPTION
Jobs for the eveapi not queued properly. Most Jobs were queue into "public" queue due queue override in constructor of "EsiBase" class.

I have removed this while default queue value is already set for public property $queue. Also Notification jobs now queue into "notifications" queue while they are highly important for pings on discord.