### PR TITLE
delete assets without list of asset ids

### DIFF
--- a/src/Jobs/Assets/Character/Assets.php
+++ b/src/Jobs/Assets/Character/Assets.php
@@ -122,7 +122,7 @@ class Assets extends AbstractAuthCharacterJob
 
         // Cleanup old assets
         CharacterAsset::where('character_id', $this->getCharacterId())
-            ->where('updated_at','<',$start)
+            ->where('updated_at', '<', $start)
             ->delete();
 
         // schedule jobs for structures

--- a/src/Jobs/Assets/Character/Assets.php
+++ b/src/Jobs/Assets/Character/Assets.php
@@ -66,19 +66,12 @@ class Assets extends AbstractAuthCharacterJob
     protected $page = 1;
 
     /**
-     * @var \Illuminate\Support\Collection
-     */
-    protected $known_assets;
-
-    /**
      * Assets constructor.
      *
      * @param  \Seat\Eveapi\Models\RefreshToken  $token
      */
     public function __construct(RefreshToken $token)
     {
-        $this->known_assets = collect();
-
         parent::__construct($token);
     }
 
@@ -92,6 +85,8 @@ class Assets extends AbstractAuthCharacterJob
     public function handle(): void
     {
         parent::handle();
+
+        $start = now();
 
         $structure_batch = new StructureBatch();
 
@@ -119,10 +114,6 @@ class Assets extends AbstractAuthCharacterJob
                         return $this->getCharacterId();
                     },
                 ])->save();
-
-                // Update the list of known item_id's which should be
-                // excluded from the database cleanup later.
-                $this->known_assets->push($asset->item_id);
             });
 
             if (! $this->nextPage($response->getPagesCount()))
@@ -131,7 +122,7 @@ class Assets extends AbstractAuthCharacterJob
 
         // Cleanup old assets
         CharacterAsset::where('character_id', $this->getCharacterId())
-            ->whereNotIn('item_id', $this->known_assets->flatten()->all())
+            ->where('updated_at','<',$start)
             ->delete();
 
         // schedule jobs for structures

--- a/src/Jobs/Assets/Corporation/Assets.php
+++ b/src/Jobs/Assets/Corporation/Assets.php
@@ -131,7 +131,7 @@ class Assets extends AbstractAuthCorporationJob
 
         // Cleanup old assets
         CorporationAsset::where('corporation_id', $this->getCorporationId())
-            ->where('updated_at','<',$start)
+            ->where('updated_at', '<', $start)
             ->delete();
 
         // schedule jobs for structures


### PR DESCRIPTION
A while ago, someone reported that his asset jobs fail with a  SQL error:

```
[2024-01-24 20:14:41] local.ERROR: SQLSTATE[HY000]: General error: 1390 Prepared statement contains too many placeholders (Connection: mysql, SQL: delete from `corporation_assets` where `corporation_id` = XXXXXXXX and `item_id` not in (...,...,...)) at /var/www/seat/vendor/laravel/framework/src/Illuminate/Database/Connection.php:822)
```

This can happen if a character has too many assets and the `$known_assets` grows too large so that no SQL statement can be generated anymore: https://github.com/eveseat/eveapi/blob/d569e3e8a753da97707b31f6b31aa036f08a6148/src/Jobs/Assets/Character/Assets.php#L134

The fix is to use `updated_at`: Items that have a outdated updated_at are the items that are no longer returned by ESI, aka deleted.