### PR TITLE
readd eve:update:status

### DIFF
--- a/src/database/seeders/ScheduleSeeder.php
+++ b/src/database/seeders/ScheduleSeeder.php
@@ -48,6 +48,14 @@ class ScheduleSeeder extends AbstractScheduleSeeder
                 'ping_before' => null,
                 'ping_after' => null,
             ],
+            [   // EVE Server Status | Every Minute
+                'command' => 'eve:update:status',
+                'expression' => '* * * * *',
+                'allow_overlap' => false,
+                'allow_maintenance' => false,
+                'ping_before' => null,
+                'ping_after' => null,
+            ],
             [   // SDE Data | Monthly
                 'command' => 'eve:update:sde',
                 'expression' => '0 0 1 * *',


### PR DESCRIPTION
While copy-pasting the schedule list when refactoring, `eve:update:status` (not to be confused with `esi:update:status`) got lost. 

This job is responsible for deciding if the ESI servers are online and other calls can be made. When creating a new instance, seat never runs this job and therefore refuses to contact ESI. Existing instances continue to work because the schedule seeder doesn't remove command, it only adds new commands so it still runs fine on them.