### PR TITLE
only schedule job if the token has scopes for the job

### DIFF
--- a/src/Bus/Alliance.php
+++ b/src/Bus/Alliance.php
@@ -43,11 +43,6 @@ class Alliance extends Bus
     private int $alliance_id;
 
     /**
-     * @var \Seat\Eveapi\Models\RefreshToken|null
-     */
-    private ?RefreshToken $token;
-
-    /**
      * Alliance constructor.
      *
      * @param  int  $alliance_id
@@ -55,7 +50,7 @@ class Alliance extends Bus
      */
     public function __construct(int $alliance_id, ?RefreshToken $token = null)
     {
-        parent::__construct();
+        parent::__construct($token);
 
         $this->token = $token;
         $this->alliance_id = $alliance_id;
@@ -66,7 +61,7 @@ class Alliance extends Bus
      *
      * @return void
      */
-    public function fire()
+    public function fire(): void
     {
         $this->addPublicJobs();
 
@@ -117,8 +112,8 @@ class Alliance extends Bus
      */
     protected function addPublicJobs()
     {
-        $this->jobs->add(new Info($this->alliance_id));
-        $this->jobs->add(new Members($this->alliance_id));
+        $this->addPublicJob(new Info($this->alliance_id));
+        $this->addPublicJob(new Members($this->alliance_id));
     }
 
     /**
@@ -128,7 +123,7 @@ class Alliance extends Bus
      */
     protected function addAuthenticatedJobs()
     {
-        $this->jobs->add(new Labels($this->alliance_id, $this->token));
-        $this->jobs->add(new Contacts($this->alliance_id, $this->token));
+        $this->addAuthenticatedJob(new Labels($this->alliance_id, $this->token));
+        $this->addAuthenticatedJob(new Contacts($this->alliance_id, $this->token));
     }
 }

--- a/src/Bus/Bus.php
+++ b/src/Bus/Bus.php
@@ -61,8 +61,9 @@ abstract class Bus
     abstract public function fire(): void;
 
     /**
-     * Checks if the scopes of the token allow this job and if so, add it to the job list
-     * @param EsiBase $job
+     * Checks if the scopes of the token allow this job and if so, add it to the job list.
+     *
+     * @param  EsiBase  $job
      * @return void
      */
     protected function addAuthenticatedJob(EsiBase $job): void
@@ -75,8 +76,9 @@ abstract class Bus
     }
 
     /**
-     * Add a public job to the job list
-     * @param ShouldQueue $job
+     * Add a public job to the job list.
+     *
+     * @param  ShouldQueue  $job
      * @return void
      */
     protected function addPublicJob(ShouldQueue $job): void

--- a/src/Bus/Bus.php
+++ b/src/Bus/Bus.php
@@ -22,7 +22,10 @@
 
 namespace Seat\Eveapi\Bus;
 
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Collection;
+use Seat\Eveapi\Jobs\EsiBase;
+use Seat\Eveapi\Models\RefreshToken;
 
 /**
  * Interface Bus.
@@ -37,11 +40,17 @@ abstract class Bus
     protected Collection $jobs;
 
     /**
+     * @var \Seat\Eveapi\Models\RefreshToken|null
+     */
+    protected ?RefreshToken $token;
+
+    /**
      * Bus constructor.
      */
-    public function __construct()
+    public function __construct(?RefreshToken $token)
     {
         $this->jobs = collect();
+        $this->token = $token;
     }
 
     /**
@@ -49,19 +58,29 @@ abstract class Bus
      *
      * @return void
      */
-    abstract public function fire();
+    abstract public function fire(): void;
 
     /**
-     * Seed jobs list with job which did not require authentication.
-     *
+     * Checks if the scopes of the token allow this job and if so, add it to the job list
+     * @param EsiBase $job
      * @return void
      */
