### PR TITLE
schedule type ids for market history from esi

### DIFF
--- a/src/Commands/Esi/Update/Prices.php
+++ b/src/Commands/Esi/Update/Prices.php
@@ -25,12 +25,10 @@ namespace Seat\Eveapi\Commands\Esi\Update;
 use Illuminate\Bus\Batch;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Bus;
-use Seat\Eveapi\Jobs\Market\History;
 use Seat\Eveapi\Jobs\Market\DispatchHistoryJobs;
 use Seat\Eveapi\Jobs\Market\OrderAggregates;
 use Seat\Eveapi\Jobs\Market\Orders;
 use Seat\Eveapi\Jobs\Market\Prices as PricesJob;
-use Seat\Eveapi\Models\Sde\InvType;
 use Throwable;
 
 /**
@@ -64,8 +62,8 @@ class Prices extends Command
             new DispatchHistoryJobs(),
             [
                 new Orders(),
-                new OrderAggregates()
-            ]
+                new OrderAggregates(),
+            ],
         ])
             ->then(function (Batch $batch) {
                 logger()->info(

--- a/src/Commands/Esi/Update/Prices.php
+++ b/src/Commands/Esi/Update/Prices.php
@@ -26,6 +26,7 @@ use Illuminate\Bus\Batch;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Bus;
 use Seat\Eveapi\Jobs\Market\History;
+use Seat\Eveapi\Jobs\Market\DispatchHistoryJobs;
 use Seat\Eveapi\Jobs\Market\OrderAggregates;
 use Seat\Eveapi\Jobs\Market\Orders;
 use Seat\Eveapi\Jobs\Market\Prices as PricesJob;
@@ -58,21 +59,14 @@ class Prices extends Command
      */
     public function handle()
     {
-        $jobs = collect([new PricesJob()]);
-
-        // collect all items which can be sold on the market.
-        $types = InvType::whereNotNull('marketGroupID')
-            ->where('published', true)
-            ->select('typeID');
-
-        $batch_jobs_count = (int) ceil($types->count() / History::ENDPOINT_RATE_LIMIT_CALLS);
-
-        $types->chunk(History::ENDPOINT_RATE_LIMIT_CALLS, function ($results, $page) use ($batch_jobs_count, $jobs) {
-            $type_ids = $results->pluck('typeID')->toArray();
-            $jobs->add((new History($type_ids))->setCurrentBatchCount($page)->setTotalBatchCount($batch_jobs_count));
-        });
-
-        Bus::batch($jobs->toArray())
+        Bus::batch([
+            new PricesJob(),
+            new DispatchHistoryJobs(),
+            [
+                new Orders(),
+                new OrderAggregates()
+            ]
+        ])
             ->then(function (Batch $batch) {
                 logger()->info(
                     sprintf('[Batches][%s] %s - Succeeded : %d/%d - %d failed.',
@@ -93,10 +87,6 @@ class Prices extends Command
             ->onQueue('public')
             ->name('Market Prices')
             ->dispatch();
-
-        Orders::withChain([
-            new OrderAggregates(),
-        ])->dispatch();
 
         return $this::SUCCESS;
     }

--- a/src/Jobs/Market/DispatchHistoryJobs.php
+++ b/src/Jobs/Market/DispatchHistoryJobs.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Jobs\Market;
 
 use Illuminate\Bus\Batchable;
@@ -7,7 +27,7 @@ use Illuminate\Support\Facades\Bus;
 use Seat\Eveapi\Jobs\EsiBase;
 
 /**
- * Loads all Type IDs for which the history is available
+ * Loads all Type IDs for which the history is available.
  */
 class DispatchHistoryJobs extends EsiBase
 {
@@ -53,12 +73,12 @@ class DispatchHistoryJobs extends EsiBase
             $types = $types->merge($orders);
 
             // if there are more pages with orders, continue loading them
-            if (!$this->nextPage($response->getPagesCount())) break;
+            if (! $this->nextPage($response->getPagesCount())) break;
         }
 
         // create history jobs
         $jobs = collect();
-        $batch_jobs_count = (int)ceil($types->count() / History::ENDPOINT_RATE_LIMIT_CALLS);
+        $batch_jobs_count = (int) ceil($types->count() / History::ENDPOINT_RATE_LIMIT_CALLS);
         $types->chunk(History::ENDPOINT_RATE_LIMIT_CALLS)->each(function ($results, $page) use ($batch_jobs_count, $jobs) {
             $jobs->add((new History($results->toArray()))->setCurrentBatchCount($page)->setTotalBatchCount($batch_jobs_count));
         });

--- a/src/Jobs/Market/DispatchHistoryJobs.php
+++ b/src/Jobs/Market/DispatchHistoryJobs.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Seat\Eveapi\Jobs\Market;
+
+use Illuminate\Bus\Batchable;
+use Illuminate\Support\Facades\Bus;
+use Seat\Eveapi\Jobs\EsiBase;
+
+/**
+ * Loads all Type IDs for which the history is available
+ */
+class DispatchHistoryJobs extends EsiBase
+{
+    use Batchable;
+
+    const THE_FORGE = 10000002;
+
+    /**
+     * @var string
+     */
+    protected $method = 'get';
+
+    /**
+     * @var string
+     */
+    protected $endpoint = '/markets/{region_id}/types/';
+
+    /**
+     * @var string
+     */
+    protected $version = 'v1';
+
+    /**
+     * @var array
+     */
+    protected $tags = ['public', 'market'];
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $region_id = setting('market_prices_region_id', true) ?: self::THE_FORGE;
+
+        $types = collect();
+
+        while (true) {
+            $response = $this->retrieve(['region_id' => $region_id]);
+            $orders = $response->getBody();
+
+            $types = $types->merge($orders);
+
+            // if there are more pages with orders, continue loading them
+            if (!$this->nextPage($response->getPagesCount())) break;
+        }
+
+        // create history jobs
+        $jobs = collect();
+        $batch_jobs_count = (int)ceil($types->count() / History::ENDPOINT_RATE_LIMIT_CALLS);
+        $types->chunk(History::ENDPOINT_RATE_LIMIT_CALLS)->each(function ($results, $page) use ($batch_jobs_count, $jobs) {
+            $jobs->add((new History($results->toArray()))->setCurrentBatchCount($page)->setTotalBatchCount($batch_jobs_count));
+        });
+
+        if ($jobs->isEmpty()) return;
+
+        if ($this->batchId) {
+            $this->batch()->add($jobs);
+        } else {
+            Bus::batch($jobs)
+                ->name('Market History')
+                ->onQueue($this->job->getQueue())
+                ->dispatch();
+        }
+    }
+}


### PR DESCRIPTION
It turns out that ESI returns an error on the market history endpoint for all type ids that are not in `/markets/{region_id}/types/`. Currently, we get the type ids from the SDE, which might be outdated.

With this PR, we have a job that fetches all type ids from  `/markets/{region_id}/types/` and then schedules market history jobs for them.