### PR TITLE
Granular esi scheduling for characters

### DIFF
--- a/src/Commands/Seat/Buckets/Update.php
+++ b/src/Commands/Seat/Buckets/Update.php
@@ -69,9 +69,9 @@ class Update extends Command
     }
 
     /**
-     * Checks whether a token should be updated and dispatches the required jobs
+     * Checks whether a token should be updated and dispatches the required jobs.
      *
-     * @param RefreshToken $token
+     * @param  RefreshToken  $token
      * @return void
      */
     private function updateToken(RefreshToken $token): void
@@ -94,9 +94,9 @@ class Update extends Command
     }
 
     /**
-     * Dispatches the jobs to update the character
+     * Dispatches the jobs to update the character.
      *
-     * @param RefreshToken $token
+     * @param  RefreshToken  $token
      * @return void
      */
     private function dispatchCharacterEsiUpdate(RefreshToken $token): void
@@ -135,7 +135,7 @@ class Update extends Command
     /**
      * Dispatches a job that uses the token, so it doesn't expire.
      *
-     * @param RefreshToken $token
+     * @param  RefreshToken  $token
      * @return void
      */
     private function dispatchCharacterTokenKeepAlive(RefreshToken $token): void
@@ -184,9 +184,9 @@ class Update extends Command
     }
 
     /**
-     * Determine if jobs for a corporation have already been scheduled
+     * Determine if jobs for a corporation have already been scheduled.
      *
-     * @param int $corporation_id
+     * @param  int  $corporation_id
      * @return bool
      */
     private function isCorporationAlreadyScheduled(int $corporation_id): bool
@@ -195,9 +195,9 @@ class Update extends Command
     }
 
     /**
-     * Mark a corporation as already being processed
+     * Mark a corporation as already being processed.
      *
-     * @param int $corporation_id
+     * @param  int  $corporation_id
      * @return void
      */
     private function markCorporationScheduled(int $corporation_id): void

--- a/src/Commands/Seat/Buckets/Update.php
+++ b/src/Commands/Seat/Buckets/Update.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Facades\Cache;
 use Seat\Eveapi\Bus\Character;
 use Seat\Eveapi\Bus\Corporation;
 use Seat\Eveapi\Models\Bucket;
+use Seat\Eveapi\Models\RefreshToken;
 
 /**
  * Class Update.
@@ -45,6 +46,8 @@ class Update extends Command
      */
     protected $description = 'Schedule jobs from next bucket to update tokens.';
 
+    private array $scheduled_corporations = [];
+
     /**
      * Execute command.
      */
@@ -56,91 +59,93 @@ class Update extends Command
         // store bucket ID, so we keep track of the flow.
         Cache::forever('buckets:processed', $bucket->id);
 
-        $this->updateCharacters($bucket);
-        $this->updateCorporations($bucket);
+        $bucket->refresh_tokens()
+            ->with(['character', 'affiliation'])
+            ->get()->each(function (RefreshToken $token) {
+                $this->updateToken($token);
+            });
+    }
+
+    private function updateToken(RefreshToken $token)
+    {
+        // schedule character related update
+        $this->scheduleCharacterJobs($token);
+
+        // if this is a director, schedule corporation related updates
+        if (
+            $token->affiliation->corporation_id !== null
+            && $token->character->corporation_roles->where('scope', 'roles')->where('role', 'Director')->isNotEmpty()
+            && !$this->isCorporationAlreadyScheduled($token->affiliation->corporation_id)
+        ) {
+            $this->markCorporationScheduled($token->affiliation->corporation_id);
+            $this->scheduleCorporationJobs($token);
+        }
     }
 
     /**
      * Update characters tied to the bucket tokens.
      *
-     * @param  \Seat\Eveapi\Models\Bucket  $bucket
+     * @param RefreshToken $token
      */
