### PR TITLE
Fix migration issue

### DIFF
--- a/src/database/migrations/2022_01_16_115110_remove_corporation_id_column_from_corporation_title_roles_table.php
+++ b/src/database/migrations/2022_01_16_115110_remove_corporation_id_column_from_corporation_title_roles_table.php
@@ -72,8 +72,6 @@ class RemoveCorporationIdColumnFromCorporationTitleRolesTable extends Migration
             $table->dropPrimary('corporation_title_roles_primary_key');
             $table->dropColumn('corporation_id');
             $table->integer('title_id')->unsigned()->change();
-
-            $table->unique(['title_id', 'type', 'role']);
         });
 
         // move the data from the temporary column to the correct column
@@ -83,6 +81,8 @@ class RemoveCorporationIdColumnFromCorporationTitleRolesTable extends Migration
         Schema::table('corporation_title_roles', function (Blueprint $table) {
             $table->bigIncrements('id')->first();
             $table->dropColumn('title_id_temporary');
+
+            $table->unique(['title_id', 'type', 'role']);
 
             $table->foreign('title_id')
                 ->references('id')


### PR DESCRIPTION
I think this should fix the new migration issue experienced by Kiba. It turns out, there was a second issue I didn't catch. Here is his report:

DB migration was failing due to a problem that was thought to be resolved
https://github.com/eveseat/eveapi/pull/379

seat-docker-front-1      |    INFO  Running migrations.
seat-docker-front-1      |
seat-docker-front-1      |   2018_01_05_112025_add_unique_mail_id_on_mail_headers_table ........ 2ms DONE
seat-docker-front-1      |   2018_01_07_162051_add_unique_fitting_id_on_character_fittings_table  1ms DONE
seat-docker-front-1      |   2020_11_21_173927_add_unique_on_starbase_id_in_corporation_starbases_table  47ms DONE
seat-docker-worker-1     | Horizon started successfully.
seat-docker-front-1      |   2022_01_01_171359_add_uuid_to_failed_jobs_table ................. 578ms DONE
seat-docker-front-1      |   2022_01_03_221839_add_id_to_user_login_histories_table .......... 181ms DONE
seat-docker-front-1      |   2022_01_07_124200_create_job_batches_table ....................... 23ms DONE
seat-docker-front-1      |   2022_01_16_115110_remove_corporation_id_column_from_corporation_title_roles_table  604ms FAIL
seat-docker-front-1      |
seat-docker-front-1      | In Connection.php line 817:
seat-docker-front-1      |
seat-docker-front-1      |   SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '1-ro
seat-docker-front-1      |   les-Rent_Factory_Facility' for key 'corporation_title_roles_title_id_type_r
seat-docker-front-1      |   ole_unique' (Connection: mysql, SQL: alter table `corporation_title_roles`
seat-docker-front-1      |   add unique `corporation_title_roles_title_id_type_role_unique`(`title_id`,
seat-docker-front-1      |   `type`, `role`))
seat-docker-front-1      |
seat-docker-front-1      |
seat-docker-front-1      | In Connection.php line 580:
seat-docker-front-1      |
seat-docker-front-1      |   SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '1-ro
seat-docker-front-1      |   les-Rent_Factory_Facility' for key 'corporation_title_roles_title_id_type_r
seat-docker-front-1      |   ole_unique'
seat-docker-front-1      |
seat-docker-front-1      |
seat-docker-front-1 exited with code 0


For the above, I did verify that my instance has eveapi v5.0.2 which should include the fix. I was able to truncate corporation_title_roles to get around the error as mentioned in a past message. Everything came up well after that.