### PR TITLE
Remove (Revert) the chunk logic found in Corporation:Assets

### DIFF
--- a/src/Jobs/Assets/Character/Assets.php
+++ b/src/Jobs/Assets/Character/Assets.php
@@ -98,26 +98,23 @@ class Assets extends AbstractAuthCharacterJob
 
             $assets = collect($response->getBody());
 
-            $assets->chunk(1000)->each(function ($chunk) use ($structure_batch, $start) {
+            $assets->each(function ($asset) use ($structure_batch, $start) {
 
-                $chunk->each(function ($asset) use ($structure_batch, $start) {
+                $model = CharacterAsset::firstOrNew([
+                    'item_id' => $asset->item_id,
+                ]);
 
-                    $model = CharacterAsset::firstOrNew([
-                        'item_id' => $asset->item_id,
-                    ]);
+                //make sure that the location is loaded if it is in a station or citadel
+                if (in_array($asset->location_flag, StructureBatch::RESOLVABLE_LOCATION_FLAGS) && in_array($asset->location_type, StructureBatch::RESOLVABLE_LOCATION_TYPES)) {
+                    $structure_batch->addStructure($asset->location_id);
+                }
 
-                    //make sure that the location is loaded if it is in a station or citadel
-                    if (in_array($asset->location_flag, StructureBatch::RESOLVABLE_LOCATION_FLAGS) && in_array($asset->location_type, StructureBatch::RESOLVABLE_LOCATION_TYPES)) {
-                        $structure_batch->addStructure($asset->location_id);
-                    }
-
-                    AssetMapping::make($model, $asset, [
-                        'character_id' => function () {
-                            return $this->getCharacterId();
-                        },
-                        'updated_at' => $start,
-                    ])->save();
-                });
+                AssetMapping::make($model, $asset, [
+                    'character_id' => function () {
+                        return $this->getCharacterId();
+                    },
+                    'updated_at' => $start,
+                ])->save();
             });
 
             if (! $this->nextPage($response->getPagesCount()))


### PR DESCRIPTION
When we added the `created_at => start` code, I moved over the Corporation::Assets chunk logic to Character::Assets and apparently that explodes. See that changeset here: https://github.com/eveseat/eveapi/compare/5.0.11...5.0.12

This removes that specific copy while keeping the `created_at => $start` bit.