### PR TITLE
Fixed rate limit issue

### DIFF
--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -188,7 +188,10 @@ abstract class EsiBase extends AbstractJob
      */
     public function getRateLimitKeyTtl(): int
     {
-        return Redis::ttl(Cache::getPrefix() . self::RATE_LIMIT_KEY);
+        // Redis 'default' database can be different from 'cache'
+        $redis = Redis::connection('cache');
+
+        return $redis->ttl(Cache::getPrefix() . self::RATE_LIMIT_KEY);
     }
 
     /**


### PR DESCRIPTION
The Redis:: by default use the 'default' redis connection string. Get the 'cache' connection to have the `ttl` and additional commands work towards the same connection.