### PR TITLE
Fix error in Seat\Eveapi\Jobs\Assets\Character\Assets

### DIFF
--- a/src/Jobs/Assets/Character/Assets.php
+++ b/src/Jobs/Assets/Character/Assets.php
@@ -115,7 +115,9 @@ class Assets extends AbstractAuthCharacterJob
                         'character_id' => function () {
                             return $this->getCharacterId();
                         },
-                        'updated_at' => $start,
+                        'updated_at' => function () use ($start) {
+                            return $start;
+                        },
                     ])->save();
                 });
             });


### PR DESCRIPTION
Fixes the error count(): Argument #1 ($value) must be of type Countable|array, stdClass given {"exception":"[object] (TypeError(code: 0): count(): Argument #1 ($value) must be of type Countable|array, stdClass given at /var/www/seat/vendor/softcreatr/jsonpath/src/Filters/SliceFilter.php:17).

When the type of a value passed to the `$overrides` parameter of `AssetMapping::make` is not of type `Closure`, it is treated as a key to be checked on the API response and not a static value. When including data in the asset mapping that doesn't come from the API response, it must be passed as part of a closure to avoid this.

The previous version of this code was effectively doing this:
```
$data = json_decode('{"is_singleton":false,"item_id":1234,"location_flag":"Hangar","location_id":1234,"location_type":"station","quantity":1234,"type_id":1234}');
$jp = new JSONPath($data);
$jp->find('2024-05:22 21:14:40');
```

This caused an error because no key exists with a name matching a datetime string.