### PR TITLE
Don't fail job batches if a single job fails

### DIFF
--- a/src/Bus/Alliance.php
+++ b/src/Bus/Alliance.php
@@ -107,7 +107,7 @@ class Alliance extends Bus
                             'total' => $batch->totalJobs,
                         ],
                     ]);
-            })->onQueue('public')->name($alliance->name)->dispatch();
+            })->onQueue('public')->name($alliance->name)->allowFailures()->dispatch();
         // in order to prevent ESI to receive massive income of all existing SeAT instances in the world
         // add a bit of randomize when job can be processed - we use seconds here, so we have more flexibility
         // https://github.com/eveseat/seat/issues/731

--- a/src/Bus/Alliance.php
+++ b/src/Bus/Alliance.php
@@ -108,9 +108,6 @@ class Alliance extends Bus
                         ],
                     ]);
             })->onQueue('public')->name($alliance->name)->allowFailures()->dispatch();
-        // in order to prevent ESI to receive massive income of all existing SeAT instances in the world
-        // add a bit of randomize when job can be processed - we use seconds here, so we have more flexibility
-        // https://github.com/eveseat/seat/issues/731
     }
 
     /**

--- a/src/Bus/Character.php
+++ b/src/Bus/Character.php
@@ -145,9 +145,6 @@ class Character extends Bus
                         ],
                     ]);
             })->onQueue('characters')->name($character->name)->allowFailures()->dispatch();
-        // in order to prevent ESI to receive massive income of all existing SeAT instances in the world
-        // add a bit of randomize when job can be processed - we use seconds here, so we have more flexibility
-        // https://github.com/eveseat/seat/issues/731
     }
 
     /**

--- a/src/Bus/Character.php
+++ b/src/Bus/Character.php
@@ -144,7 +144,7 @@ class Character extends Bus
                             'total' => $batch->totalJobs,
                         ],
                     ]);
-            })->onQueue('characters')->name($character->name)->dispatch();
+            })->onQueue('characters')->name($character->name)->allowFailures()->dispatch();
         // in order to prevent ESI to receive massive income of all existing SeAT instances in the world
         // add a bit of randomize when job can be processed - we use seconds here, so we have more flexibility
         // https://github.com/eveseat/seat/issues/731

--- a/src/Bus/Corporation.php
+++ b/src/Bus/Corporation.php
@@ -141,7 +141,7 @@ class Corporation extends Bus
                             'total' => $batch->totalJobs,
                         ],
                     ]);
-            })->onQueue('corporations')->name($corporation->name)->dispatch();
+            })->onQueue('corporations')->name($corporation->name)->allowFailures()->dispatch();
         // in order to prevent ESI to receive massive income of all existing SeAT instances in the world
         // add a bit of randomize when job can be processed - we use seconds here, so we have more flexibility
         // https://github.com/eveseat/seat/issues/731

--- a/src/Bus/Corporation.php
+++ b/src/Bus/Corporation.php
@@ -142,9 +142,6 @@ class Corporation extends Bus
                         ],
                     ]);
             })->onQueue('corporations')->name($corporation->name)->allowFailures()->dispatch();
-        // in order to prevent ESI to receive massive income of all existing SeAT instances in the world
-        // add a bit of randomize when job can be processed - we use seconds here, so we have more flexibility
-        // https://github.com/eveseat/seat/issues/731
     }
 
     /**


### PR DESCRIPTION
Currently, if a single job in the ESI batches fails, all the following batches will fail too.

This PR allows failures in the ESI job batches. Additionally, I removed comments that no longer look to be relevant.

This PR isn't very high-priority and doesn't need an immediate release