### PR TITLE
fix fitting exports

### DIFF
--- a/src/Models/Corporation/CorporationStructure.php
+++ b/src/Models/Corporation/CorporationStructure.php
@@ -317,31 +317,31 @@ class CorporationStructure extends ExtensibleModel implements HasTypeID
         return sprintf('[%s, %s]', $this->type->typeName, $this->info->name) . PHP_EOL .
 
             $this->low_slots->map(function ($slot) {
-                return sprintf('%s x%d', $slot->type->typeName, $slot->quantity);
+                return sprintf('%s', $slot->type->typeName);
             })->implode(PHP_EOL) .
 
             PHP_EOL . PHP_EOL .
 
             $this->medium_slots->map(function ($slot) {
-                return sprintf('%s x%d', $slot->type->typeName, $slot->quantity);
+                return sprintf('%s', $slot->type->typeName);
             })->implode(PHP_EOL) .
 
             PHP_EOL . PHP_EOL .
 
             $this->high_slots->map(function ($slot) {
-                return sprintf('%s x%d', $slot->type->typeName, $slot->quantity);
+                return sprintf('%s', $slot->type->typeName);
             })->implode(PHP_EOL) .
 
             PHP_EOL . PHP_EOL .
 
             $this->services_slots->map(function ($slot) {
-                return sprintf('%s x%d', $slot->type->typeName, $slot->quantity);
+                return sprintf('%s', $slot->type->typeName);
             })->implode(PHP_EOL) .
 
             PHP_EOL . PHP_EOL .
 
             $this->rig_slots->map(function ($slot) {
-                return sprintf('%s x%d', $slot->type->typeName, $slot->quantity);
+                return sprintf('%s', $slot->type->typeName);
             })->implode(PHP_EOL) .
 
             PHP_EOL . PHP_EOL .

--- a/src/Models/Fittings/CharacterFitting.php
+++ b/src/Models/Fittings/CharacterFitting.php
@@ -161,31 +161,31 @@ class CharacterFitting extends ExtensibleModel
         return sprintf('[%s, %s]', $this->ship->typeName, $this->name) . PHP_EOL .
 
         $this->low_slots->map(function ($slot) {
-            return sprintf('%s x%d', $slot->type->typeName, $slot->quantity);
+            return sprintf('%s', $slot->type->typeName);
         })->implode(PHP_EOL) .
 
         PHP_EOL . PHP_EOL .
 
         $this->medium_slots->map(function ($slot) {
-            return sprintf('%s x%d', $slot->type->typeName, $slot->quantity);
+            return sprintf('%s', $slot->type->typeName);
         })->implode(PHP_EOL) .
 
         PHP_EOL . PHP_EOL .
 
         $this->high_slots->map(function ($slot) {
-            return sprintf('%s x%d', $slot->type->typeName, $slot->quantity);
+            return sprintf('%s', $slot->type->typeName);
         })->implode(PHP_EOL) .
 
         PHP_EOL . PHP_EOL .
 
         $this->sub_systems->map(function ($slot) {
-            return sprintf('%s x%d', $slot->type->typeName, $slot->quantity);
+            return sprintf('%s', $slot->type->typeName);
         })->implode(PHP_EOL) .
 
         PHP_EOL . PHP_EOL .
 
         $this->rig_slots->map(function ($slot) {
-            return sprintf('%s x%d', $slot->type->typeName, $slot->quantity);
+            return sprintf('%s', $slot->type->typeName);
         })->implode(PHP_EOL) .
 
         PHP_EOL . PHP_EOL .


### PR DESCRIPTION
fixes https://github.com/eveseat/seat/issues/904

before:
```
[Huginn, webby boi]
Power Diagnostic System II x1
Power Diagnostic System II x1
Power Diagnostic System II x1
Damage Control II x1

Multispectrum Shield Hardener II x1
Multispectrum Shield Hardener II x1
Large Shield Extender II x1
Large Shield Extender II x1
50MN Cold-Gas Enduring Microwarpdrive x1
Domination Stasis Webifier x1

Small EMP Smartbomb II x1
650mm Artillery Cannon II x1
650mm Artillery Cannon II x1
650mm Artillery Cannon II x1
650mm Artillery Cannon II x1



Medium Core Defense Field Extender II x1
Medium Core Defense Field Extender II x1

Warrior II x2
Valkyrie II x3

Tremor M x1600
Improved Mindflood Booster x1
```


after:
```
[Huginn, webby boi]
Power Diagnostic System II
Power Diagnostic System II
Power Diagnostic System II
Damage Control II

Multispectrum Shield Hardener II
Multispectrum Shield Hardener II
Large Shield Extender II
Large Shield Extender II
50MN Cold-Gas Enduring Microwarpdrive
Domination Stasis Webifier

Small EMP Smartbomb II
650mm Artillery Cannon II
650mm Artillery Cannon II
650mm Artillery Cannon II
650mm Artillery Cannon II



Medium Core Defense Field Extender II
Medium Core Defense Field Extender II

Warrior II x2
Valkyrie II x3

Tremor M x1600
Improved Mindflood Booster x1
```

same fix for structure fittings as well