### PR TITLE
Update `updated_at` for Assets Jobs

### DIFF
--- a/src/Jobs/Assets/Character/Assets.php
+++ b/src/Jobs/Assets/Character/Assets.php
@@ -98,22 +98,26 @@ class Assets extends AbstractAuthCharacterJob
 
             $assets = collect($response->getBody());
 
-            $assets->each(function ($asset) use ($structure_batch) {
+            $assets->chunk(1000)->each(function ($chunk) use ($structure_batch, $start) {
 
-                $model = CharacterAsset::firstOrNew([
-                    'item_id' => $asset->item_id,
-                ]);
+                $chunk->each(function ($asset) use ($structure_batch, $start) {
 
-                //make sure that the location is loaded if it is in a station or citadel
-                if (in_array($asset->location_flag, StructureBatch::RESOLVABLE_LOCATION_FLAGS) && in_array($asset->location_type, StructureBatch::RESOLVABLE_LOCATION_TYPES)) {
-                    $structure_batch->addStructure($asset->location_id);
-                }
+                    $model = CharacterAsset::firstOrNew([
+                        'item_id' => $asset->item_id,
+                    ]);
 
-                AssetMapping::make($model, $asset, [
-                    'character_id' => function () {
-                        return $this->getCharacterId();
-                    },
-                ])->save();
+                    //make sure that the location is loaded if it is in a station or citadel
+                    if (in_array($asset->location_flag, StructureBatch::RESOLVABLE_LOCATION_FLAGS) && in_array($asset->location_type, StructureBatch::RESOLVABLE_LOCATION_TYPES)) {
+                        $structure_batch->addStructure($asset->location_id);
+                    }
+
+                    AssetMapping::make($model, $asset, [
+                        'character_id' => function () {
+                            return $this->getCharacterId();
+                        },
+                        'updated_at' => $start,
+                    ])->save();
+                });
             });
 
             if (! $this->nextPage($response->getPagesCount()))

--- a/src/Jobs/Assets/Corporation/Assets.php
+++ b/src/Jobs/Assets/Corporation/Assets.php
@@ -104,9 +104,9 @@ class Assets extends AbstractAuthCorporationJob
 
             $assets = collect($response->getBody());
 
-            $assets->chunk(1000)->each(function ($chunk) use ($structure_batch) {
+            $assets->chunk(1000)->each(function ($chunk) use ($structure_batch, $start) {
 
-                $chunk->each(function ($asset) use ($structure_batch) {
+                $chunk->each(function ($asset) use ($structure_batch, $start) {
 
                     $model = CorporationAsset::firstOrNew([
                         'item_id' => $asset->item_id,
@@ -121,6 +121,7 @@ class Assets extends AbstractAuthCorporationJob
                         'corporation_id' => function () {
                             return $this->getCorporationId();
                         },
+                        'updated_at' => $start,
                     ])->save();
                 });
             });


### PR DESCRIPTION
Potential fix for https://github.com/eveseat/seat/issues/908

Make a change to the model to reference the `$start` time when updated assets so that an update actually occurs on the asset records (`isDirty() = true`)