### PR TITLE
fix: Adjust RATE_LIMIT for Citadel jobs

### DIFF
--- a/src/Jobs/Middleware/CheckEsiRateLimit.php
+++ b/src/Jobs/Middleware/CheckEsiRateLimit.php
@@ -46,6 +46,7 @@ class CheckEsiRateLimit
                 [
                     'fqcn' => get_class($job),
                     'delay' => $job::RATE_LIMIT_DURATION,
+                    'limit' => $job::RATE_LIMIT,
                 ]);
 
             $job->release($job::RATE_LIMIT_DURATION);

--- a/src/Jobs/Universe/Structures/Citadel.php
+++ b/src/Jobs/Universe/Structures/Citadel.php
@@ -36,6 +36,11 @@ use Seat\Eveapi\Models\Universe\UniverseStructure;
 class Citadel extends AbstractAuthCharacterJob
 {
     /**
+     * HTTP 403 is frequent for Citadel jobs. Decrease RATE_LIMIT to not starve out other jobs.
+     */
+    const RATE_LIMIT = parent::RATE_LIMIT * 0.65;
+
+    /**
      * @var string
      */
     protected $method = 'get';


### PR DESCRIPTION
HTTP 403 is frequent for Citadel jobs which in turn decrease the ESI `X-ESI-Error-Limit-Remain`. Decrease RATE_LIMIT to not starve out other jobs.