-    abstract protected function addPublicJobs();
+    protected function addAuthenticatedJob(EsiBase $job): void
+    {
+        if(is_null($this->token)) return;
+
+        if(in_array($job->getScope(), $this->token->getScopes())) {
+            $this->jobs->add($job);
+        }
+    }
 
     /**
-     * Seed jobs list with job requiring authentication.
-     *
+     * Add a public job to the job list
+     * @param ShouldQueue $job
      * @return void
      */
-    abstract protected function addAuthenticatedJobs();
+    protected function addPublicJob(ShouldQueue $job): void
+    {
+        $this->jobs->add($job);
+    }
 }

--- a/src/Bus/Character.php
+++ b/src/Bus/Character.php
@@ -79,11 +79,6 @@ class Character extends Bus
     private int $character_id;
 
     /**
-     * @var \Seat\Eveapi\Models\RefreshToken|null
-     */
-    private ?RefreshToken $token;
-
-    /**
      * Character constructor.
      *
      * @param  int  $character_id
@@ -91,10 +86,9 @@ class Character extends Bus
      */
     public function __construct(int $character_id, ?RefreshToken $token = null)
     {
-        parent::__construct();
+        parent::__construct($token);
 
         $this->character_id = $character_id;
-        $this->token = $token;
     }
 
     /**
@@ -102,7 +96,7 @@ class Character extends Bus
      *
      * @return void
      */
-    public function fire()
+    public function fire(): void
     {
         $this->addPublicJobs();
 
@@ -154,9 +148,9 @@ class Character extends Bus
      */
     protected function addPublicJobs()
     {
-        $this->jobs->add(new Info($this->character_id));
-        $this->jobs->add(new CorporationHistory($this->character_id));
-        $this->jobs->add(new Affiliation([$this->character_id]));
+        $this->addPublicJob(new Info($this->character_id));
+        $this->addPublicJob(new CorporationHistory($this->character_id));
+        $this->addPublicJob(new Affiliation([$this->character_id]));
     }
 
     /**
@@ -166,57 +160,57 @@ class Character extends Bus
      */
     protected function addAuthenticatedJobs()
     {
-        $this->jobs->add(new Roles($this->token));
-        $this->jobs->add(new Titles($this->token));
-        $this->jobs->add(new Clones($this->token));
-        $this->jobs->add(new Implants($this->token));
+        $this->addAuthenticatedJob(new Roles($this->token));
+        $this->addAuthenticatedJob(new Titles($this->token));
+        $this->addAuthenticatedJob(new Clones($this->token));
+        $this->addAuthenticatedJob(new Implants($this->token));
 
-        $this->jobs->add(new Location($this->token));
-        $this->jobs->add(new Online($this->token));
-        $this->jobs->add(new Ship($this->token));
+        $this->addAuthenticatedJob(new Location($this->token));
+        $this->addAuthenticatedJob(new Online($this->token));
+        $this->addAuthenticatedJob(new Ship($this->token));
 
-        $this->jobs->add(new Attributes($this->token));
-        $this->jobs->add(new Queue($this->token));
-        $this->jobs->add(new Skills($this->token));
+        $this->addAuthenticatedJob(new Attributes($this->token));
+        $this->addAuthenticatedJob(new Queue($this->token));
+        $this->addAuthenticatedJob(new Skills($this->token));
 
         // collect military information
-        $this->jobs->add(new Fittings($this->token));
+        $this->addAuthenticatedJob(new Fittings($this->token));
 
-        $this->jobs->add(new Fatigue($this->token));
-        $this->jobs->add(new Medals($this->token));
+        $this->addAuthenticatedJob(new Fatigue($this->token));
+        $this->addAuthenticatedJob(new Medals($this->token));
 
         // collect industrial information
-        $this->jobs->add(new Blueprints($this->token));
-        $this->jobs->add(new Jobs($this->token));
-        $this->jobs->add(new Mining($this->token));
-        $this->jobs->add(new AgentsResearch($this->token));
+        $this->addAuthenticatedJob(new Blueprints($this->token));
+        $this->addAuthenticatedJob(new Jobs($this->token));
+        $this->addAuthenticatedJob(new Mining($this->token));
+        $this->addAuthenticatedJob(new AgentsResearch($this->token));
 
         // collect financial information
-        $this->jobs->add(new Orders($this->token));
-        $this->jobs->add(new History($this->token));
-        $this->jobs->add(new Planets($this->token));
-        $this->jobs->add(new Balance($this->token));
-        $this->jobs->add(new Journal($this->token));
-        $this->jobs->add(new Transactions($this->token));
-        $this->jobs->add(new LoyaltyPoints($this->token));
+        $this->addAuthenticatedJob(new Orders($this->token));
+        $this->addAuthenticatedJob(new History($this->token));
+        $this->addAuthenticatedJob(new Planets($this->token));
+        $this->addAuthenticatedJob(new Balance($this->token));
+        $this->addAuthenticatedJob(new Journal($this->token));
+        $this->addAuthenticatedJob(new Transactions($this->token));
+        $this->addAuthenticatedJob(new LoyaltyPoints($this->token));
 
         // collect intel information
-        $this->jobs->add(new Standings($this->token));
-        $this->jobs->add(new Contacts($this->token));
-        $this->jobs->add(new ContactLabels($this->token));
+        $this->addAuthenticatedJob(new Standings($this->token));
+        $this->addAuthenticatedJob(new Contacts($this->token));
+        $this->addAuthenticatedJob(new ContactLabels($this->token));
 
-        $this->jobs->add(new MailLabels($this->token));
-        $this->jobs->add(new MailingLists($this->token));
-        $this->jobs->add(new Mails($this->token));
+        $this->addAuthenticatedJob(new MailLabels($this->token));
+        $this->addAuthenticatedJob(new MailingLists($this->token));
+        $this->addAuthenticatedJob(new Mails($this->token));
 
         // calendar events
-        $this->jobs->add(new Events($this->token));
-        $this->jobs->add(new Detail($this->token));
-        $this->jobs->add(new Attendees($this->token));
+        $this->addAuthenticatedJob(new Events($this->token));
+        $this->addAuthenticatedJob(new Detail($this->token));
+        $this->addAuthenticatedJob(new Attendees($this->token));
 
         // assets
-        $this->jobs->add(new Assets($this->token));
-        $this->jobs->add(new Names($this->token));
-        $this->jobs->add(new Locations($this->token));
+        $this->addAuthenticatedJob(new Assets($this->token));
+        $this->addAuthenticatedJob(new Names($this->token));
+        $this->addAuthenticatedJob(new Locations($this->token));
     }
 }