-    private function updateCharacters(Bucket $bucket)
+    private function scheduleCharacterJobs(RefreshToken $token): void
     {
-        // loop over each attached tokens and enqueue job tied to this token.
-        $bucket->refresh_tokens->each(function ($token) use ($bucket) {
+        // create a cache entry with TTL 1 hour - so we can prevent a character to be updated more than once
+        // in the defined update window.
+        $lock = Cache::lock(sprintf('buckets:characters:%d', $token->character_id), 3600);
 
-            // create a cache entry with TTL 1 hour - so we can prevent a character to be updated more than once
-            // in the defined update window.
-            $lock = Cache::lock(sprintf('buckets:characters:%d', $token->character_id), 3600);
-
-            // if we are not able to spawn the entry, log the event and interrupt the command.
-            if (! $lock->get()) {
-                logger()->warning('[Buckets] This character has already been processed during the last update window. Process has been interrupted.', [
-                    'bucket_id' => $bucket->id,
-                    'character_id' => $token->character_id,
-                    'update_window' => 3600,
-                ]);
-
-                return;
-            }
-
-            // queue character jobs for the selected token.
-            (new Character($token->character_id, $token))->fire();
-
-            logger()->debug('[Buckets] Processing token from a bucket', [
-                'bucket' => $bucket->id,
-                'flow' => 'character',
-                'token' => $token->character_id,
+        // if we are not able to spawn the entry, log the event and interrupt the command.
+        if (!$lock->get()) {
+            logger()->warning('[Buckets] This character has already been processed during the last update window. Process has been interrupted.', [
+                'character_id' => $token->character_id,
             ]);
-        });
+
+            return;
+        }
+
+        // queue character jobs for the selected token.
+        (new Character($token->character_id, $token))->fire();
+
+        logger()->debug('[Buckets] Processing token from a bucket', [
+            'flow' => 'character',
+            'token' => $token->character_id,
+        ]);
+
     }
 
     /**
      * Update corporations tied to the bucket tokens.
      *
-     * @param  \Seat\Eveapi\Models\Bucket  $bucket
+     * @param RefreshToken $token
      */
-    private function updateCorporations(Bucket $bucket)
+    private function scheduleCorporationJobs(RefreshToken $token): void
     {
-        $bucket->refresh_tokens()->whereHas('character.affiliation', function ($query) {
-            $query->whereNotNull('corporation_id');
-        })->whereHas('character.corporation_roles', function ($query) {
-            $query->where('scope', 'roles');
-            $query->where('role', 'Director');
-        })->get()->unique('character.affiliation.corporation_id')->each(function ($token) use ($bucket) {
+        // create a cache entry with TTL 1 hour - so we can prevent a corporation to be updated more than once
+        // in the defined update window.
+        $lock = Cache::lock(sprintf('buckets:corporations:%d',
+            $token->character->affiliation->corporation_id), 3600);
 
-            // create a cache entry with TTL 1 hour - so we can prevent a corporation to be updated more than once
-            // in the defined update window.
-            $lock = Cache::lock(sprintf('buckets:corporations:%d',
-                $token->character->affiliation->corporation_id), 3600);
-
-            // if we are not able to spawn the entry, log the event and interrupt the command.
-            if (! $lock->get()) {
-                logger()->warning('[Buckets] This corporation has already been processed during the last update window. Process has been interrupted.', [
-                    'bucket_id' => $bucket->id,
-                    'corporation_id' => $token->character->affiliation->corporation_id,
-                    'update_window' => 3600,
-                ]);
-
-                return;
-            }
-
-            // Fire the class to update corporation information
-            (new Corporation($token->character->affiliation->corporation_id, $token))->fire();
-
-            logger()->debug('[Buckets] Processing token from a bucket.', [
-                'bucket' => $bucket->id,
-                'flow' => 'corporation',
-                'token' => $token->character_id,
+        // if we are not able to spawn the entry, log the event and interrupt the command.
+        if (!$lock->get()) {
+            logger()->warning('[Buckets] This corporation has already been processed during the last update window. Process has been interrupted.', [
+                'corporation_id' => $token->character->affiliation->corporation_id,
             ]);
-        });
+
+            return;
+        }
+
+        // Fire the class to update corporation information
+        (new Corporation($token->character->affiliation->corporation_id, $token))->fire();
+
+        logger()->debug('[Buckets] Processing token from a bucket.', [
+            'flow' => 'corporation',
+            'token' => $token->character_id,
+        ]);
     }
 
     /**
      * Determine what is the next bucket to process.
      *
-     * @return \Seat\Eveapi\Models\Bucket
+     * @return Bucket
      */
     private function getNextBucket(): Bucket
     {
@@ -155,7 +160,7 @@ class Update extends Command
             $bucket = Bucket::orderBy('id')->first();
 
             // if we're still not able to find a candidate, spawn a new bucket.
-            if (! $bucket) {
+            if (!$bucket) {
                 $bucket = new Bucket();
                 $bucket->save();
 
@@ -174,5 +179,15 @@ class Update extends Command
     private function getLastProcessedBucketID(): int
     {
         return Cache::get('buckets:processed') ?: 0;
+    }
+
+    private function isCorporationAlreadyScheduled(int $corporation_id): bool
+    {
+        return array_key_exists($corporation_id, $this->scheduled_corporations);
+    }
+
+    private function markCorporationScheduled(int $corporation_id): void
+    {
+        $this->scheduled_corporations[$corporation_id] = true;
     }
 }

--- a/src/Models/Character/CharacterInfo.php
+++ b/src/Models/Character/CharacterInfo.php
@@ -58,6 +58,8 @@ use Seat\Tests\Eveapi\Database\Factories\CharacterInfoFactory;
  * Class CharacterInfo.
  *
  * @package Seat\Eveapi\Models\Character
+ *
+ * @property CharacterRole $corporation_roles
  */
 class CharacterInfo extends ExtensibleModel
 {

--- a/src/Models/Character/CharacterRole.php
+++ b/src/Models/Character/CharacterRole.php
@@ -31,6 +31,9 @@ use Seat\Tests\Eveapi\Database\Factories\CharacterRoleFactory;
  * Class CharacterRole.
  *
  * @package Seat\Eveapi\Models\Character
+ *
+ * @property string $scope
+ * @property string $role
  */
 class CharacterRole extends ExtensibleModel
 {

--- a/src/Models/RefreshToken.php
+++ b/src/Models/RefreshToken.php
@@ -38,7 +38,9 @@ use Seat\Tests\Eveapi\Database\Factories\RefreshTokenFactory;
 /**
  * @property CharacterInfo $character
  * @property CharacterAffiliation $affiliation
- * @property
+ * @property int $character_id
+ * @property int esi_update_interval The time in seconds after which this character should be updated
+ * @property \Carbon\Carbon last_esi_update The last time this token has been scheduled for an update
  */
 class RefreshToken extends ExtensibleModel implements EsiToken
 {
@@ -67,6 +69,7 @@ class RefreshToken extends ExtensibleModel implements EsiToken
         'scopes' => 'array',
         'expires_on' => 'datetime',
         'deleted_at' => 'datetime',
+        'last_esi_update' => 'datetime'
     ];
 
     /**

--- a/src/Models/RefreshToken.php
+++ b/src/Models/RefreshToken.php
@@ -39,6 +39,7 @@ use Seat\Tests\Eveapi\Database\Factories\RefreshTokenFactory;
  * @property CharacterInfo $character
  * @property CharacterAffiliation $affiliation
  * @property int $character_id
+ * @property \Carbon\Carbon $updated_at
  * @property int esi_update_interval The time in seconds after which this character should be updated
  * @property \Carbon\Carbon last_esi_update The last time this token has been scheduled for an update
  */

--- a/src/Models/RefreshToken.php
+++ b/src/Models/RefreshToken.php
@@ -35,6 +35,11 @@ use Seat\Services\Contracts\EsiToken;
 use Seat\Services\Models\ExtensibleModel;
 use Seat\Tests\Eveapi\Database\Factories\RefreshTokenFactory;
 
+/**
+ * @property CharacterInfo $character
+ * @property CharacterAffiliation $affiliation
+ * @property
+ */
 class RefreshToken extends ExtensibleModel implements EsiToken
 {
     use HasFactory, SoftDeletes {

--- a/src/Models/RefreshToken.php
+++ b/src/Models/RefreshToken.php
@@ -38,10 +38,9 @@ use Seat\Tests\Eveapi\Database\Factories\RefreshTokenFactory;
 /**
  * @property CharacterInfo $character
  * @property CharacterAffiliation $affiliation
+ * @property RefreshTokenSchedule $token_schedule
  * @property int $character_id
  * @property \Carbon\Carbon $updated_at
- * @property int esi_update_interval The time in seconds after which this character should be updated
- * @property \Carbon\Carbon last_esi_update The last time this token has been scheduled for an update
  */
 class RefreshToken extends ExtensibleModel implements EsiToken
 {
@@ -70,7 +69,6 @@ class RefreshToken extends ExtensibleModel implements EsiToken
         'scopes' => 'array',
         'expires_on' => 'datetime',
         'deleted_at' => 'datetime',
-        'last_esi_update' => 'datetime'
     ];
 
     /**
@@ -171,6 +169,11 @@ class RefreshToken extends ExtensibleModel implements EsiToken
     public function user()
     {
         return $this->belongsTo(self::$user_instance::class, 'user_id', self::$user_instance->getAuthIdentifierName());
+    }
+
+    public function token_schedule()
+    {
+        return $this->hasOne(RefreshTokenSchedule::class,'character_id');
     }
 
     /**

--- a/src/Models/RefreshToken.php
+++ b/src/Models/RefreshToken.php
@@ -173,7 +173,7 @@ class RefreshToken extends ExtensibleModel implements EsiToken
 
     public function token_schedule()
     {
-        return $this->hasOne(RefreshTokenSchedule::class,'character_id');
+        return $this->hasOne(RefreshTokenSchedule::class, 'character_id');
     }
 
     /**

--- a/src/Models/RefreshTokenSchedule.php
+++ b/src/Models/RefreshTokenSchedule.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Seat\Eveapi\Models;
+
+use Carbon\Carbon;
+use Seat\Services\Models\ExtensibleModel;
+
+/**
+ * @property int $character_id
+ * @property Carbon $last_update
+ * @property int $update_interval
+ * @property RefreshToken $token
+ */
+class RefreshTokenSchedule extends ExtensibleModel
+{
+    protected $table = 'refresh_token_schedules';
+    protected $primaryKey = 'character_id';
+    public $incrementing = false;
+    public $timestamps = false;
+
+    protected $casts = [
+        'last_update' => 'datetime',
+    ];
+    public function token()
+    {
+        return $this->hasOne(RefreshToken::class,'character_id');
+    }
+}

--- a/src/Models/RefreshTokenSchedule.php
+++ b/src/Models/RefreshTokenSchedule.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Models;
 
 use Carbon\Carbon;
@@ -21,8 +41,9 @@ class RefreshTokenSchedule extends ExtensibleModel
     protected $casts = [
         'last_update' => 'datetime',
     ];
+
     public function token()
     {
-        return $this->hasOne(RefreshToken::class,'character_id');
+        return $this->hasOne(RefreshToken::class, 'character_id');
     }
 }

--- a/src/database/migrations/2024_07_02_103850_add_last_update_scheduled_field.php
+++ b/src/database/migrations/2024_07_02_103850_add_last_update_scheduled_field.php
@@ -34,9 +34,10 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::table('refresh_tokens', function (Blueprint $table) {
-            $table->timestamp('last_esi_update')->nullable();
-            $table->integer('esi_update_interval')->unsigned()->default(60*60);
+        Schema::create('refresh_token_schedules', function (Blueprint $table){
+            $table->bigInteger('character_id')->unsigned()->primary();
+            $table->timestamp('last_update');
+            $table->integer('update_interval')->default(60*60);
         });
     }
 
@@ -47,9 +48,6 @@ return new class extends Migration
      */
     public function down()
     {
-        Schema::table('refresh_tokens', function (Blueprint $table) {
-            $table->dropColumn('last_esi_update');
-            $table->dropColumn('esi_update_interval');
-        });
+        Schema::drop('refresh_token_schedules');
     }
 };

--- a/src/database/migrations/2024_07_02_103850_add_last_update_scheduled_field.php
+++ b/src/database/migrations/2024_07_02_103850_add_last_update_scheduled_field.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('refresh_tokens', function (Blueprint $table) {
+            $table->timestamp('last_esi_update')->nullable();
+            $table->integer('esi_update_interval')->unsigned()->default(60*60);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('refresh_tokens', function (Blueprint $table) {
+            $table->dropColumn('last_esi_update');
+            $table->dropColumn('esi_update_interval');
+        });
+    }
+};

--- a/src/database/migrations/2024_07_02_103850_add_refresh_token_schedules_table.php
+++ b/src/database/migrations/2024_07_02_103850_add_refresh_token_schedules_table.php
@@ -24,9 +24,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      *
@@ -34,10 +32,10 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::create('refresh_token_schedules', function (Blueprint $table){
+        Schema::create('refresh_token_schedules', function (Blueprint $table) {
             $table->bigInteger('character_id')->unsigned()->primary();
             $table->timestamp('last_update');
-            $table->integer('update_interval')->default(60*60);
+            $table->integer('update_interval')->default(60 * 60);
         });
     }
 


### PR DESCRIPTION
# Granular esi scheduling for characters
I'm currently working on making it possible to adjust the esi update interval per character. This PR updates the eveapi side of this project.

This PR is already up to collect some early feedback.

## How does it work?
This PR modifies how buckets schedule tokens. This means only the hourly esi updates of endpoints on a 1 hour cache timer are affected.

Each `refresh_token` gets an associated entry in the new `refresh_token_schedules` table. This entry contains the last time jobs for the token have been scheduled (`last_update`), and how often the token should be scheduled (`update_interval`). The buckets logic only dispatches jobs if the configured time(`update_interval`) since the last update has passed.

The system is designed with super-long update intervals in mind(think weeks). It stores the last update in the database opposed to redis so that the update spacing is maintained even across restarts. To prevent tokens from expiring, at least once a day, a single job is scheduled.