### PR TITLE
refactor: remove $tries from esi jobs

### DIFF
--- a/src/Jobs/Contracts/Character/Items.php
+++ b/src/Jobs/Contracts/Character/Items.php
@@ -81,11 +81,6 @@ class Items extends AbstractAuthCharacterJob
     protected $tags = ['character', 'contract'];
 
     /**
-     * @var int
-     */
-    public $tries = 60;
-
-    /**
      * Items constructor.
      *
      * @param  \Seat\Eveapi\Models\RefreshToken  $token

--- a/src/Jobs/Contracts/Corporation/Items.php
+++ b/src/Jobs/Contracts/Corporation/Items.php
@@ -81,11 +81,6 @@ class Items extends AbstractAuthCorporationJob
     protected $tags = ['corporation', 'contract'];
 
     /**
-     * @var int
-     */
-    public $tries = 60;
-
-    /**
      * Items constructor.
      *
      * @param  int  $corporation_id

--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -76,11 +76,6 @@ abstract class EsiBase extends AbstractJob
     public $queue = 'public'; // By default, queue all ESI jobs on public queue.
 
     /**
-     * @var int By default, retry all ESI jobs 3 times.
-     */
-    public $tries = 3;
-
-    /**
      * The HTTP method used for the API Call.
      *
      * Eg: GET, POST, PUT, DELETE

--- a/src/Jobs/Market/History.php
+++ b/src/Jobs/Market/History.php
@@ -84,18 +84,6 @@ class History extends EsiBase
     protected $tags = ['public', 'market'];
 
     /**
-     * Override base attempts limit and allow the job to be retried up to 100 times.
-     * This value is tied to the amount of requests which should be done against ESI
-     * in order to process a complete batch.
-     *
-     * Everytime a TemporaryOutageException is thrown, we will release the job back
-     * in the queue. Every release is counting as an attempts.
-     *
-     * @var int
-     */
-    public $tries = 100;
-
-    /**
      * @var array
      */
     private $type_ids;


### PR DESCRIPTION
Since we define a retryUntil method in \Seat\Eveapi\Jobs\AbstractJob, $tries is ignored in all subclasses. This commit removes all usages of it, as the $tries definition doesn't do anything for these jobs.

I'll be testing this for a bit longer and then convert this from a draft to a regular PR.