--- a/src/Bus/Corporation.php
+++ b/src/Bus/Corporation.php
@@ -76,11 +76,6 @@ class Corporation extends Bus
     private int $corporation_id;
 
     /**
-     * @var \Seat\Eveapi\Models\RefreshToken|null
-     */
-    private ?RefreshToken $token;
-
-    /**
      * Corporation constructor.
      *
      * @param  int  $corporation_id
@@ -88,7 +83,7 @@ class Corporation extends Bus
      */
     public function __construct(int $corporation_id, ?RefreshToken $token = null)
     {
-        parent::__construct();
+        parent::__construct($token);
 
         $this->corporation_id = $corporation_id;
         $this->token = $token;
@@ -99,7 +94,7 @@ class Corporation extends Bus
      *
      * @return void
      */
-    public function fire()
+    public function fire(): void
     {
         $this->addPublicJobs();
 
@@ -151,8 +146,8 @@ class Corporation extends Bus
      */
     protected function addPublicJobs()
     {
-        $this->jobs->add(new Info($this->corporation_id));
-        $this->jobs->add(new AllianceHistory($this->corporation_id));
+        $this->addPublicJob(new Info($this->corporation_id));
+        $this->addPublicJob(new AllianceHistory($this->corporation_id));
     }
 
     /**
@@ -162,53 +157,53 @@ class Corporation extends Bus
      */
     protected function addAuthenticatedJobs()
     {
-        $this->jobs->add(new Divisions($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Divisions($this->corporation_id, $this->token));
 
-        $this->jobs->add(new Roles($this->corporation_id, $this->token));
-        $this->jobs->add(new RoleHistories($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Roles($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new RoleHistories($this->corporation_id, $this->token));
 
-        $this->jobs->add(new Titles($this->corporation_id, $this->token));
-        $this->jobs->add(new MembersTitles($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Titles($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new MembersTitles($this->corporation_id, $this->token));
 
-        $this->jobs->add(new MembersLimit($this->corporation_id, $this->token));
-        $this->jobs->add(new Members($this->corporation_id, $this->token));
-        $this->jobs->add(new MemberTracking($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new MembersLimit($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Members($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new MemberTracking($this->corporation_id, $this->token));
 
-        $this->jobs->add(new Medals($this->corporation_id, $this->token));
-        $this->jobs->add(new IssuedMedals($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Medals($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new IssuedMedals($this->corporation_id, $this->token));
 
         // collect industrial information
-        $this->jobs->add(new Blueprints($this->corporation_id, $this->token));
-        $this->jobs->add(new Facilities($this->corporation_id, $this->token));
-        $this->jobs->add(new Jobs($this->corporation_id, $this->token));
-        $this->jobs->add(new Observers($this->corporation_id, $this->token));
-        $this->jobs->add(new ObserverDetails($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Blueprints($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Facilities($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Jobs($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Observers($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new ObserverDetails($this->corporation_id, $this->token));
 
         // collect financial information
-        $this->jobs->add(new Orders($this->corporation_id, $this->token));
-        $this->jobs->add(new History($this->corporation_id, $this->token));
-        $this->jobs->add(new Shareholders($this->corporation_id, $this->token));
-        $this->jobs->add(new Balances($this->corporation_id, $this->token));
-        $this->jobs->add(new Journals($this->corporation_id, $this->token));
-        $this->jobs->add(new Transactions($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Orders($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new History($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Shareholders($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Balances($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Journals($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Transactions($this->corporation_id, $this->token));
 
         // collect intel information
-        $this->jobs->add(new Labels($this->corporation_id, $this->token));
-        $this->jobs->add(new Standings($this->corporation_id, $this->token));
-        $this->jobs->add(new Contacts($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Labels($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Standings($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Contacts($this->corporation_id, $this->token));
 
         // structures
-        $this->jobs->add(new Starbases($this->corporation_id, $this->token));
-        $this->jobs->add(new StarbaseDetails($this->corporation_id, $this->token));
-        $this->jobs->add(new Structures($this->corporation_id, $this->token));
-        $this->jobs->add(new Extractions($this->corporation_id, $this->token));
-        $this->jobs->add(new CustomsOffices($this->corporation_id, $this->token));
-        $this->jobs->add(new CustomsOfficeLocations($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Starbases($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new StarbaseDetails($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Structures($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Extractions($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new CustomsOffices($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new CustomsOfficeLocations($this->corporation_id, $this->token));
 
         // assets
-        $this->jobs->add(new Assets($this->corporation_id, $this->token));
-        $this->jobs->add(new ContainerLogs($this->corporation_id, $this->token));
-        $this->jobs->add(new Locations($this->corporation_id, $this->token));
-        $this->jobs->add(new Names($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Assets($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new ContainerLogs($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Locations($this->corporation_id, $this->token));
+        $this->addAuthenticatedJob(new Names($this->corporation_id, $this->token));
     }
 }


### PR DESCRIPTION
Recently a few people started complaining about jobs getting scheduled if the character doesn't have the scopes for the job. While not very critical, it is probablly not a bad thing to fix it. This PR adds a scope check to the job scheduling logic before scheduling a job.

It is also still possible to manually schedule a job for a character without appropriate scopes, only the regular bucket updates are affected by this.

The PR also includes a little refactor of the Bus class: Mainly, addAuthentificatedJobs and addPublicJobs are now a implementation detail of each bus implementation instead of a abstract method.