### PR TITLE
PI Planets job: create new batch when job isn't running in a batch

### DIFF
--- a/src/Jobs/Killmails/Character/Recent.php
+++ b/src/Jobs/Killmails/Character/Recent.php
@@ -117,7 +117,7 @@ class Recent extends AbstractAuthCharacterJob
                 $this->batch()->add($this->killmail_jobs->toArray());
             } else {
                 Bus::batch($this->killmail_jobs->toArray())
-                    ->name(sprintf('PI: %s', $this->token->character->name ?? $this->token->character_id))
+                    ->name(sprintf('KM: %s', $this->token->character->name ?? $this->token->character_id))
                     ->onQueue($this->job->getQueue())
                     ->dispatch();
             }

--- a/src/Jobs/Killmails/Character/Recent.php
+++ b/src/Jobs/Killmails/Character/Recent.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\Killmails\Character;
 
+use Illuminate\Support\Facades\Bus;
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
 use Seat\Eveapi\Jobs\Killmails\Detail;
 use Seat\Eveapi\Models\Killmails\Killmail;
@@ -111,7 +112,15 @@ class Recent extends AbstractAuthCharacterJob
                 break;
         }
 
-        if ($this->killmail_jobs->isNotEmpty())
-            $this->batch()->add($this->killmail_jobs->toArray());
+        if ($this->killmail_jobs->isNotEmpty()) {
+            if($this->batchId) {
+                $this->batch()->add($this->killmail_jobs->toArray());
+            } else {
+                Bus::batch($this->killmail_jobs->toArray())
+                    ->name(sprintf('PI: %s', $this->token->character->name ?? $this->token->character_id))
+                    ->onQueue($this->job->getQueue())
+                    ->dispatch();
+            }
+        }
     }
 }

--- a/src/Jobs/Killmails/Corporation/Recent.php
+++ b/src/Jobs/Killmails/Corporation/Recent.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\Killmails\Corporation;
 
+use Illuminate\Support\Facades\Bus;
 use Seat\Eveapi\Jobs\AbstractAuthCorporationJob;
 use Seat\Eveapi\Jobs\Killmails\Detail;
 use Seat\Eveapi\Models\Killmails\Killmail;
@@ -115,7 +116,15 @@ class Recent extends AbstractAuthCorporationJob
                 break;
         }
 
-        if ($this->killmail_jobs->isNotEmpty())
-            $this->batch()->add($this->killmail_jobs->toArray());
+        if ($this->killmail_jobs->isNotEmpty()) {
+            if($this->batchId) {
+                $this->batch()->add($this->killmail_jobs->toArray());
+            } else {
+                Bus::batch($this->killmail_jobs->toArray())
+                    ->name(sprintf('KM: %s', $this->token->character->name ?? $this->token->character_id))
+                    ->onQueue($this->job->getQueue())
+                    ->dispatch();
+            }
+        }
     }
 }

--- a/src/Jobs/Market/History.php
+++ b/src/Jobs/Market/History.php
@@ -140,7 +140,7 @@ class History extends EsiBase
      */
     public function handle()
     {
-        if ($this->batch()->cancelled()) {
+        if ($this->batchId && $this->batch()->cancelled()) {
             logger()->debug(sprintf('[Jobs][%s] Orders - Cancelling job due to relevant batch %s cancellation.', $this->job->getJobId(), $this->batch()->id));
 
             return;

--- a/src/Jobs/Market/Prices.php
+++ b/src/Jobs/Market/Prices.php
@@ -62,7 +62,7 @@ class Prices extends EsiBase
      */
     public function handle()
     {
-        if ($this->batch()->cancelled()) {
+        if ($this->batchId && $this->batch()->cancelled()) {
             logger()->debug(sprintf('[Jobs][%s] Orders - Cancelling job due to relevant batch %s cancellation.', $this->job->getJobId(), $this->batch()->id));
 
             return;


### PR DESCRIPTION
The PI Plantes job launches new jobs with the data it has loaded from ESI. Normally, these jobs are added to the current batch. However, when manually scheduling an update over the web ui, jobs aren't launched in a batch.

This PR makes the Planets job handle the case where it isn't running in a batch.