### PR TITLE
add access token refreshing logic

### DIFF
--- a/src/Commands/Seat/Buckets/Update.php
+++ b/src/Commands/Seat/Buckets/Update.php
@@ -26,7 +26,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Cache;
 use Seat\Eveapi\Bus\Character;
 use Seat\Eveapi\Bus\Corporation;
-use Seat\Eveapi\Jobs\Character\Roles;
+use Seat\Eveapi\Jobs\Token\RefreshAccessToken;
 use Seat\Eveapi\Models\Bucket;
 use Seat\Eveapi\Models\RefreshToken;
 use Seat\Eveapi\Models\RefreshTokenSchedule;
@@ -140,8 +140,7 @@ class Update extends Command
      */
     private function dispatchCharacterTokenKeepAlive(RefreshToken $token): void
     {
-        // TODO: add a job that only requests a new access token instead of a random esi job. This will require some eseye rework
-        Roles::dispatch($token)->onQueue('characters');
+        RefreshAccessToken::dispatch($token)->onQueue('characters');
     }
 
     /**

--- a/src/InteractsWithToken.php
+++ b/src/InteractsWithToken.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eveapi;
+
+use Seat\Eveapi\Models\RefreshToken;
+use Seat\Services\Contracts\EsiClient;
+
+trait InteractsWithToken
+{
+    abstract protected function getClient(): EsiClient;
+
+    abstract protected function getToken(): ?RefreshToken;
+
+    /**
+     * @return void
+     */
+    protected function configureTokenForEsiClient(): void
+    {
+        $token = $this->getToken();
+        if($token !== null) {
+            $this->getClient()->setAuthentication($token);
+        }
+    }
+
+    /**
+     * Update the access_token last used in the job,
+     * along with the expiry time.
+     *
+     * @return void
+     */
+    public function updateRefreshToken(): void
+    {
+        $client = $this->getClient();
+        $token = $this->getToken();
+
+        // If  it is an unauthenticated call, there is nothing to update
+        if (is_null($token))
+            return;
+
+        if (! $client->isAuthenticated())
+            return;
+
+        $last_auth = $client->getAuthentication();
+
+        // update the token
+        if (! empty($last_auth->getRefreshToken()))
+            $token->refresh_token = $last_auth->getRefreshToken();
+        $token->token = $last_auth->getAccessToken() ?? '-';
+        $token->expires_on = $last_auth->getExpiresOn();
+        $token->save();
+    }
+}

--- a/src/Jobs/Token/RefreshAccessToken.php
+++ b/src/Jobs/Token/RefreshAccessToken.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Seat\Eveapi\Jobs\Token;
+
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Seat\Eseye\Exceptions\RequestFailedException;
+use Seat\Eveapi\Jobs\AbstractJob;
+use Seat\Eveapi\Models\RefreshToken;
+use Seat\Services\Contracts\EsiClient;
+
+class RefreshAccessToken extends AbstractJob
+{
+    /**
+     * @var array
+     */
+    protected $tags = ['character', 'token'];
+
+    /**
+     * @var \Seat\Eveapi\Models\RefreshToken
+     */
+    protected $token;
+
+    /**
+     * @var \Seat\Services\Contracts\EsiClient
+     */
+    protected EsiClient $esi;
+
+
+    /**
+     * @param RefreshToken $token
+     * @throws BindingResolutionException
+     */
+    public function __construct(RefreshToken $token)
+    {
+        $this->token = $token;
+        $this->esi = app()->make(EsiClient::class);
+    }
+
+
+    /**
+     * @return void
+     */
+    public function handle()
+    {
+        // normally the retrieve function passes the token down the esi stack, but we don't use retrieve
+        $this->esi->setAuthentication($this->token);
+
+        try {
+            // get or renew access token
+            $this->esi->getValidAccessToken();
+        } catch (RequestFailedException $e) {
+
+        }
+
+        // save the new access token. the following logic is extracted from EsiBase
+        $this->token = $this->token->fresh(); // since the model might have been in the queue for a while, amke sure to get the latest info
+        $last_auth = $this->esi->getAuthentication(); // extract the access token info from eseye
+
+        if (! empty($last_auth->getRefreshToken()))
+            $this->token->refresh_token = $last_auth->getRefreshToken();
+
+        $this->token->token = $last_auth->getAccessToken() ?? '-';
+        $this->token->expires_on = $last_auth->getExpiresOn();
+
+        $this->token->save();
+    }
+}

--- a/src/Jobs/Token/RefreshAccessToken.php
+++ b/src/Jobs/Token/RefreshAccessToken.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Jobs\Token;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
@@ -25,9 +45,9 @@ class RefreshAccessToken extends AbstractJob
      */
     protected EsiClient $esi;
 
-
     /**
-     * @param RefreshToken $token
+     * @param  RefreshToken  $token
+     *
      * @throws BindingResolutionException
      */
     public function __construct(RefreshToken $token)
@@ -35,7 +55,6 @@ class RefreshAccessToken extends AbstractJob
         $this->token = $token;
         $this->esi = app()->make(EsiClient::class);
     }
-
 
     /**
      * @return void

--- a/src/Services/EseyeClient.php
+++ b/src/Services/EseyeClient.php
@@ -34,6 +34,8 @@ use Psr\SimpleCache\CacheInterface;
 use Seat\Eseye\Configuration;
 use Seat\Eseye\Containers\EsiAuthentication;
 use Seat\Eseye\Eseye;
+use Seat\Eseye\Exceptions\InvalidAuthenticationException;
+use Seat\Eseye\Exceptions\InvalidContainerDataException;
 use Seat\Services\Contracts\EsiClient;
 use Seat\Services\Contracts\EsiResponse;
 use Seat\Services\Contracts\EsiToken;
@@ -226,5 +228,14 @@ class EseyeClient implements EsiClient
     public function getCache(): CacheInterface
     {
         return $this->instance->getConfiguration()->getCache();
+    }
+
+    /**
+     * @throws InvalidAuthenticationException
+     * @throws InvalidContainerDataException
+     */
+    public function getValidAccessToken(): string
+    {
+        return $this->instance->getValidAccessToken()->access_token;
     }
 }


### PR DESCRIPTION
This PR builds upon https://github.com/eveseat/eseye/pull/98 and adds a job that can refresh access tokens without making esi calls. This way, for example `publicData` tokens can be kept alive.

This is also intended to be integrated with https://github.com/eveseat/eveapi/pull/409 to allow token hibernation(no esi calls for a extended period of time)

Requirements before merging:
- merge and tag https://github.com/eveseat/eseye/pull/98
- bump the eseye dependency
- merge and tag at the same time as https://github.com/eveseat/services/pull/181 (including bumping eveapi->eseye dependency)