### PR TITLE
Cache Rework Part 1

### DIFF
--- a/src/Config/eveapi.cache.php
+++ b/src/Config/eveapi.cache.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+return [
+    'respect_cache' => env('EVEAPI_RESPECT_CACHE', 'true'),
+];

--- a/src/Config/eveapi.cache.php
+++ b/src/Config/eveapi.cache.php
@@ -21,5 +21,5 @@
  */
 
 return [
-    'respect_cache' => env('EVEAPI_RESPECT_CACHE', true),
+    'respect_cache' => env('EVEAPI_RESPECT_CACHE', false),
 ];

--- a/src/Config/eveapi.cache.php
+++ b/src/Config/eveapi.cache.php
@@ -21,5 +21,5 @@
  */
 
 return [
-    'respect_cache' => env('EVEAPI_RESPECT_CACHE', 'true'),
+    'respect_cache' => env('EVEAPI_RESPECT_CACHE', true),
 ];

--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -71,6 +71,8 @@ class EveapiServiceProvider extends AbstractSeatPlugin
             \Seat\Eveapi\Database\Seeders\ScheduleSeeder::class,
             // \Seat\Eveapi\Database\Seeders\Sde\SdeSeeder::class, -- Disabled until later implemented again in services
         ]);
+
+        $this->mergeConfigFrom(__DIR__ . '/Config/eveapi.cache.php', 'eveapi.cache');
     }
 
     private function addCommands()

--- a/src/Jobs/Alliances/Info.php
+++ b/src/Jobs/Alliances/Info.php
@@ -60,11 +60,13 @@ class Info extends AbstractAllianceJob
             'alliance_id' => $this->alliance_id,
         ]);
 
-        $info = $response->getBody();
-
         $model = Alliance::firstOrNew([
             'alliance_id' => $this->alliance_id,
         ]);
+
+        if ($response->isFromCache() && $model->exists) return; // No need to hit the DB here
+
+        $info = $response->getBody();
 
         InfoMapping::make($model, $info, [
             'alliance_id' => function () {

--- a/src/Jobs/Alliances/Info.php
+++ b/src/Jobs/Alliances/Info.php
@@ -64,7 +64,7 @@ class Info extends AbstractAllianceJob
             'alliance_id' => $this->alliance_id,
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && $model->exists) return; // No need to hit the DB here
+        if ($this->shouldUseCache($response) && $model->exists) return; // No need to hit the DB here
 
         $info = $response->getBody();
 

--- a/src/Jobs/Alliances/Info.php
+++ b/src/Jobs/Alliances/Info.php
@@ -64,7 +64,7 @@ class Info extends AbstractAllianceJob
             'alliance_id' => $this->alliance_id,
         ]);
 
-        if ($response->isFromCache() && $model->exists) return; // No need to hit the DB here
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && $model->exists) return; // No need to hit the DB here
 
         $info = $response->getBody();
 

--- a/src/Jobs/Alliances/Members.php
+++ b/src/Jobs/Alliances/Members.php
@@ -57,6 +57,10 @@ class Members extends AbstractAllianceJob
             'alliance_id' => $this->alliance_id,
         ]);
 
+        if ($response->isFromCache() && 
+            AllianceMember::where('alliance_id', $this->alliance_id)->count() > 0)
+            return;
+
         $corporation_ids = collect($response->getBody());
 
         $corporation_ids->each(function ($corporation_id) {

--- a/src/Jobs/Alliances/Members.php
+++ b/src/Jobs/Alliances/Members.php
@@ -58,7 +58,7 @@ class Members extends AbstractAllianceJob
         ]);
 
         if ($response->isFromCache() && 
-            AllianceMember::where('alliance_id', $this->alliance_id)->count() > 0)
+            AllianceMember::where('alliance_id', $this->alliance_id)->exists())
             return;
 
         $corporation_ids = collect($response->getBody());

--- a/src/Jobs/Alliances/Members.php
+++ b/src/Jobs/Alliances/Members.php
@@ -57,7 +57,7 @@ class Members extends AbstractAllianceJob
             'alliance_id' => $this->alliance_id,
         ]);
 
-        if ($this->shouldUseCache($response) && 
+        if ($this->shouldUseCache($response) &&
             AllianceMember::where('alliance_id', $this->alliance_id)->exists())
             return;
 

--- a/src/Jobs/Alliances/Members.php
+++ b/src/Jobs/Alliances/Members.php
@@ -57,7 +57,7 @@ class Members extends AbstractAllianceJob
             'alliance_id' => $this->alliance_id,
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
             AllianceMember::where('alliance_id', $this->alliance_id)->exists())
             return;
 

--- a/src/Jobs/Alliances/Members.php
+++ b/src/Jobs/Alliances/Members.php
@@ -57,7 +57,7 @@ class Members extends AbstractAllianceJob
             'alliance_id' => $this->alliance_id,
         ]);
 
-        if ($response->isFromCache() && 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && 
             AllianceMember::where('alliance_id', $this->alliance_id)->exists())
             return;
 

--- a/src/Jobs/Alliances/Members.php
+++ b/src/Jobs/Alliances/Members.php
@@ -57,7 +57,7 @@ class Members extends AbstractAllianceJob
             'alliance_id' => $this->alliance_id,
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) && 
             AllianceMember::where('alliance_id', $this->alliance_id)->exists())
             return;
 

--- a/src/Jobs/Assets/Character/Assets.php
+++ b/src/Jobs/Assets/Character/Assets.php
@@ -109,14 +109,26 @@ class Assets extends AbstractAuthCharacterJob
                     $structure_batch->addStructure($asset->location_id);
                 }
 
-                AssetMapping::make($model, $asset, [
+                // The model returned here will be modified based on the esi data.
+                // However Laravel is smart and the isClean() method will only return false
+                // If the esi fields have changed. Simply applying the same data keeps a clean model.
+                $model = AssetMapping::make($model, $asset, [
                     'character_id' => function () {
                         return $this->getCharacterId();
                     },
-                    'updated_at' => function () use ($start) {
-                            return $start;
-                        },
-                ])->save();
+                ]);
+
+                if ($model->exists && $model->isClean()){
+                    // No ESI data updated, just touch the timestamp
+                    $model->updated_at = $start;
+
+                    // There is no point triggering events when nothing has changed
+                    $model->saveQuietly();
+                } else {
+                    // ESI data has changed. So just save the model.
+                    // This will update the timestamp and also trigger events.
+                    $model->save();
+                }
             });
 
             if (! $this->nextPage($response->getPagesCount()))

--- a/src/Jobs/Assets/Corporation/Assets.php
+++ b/src/Jobs/Assets/Corporation/Assets.php
@@ -129,7 +129,7 @@ class Assets extends AbstractAuthCorporationJob
                     if ($model->exists && $model->isClean()){
                         // No ESI data updated, just touch the timestamp
                         $model->updated_at = $start;
-    
+
                         // There is no point triggering events when nothing has changed
                         $model->saveQuietly();
                     } else {
@@ -138,7 +138,6 @@ class Assets extends AbstractAuthCorporationJob
                         $model->save();
                     }
 
-                    
                 });
             });
 

--- a/src/Jobs/Assets/Corporation/Assets.php
+++ b/src/Jobs/Assets/Corporation/Assets.php
@@ -112,19 +112,33 @@ class Assets extends AbstractAuthCorporationJob
                         'item_id' => $asset->item_id,
                     ]);
 
+                    // The model returned here will be modified based on the esi data.
+                    // However Laravel is smart and the isClean() method will only return false
+                    // If the esi fields have changed. Simply applying the same data keeps a clean model.
+                    $model = AssetMapping::make($model, $asset, [
+                        'corporation_id' => function () {
+                            return $this->getCorporationId();
+                        },
+                    ]);
+
                     //make sure that the location is loaded if it is in a station or citadel
                     if (in_array($asset->location_flag, StructureBatch::RESOLVABLE_LOCATION_FLAGS) && in_array($asset->location_type, StructureBatch::RESOLVABLE_LOCATION_TYPES)) {
                         $structure_batch->addStructure($asset->location_id);
                     }
 
-                    AssetMapping::make($model, $asset, [
-                        'corporation_id' => function () {
-                            return $this->getCorporationId();
-                        },
-                        'updated_at' => function () use ($start) {
-                            return $start;
-                        },
-                    ])->save();
+                    if ($model->exists && $model->isClean()){
+                        // No ESI data updated, just touch the timestamp
+                        $model->updated_at = $start;
+    
+                        // There is no point triggering events when nothing has changed
+                        $model->saveQuietly();
+                    } else {
+                        // ESI data has changed. So just save the model.
+                        // This will update the timestamp and also trigger events.
+                        $model->save();
+                    }
+
+                    
                 });
             });
 

--- a/src/Jobs/Calendar/Attendees.php
+++ b/src/Jobs/Calendar/Attendees.php
@@ -92,7 +92,7 @@ class Attendees extends AbstractAuthCharacterJob
                 ]);
 
                 if ($response->isFromCache() &&
-                    CharacterCalendarAttendee::where('event_id', $event->event_id)->count() > 0)
+                    CharacterCalendarAttendee::where('event_id', $event->event_id)->exists())
                     return true; // Return true to move onto the next event
 
                 $attendees = collect($response->getBody());

--- a/src/Jobs/Calendar/Attendees.php
+++ b/src/Jobs/Calendar/Attendees.php
@@ -91,6 +91,10 @@ class Attendees extends AbstractAuthCharacterJob
                     'event_id' => $event->event_id,
                 ]);
 
+                if ($response->isFromCache() &&
+                    CharacterCalendarAttendee::where('event_id', $event->event_id)->count() > 0)
+                    return true; // Return true to move onto the next event
+
                 $attendees = collect($response->getBody());
 
                 $attendees->each(function ($attendee) use ($event) {

--- a/src/Jobs/Calendar/Attendees.php
+++ b/src/Jobs/Calendar/Attendees.php
@@ -91,8 +91,7 @@ class Attendees extends AbstractAuthCharacterJob
                     'event_id' => $event->event_id,
                 ]);
 
-                if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
-                    CharacterCalendarAttendee::where('event_id', $event->event_id)->exists())
+                if ($this->shouldUseCache($response) && CharacterCalendarAttendee::where('event_id', $event->event_id)->exists())
                     return true; // Return true to move onto the next event
 
                 $attendees = collect($response->getBody());

--- a/src/Jobs/Calendar/Attendees.php
+++ b/src/Jobs/Calendar/Attendees.php
@@ -91,7 +91,7 @@ class Attendees extends AbstractAuthCharacterJob
                     'event_id' => $event->event_id,
                 ]);
 
-                if ($response->isFromCache() &&
+                if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
                     CharacterCalendarAttendee::where('event_id', $event->event_id)->exists())
                     return true; // Return true to move onto the next event
 

--- a/src/Jobs/Calendar/Detail.php
+++ b/src/Jobs/Calendar/Detail.php
@@ -91,7 +91,7 @@ class Detail extends AbstractAuthCharacterJob
                     'event_id' => $event_id,
                 ]);
 
-                if (config('eveapi.cache.respect_cache') && $response->isFromCache() && $model->exists) return true; // Move onto the next detail if this is cached
+                if ($this->shouldUseCache($response) && $model->exists) return true; // Move onto the next detail if this is cached
 
                 $detail = $response->getBody();
 

--- a/src/Jobs/Calendar/Detail.php
+++ b/src/Jobs/Calendar/Detail.php
@@ -87,11 +87,13 @@ class Detail extends AbstractAuthCharacterJob
                     'event_id' => $event_id,
                 ]);
 
-                $detail = $response->getBody();
-
                 $model = CharacterCalendarEventDetail::firstOrNew([
                     'event_id' => $event_id,
                 ]);
+
+                if ($response->isFromCache() && $model->exists) return true; // Move onto the next detail if this is cached
+
+                $detail = $response->getBody();
 
                 CalendarDetailMapping::make($model, $detail, [
                     'event_id' => function () use ($event_id) {

--- a/src/Jobs/Calendar/Detail.php
+++ b/src/Jobs/Calendar/Detail.php
@@ -91,7 +91,7 @@ class Detail extends AbstractAuthCharacterJob
                     'event_id' => $event_id,
                 ]);
 
-                if ($response->isFromCache() && $model->exists) return true; // Move onto the next detail if this is cached
+                if (config('eveapi.cache.respect_cache') && $response->isFromCache() && $model->exists) return true; // Move onto the next detail if this is cached
 
                 $detail = $response->getBody();
 

--- a/src/Jobs/Calendar/Events.php
+++ b/src/Jobs/Calendar/Events.php
@@ -22,7 +22,6 @@
 
 namespace Seat\Eveapi\Jobs\Calendar;
 
-use Seat\Eveapi\Bus\Character;
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
 use Seat\Eveapi\Mapping\Characters\CalendarEventMapping;
 use Seat\Eveapi\Models\Calendar\CharacterCalendarEvent;

--- a/src/Jobs/Calendar/Events.php
+++ b/src/Jobs/Calendar/Events.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\Calendar;
 
+use Seat\Eveapi\Bus\Character;
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
 use Seat\Eveapi\Mapping\Characters\CalendarEventMapping;
 use Seat\Eveapi\Models\Calendar\CharacterCalendarEvent;
@@ -85,6 +86,9 @@ class Events extends AbstractAuthCharacterJob
             $response = $this->retrieve([
                 'character_id' => $this->getCharacterId(),
             ]);
+
+            if ($this->shouldUseCache($response) && CharacterCalendarEvent::where('character_id', $this->getCharacterId())->exists())
+                return;
 
             $events = collect($response->getBody());
 

--- a/src/Jobs/Character/AgentsResearch.php
+++ b/src/Jobs/Character/AgentsResearch.php
@@ -74,6 +74,10 @@ class AgentsResearch extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
+        if ($response->isFromCache() && 
+            CharacterAgentResearch::where('character_id', $this->getCharacterId()->count() > 0))
+            return;
+
         $agents = collect($response->getBody());
 
         $agents->each(function ($agent) {

--- a/src/Jobs/Character/AgentsResearch.php
+++ b/src/Jobs/Character/AgentsResearch.php
@@ -74,7 +74,7 @@ class AgentsResearch extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($response->isFromCache() && 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && 
             CharacterAgentResearch::where('character_id', $this->getCharacterId()->exists()))
             return;
 

--- a/src/Jobs/Character/AgentsResearch.php
+++ b/src/Jobs/Character/AgentsResearch.php
@@ -74,7 +74,7 @@ class AgentsResearch extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CharacterAgentResearch::where('character_id', $this->getCharacterId()->exists()))
             return;
 

--- a/src/Jobs/Character/AgentsResearch.php
+++ b/src/Jobs/Character/AgentsResearch.php
@@ -74,7 +74,7 @@ class AgentsResearch extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
             CharacterAgentResearch::where('character_id', $this->getCharacterId()->exists()))
             return;
 

--- a/src/Jobs/Character/AgentsResearch.php
+++ b/src/Jobs/Character/AgentsResearch.php
@@ -75,7 +75,7 @@ class AgentsResearch extends AbstractAuthCharacterJob
         ]);
 
         if ($response->isFromCache() && 
-            CharacterAgentResearch::where('character_id', $this->getCharacterId()->count() > 0))
+            CharacterAgentResearch::where('character_id', $this->getCharacterId()->exists()))
             return;
 
         $agents = collect($response->getBody());

--- a/src/Jobs/Character/Blueprints.php
+++ b/src/Jobs/Character/Blueprints.php
@@ -122,6 +122,9 @@ class Blueprints extends AbstractAuthCharacterJob
                         'item_id' => $blueprint->item_id,
                     ]);
 
+                    // Exit early in the case that the model exists.
+                    if ($model->exists) return;
+
                     BlueprintMapping::make($model, $blueprint, [
                         'character_id' => function () {
                             return $this->getCharacterId();

--- a/src/Jobs/Character/CorporationHistory.php
+++ b/src/Jobs/Character/CorporationHistory.php
@@ -62,7 +62,7 @@ class CorporationHistory extends AbstractCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CharacterCorporationHistory::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/Character/CorporationHistory.php
+++ b/src/Jobs/Character/CorporationHistory.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\Character;
 
+use Seat\Eveapi\Bus\Character;
 use Seat\Eveapi\Jobs\AbstractCharacterJob;
 use Seat\Eveapi\Models\Character\CharacterCorporationHistory;
 
@@ -61,6 +62,10 @@ class CorporationHistory extends AbstractCharacterJob
         $response = $this->retrieve([
             'character_id' => $this->getCharacterId(),
         ]);
+
+        if ($response->isFromCache() &&
+            CharacterCorporationHistory::where('character_id', $this->getCharacterId())->count()>0)
+            return;
 
         $corporations = collect($response->getBody());
 

--- a/src/Jobs/Character/CorporationHistory.php
+++ b/src/Jobs/Character/CorporationHistory.php
@@ -63,8 +63,8 @@ class CorporationHistory extends AbstractCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($response->isFromCache() &&
-            CharacterCorporationHistory::where('character_id', $this->getCharacterId())->count()>0)
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+            CharacterCorporationHistory::where('character_id', $this->getCharacterId())->exists())
             return;
 
         $corporations = collect($response->getBody());

--- a/src/Jobs/Character/CorporationHistory.php
+++ b/src/Jobs/Character/CorporationHistory.php
@@ -22,7 +22,6 @@
 
 namespace Seat\Eveapi\Jobs\Character;
 
-use Seat\Eveapi\Bus\Character;
 use Seat\Eveapi\Jobs\AbstractCharacterJob;
 use Seat\Eveapi\Models\Character\CharacterCorporationHistory;
 

--- a/src/Jobs/Character/Fatigue.php
+++ b/src/Jobs/Character/Fatigue.php
@@ -76,10 +76,10 @@ class Fatigue extends AbstractAuthCharacterJob
         $model = CharacterFatigue::firstOrNew([
             'character_id' => $this->getCharacterId(),
         ]);
-        
+
         if (config('eveapi.cache.respect_cache') && $response->isFromCache() && $model->exists) return;
 
-        $fatigue = $response->getBody();        
+        $fatigue = $response->getBody();
 
         $model->fill([
             'last_jump_date' => property_exists($fatigue, 'last_jump_date') ?

--- a/src/Jobs/Character/Fatigue.php
+++ b/src/Jobs/Character/Fatigue.php
@@ -77,7 +77,7 @@ class Fatigue extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && $model->exists) return;
+        if ($this->shouldUseCache($response) && $model->exists) return;
 
         $fatigue = $response->getBody();
 

--- a/src/Jobs/Character/Fatigue.php
+++ b/src/Jobs/Character/Fatigue.php
@@ -73,11 +73,15 @@ class Fatigue extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        $fatigue = $response->getBody();
-
-        CharacterFatigue::firstOrNew([
+        $model = CharacterFatigue::firstOrNew([
             'character_id' => $this->getCharacterId(),
-        ])->fill([
+        ]);
+        
+        if ($response->isFromCache() && $model->exists) return;
+
+        $fatigue = $response->getBody();        
+
+        $model->fill([
             'last_jump_date' => property_exists($fatigue, 'last_jump_date') ?
                 carbon($fatigue->last_jump_date) : null,
             'jump_fatigue_expire_date' => property_exists($fatigue, 'jump_fatigue_expire_date') ?

--- a/src/Jobs/Character/Fatigue.php
+++ b/src/Jobs/Character/Fatigue.php
@@ -77,7 +77,7 @@ class Fatigue extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
         
-        if ($response->isFromCache() && $model->exists) return;
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && $model->exists) return;
 
         $fatigue = $response->getBody();        
 

--- a/src/Jobs/Character/Info.php
+++ b/src/Jobs/Character/Info.php
@@ -73,7 +73,7 @@ class Info extends AbstractCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($response->isFromCache() && $model->exists) return;
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && $model->exists) return;
 
         $info = $response->getBody();
 

--- a/src/Jobs/Character/Info.php
+++ b/src/Jobs/Character/Info.php
@@ -73,7 +73,7 @@ class Info extends AbstractCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && $model->exists) return;
+        if ($this->shouldUseCache($response) && $model->exists) return;
 
         $info = $response->getBody();
 

--- a/src/Jobs/Character/Info.php
+++ b/src/Jobs/Character/Info.php
@@ -69,11 +69,13 @@ class Info extends AbstractCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        $info = $response->getBody();
-
         $model = CharacterInfo::firstOrNew([
             'character_id' => $this->getCharacterId(),
         ]);
+
+        if ($response->isFromCache() && $model->exists) return;
+
+        $info = $response->getBody();
 
         InfoMapping::make($model, $info, [
             'character_id' => function () {

--- a/src/Jobs/Character/LoyaltyPoints.php
+++ b/src/Jobs/Character/LoyaltyPoints.php
@@ -25,6 +25,7 @@ namespace Seat\Eveapi\Jobs\Character;
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
 use Seat\Eveapi\Jobs\Corporation\Info as CorporationInfoJob;
 use Seat\Eveapi\Models\Character\CharacterInfo;
+use Seat\Eveapi\Models\Character\CharacterLoyaltyPoints;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
 
 /**
@@ -84,7 +85,7 @@ class LoyaltyPoints extends AbstractAuthCharacterJob
             'character_id' => $character_id,
         ]);
 
-        // TODO: if cached and exists move on
+        if ($response->isFromCache() && CharacterLoyaltyPoints::where('character_id', $character_id)->exists()) return;
 
         //get the lp data as collection
         $loyalty_points = collect($response->getBody());

--- a/src/Jobs/Character/LoyaltyPoints.php
+++ b/src/Jobs/Character/LoyaltyPoints.php
@@ -86,7 +86,7 @@ class LoyaltyPoints extends AbstractAuthCharacterJob
             'character_id' => $character_id,
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && CharacterLoyaltyPoints::where('character_id', $character_id)->exists()) return;
+        if ($this->shouldUseCache($response) && CharacterLoyaltyPoints::where('character_id', $character_id)->exists()) return;
 
         //get the lp data as collection
         $loyalty_points = collect($response->getBody());

--- a/src/Jobs/Character/LoyaltyPoints.php
+++ b/src/Jobs/Character/LoyaltyPoints.php
@@ -85,7 +85,7 @@ class LoyaltyPoints extends AbstractAuthCharacterJob
             'character_id' => $character_id,
         ]);
 
-        if ($response->isFromCache() && CharacterLoyaltyPoints::where('character_id', $character_id)->exists()) return;
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && CharacterLoyaltyPoints::where('character_id', $character_id)->exists()) return;
 
         //get the lp data as collection
         $loyalty_points = collect($response->getBody());

--- a/src/Jobs/Character/LoyaltyPoints.php
+++ b/src/Jobs/Character/LoyaltyPoints.php
@@ -76,7 +76,6 @@ class LoyaltyPoints extends AbstractAuthCharacterJob
         //if the character doesn't exist, stop here
         if (is_null($character)){
             $this->fail();
-
             return;
         }
 
@@ -84,6 +83,8 @@ class LoyaltyPoints extends AbstractAuthCharacterJob
         $response = $this->retrieve([
             'character_id' => $character_id,
         ]);
+
+        // TODO: if cached and exists move on
 
         //get the lp data as collection
         $loyalty_points = collect($response->getBody());

--- a/src/Jobs/Character/LoyaltyPoints.php
+++ b/src/Jobs/Character/LoyaltyPoints.php
@@ -77,6 +77,7 @@ class LoyaltyPoints extends AbstractAuthCharacterJob
         //if the character doesn't exist, stop here
         if (is_null($character)){
             $this->fail();
+
             return;
         }
 

--- a/src/Jobs/Character/Medals.php
+++ b/src/Jobs/Character/Medals.php
@@ -76,7 +76,7 @@ class Medals extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($response->isFromCache() && 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && 
             CharacterMedal::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/Character/Medals.php
+++ b/src/Jobs/Character/Medals.php
@@ -74,7 +74,7 @@ class Medals extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CharacterMedal::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/Character/Medals.php
+++ b/src/Jobs/Character/Medals.php
@@ -22,9 +22,11 @@
 
 namespace Seat\Eveapi\Jobs\Character;
 
+use Seat\Eveapi\Bus\Character;
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
 use Seat\Eveapi\Mapping\Characters\MedalsMapping;
 use Seat\Eveapi\Models\Character\CharacterMedal;
+use Seat\Web\Http\Composers\CharacterMenu;
 
 /**
  * Class Medals.
@@ -73,6 +75,10 @@ class Medals extends AbstractAuthCharacterJob
         $response = $this->retrieve([
             'character_id' => $this->getCharacterId(),
         ]);
+
+        if ($response->isFromCache() && 
+            CharacterMedal::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         $medals = collect($response->getBody());
 

--- a/src/Jobs/Character/Medals.php
+++ b/src/Jobs/Character/Medals.php
@@ -77,7 +77,7 @@ class Medals extends AbstractAuthCharacterJob
         ]);
 
         if ($response->isFromCache() && 
-            CharacterMedal::where('character_id', $this->getCharacterId())->count() > 0)
+            CharacterMedal::where('character_id', $this->getCharacterId())->exists())
             return;
 
         $medals = collect($response->getBody());

--- a/src/Jobs/Character/Medals.php
+++ b/src/Jobs/Character/Medals.php
@@ -22,11 +22,9 @@
 
 namespace Seat\Eveapi\Jobs\Character;
 
-use Seat\Eveapi\Bus\Character;
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
 use Seat\Eveapi\Mapping\Characters\MedalsMapping;
 use Seat\Eveapi\Models\Character\CharacterMedal;
-use Seat\Web\Http\Composers\CharacterMenu;
 
 /**
  * Class Medals.
@@ -76,7 +74,7 @@ class Medals extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
             CharacterMedal::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/Character/Notifications.php
+++ b/src/Jobs/Character/Notifications.php
@@ -22,7 +22,6 @@
 
 namespace Seat\Eveapi\Jobs\Character;
 
-use Seat\Eveapi\Bus\Character;
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
 use Seat\Eveapi\Mapping\Characters\NotificationMapping;
 use Seat\Eveapi\Models\Character\CharacterNotification;
@@ -76,7 +75,7 @@ class Notifications extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
             CharacterNotification::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/Character/Notifications.php
+++ b/src/Jobs/Character/Notifications.php
@@ -76,7 +76,7 @@ class Notifications extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($response->isFromCache() && 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && 
             CharacterNotification::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/Character/Notifications.php
+++ b/src/Jobs/Character/Notifications.php
@@ -75,7 +75,7 @@ class Notifications extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CharacterNotification::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/Character/Notifications.php
+++ b/src/Jobs/Character/Notifications.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Eveapi\Jobs\Character;
 
+use Seat\Eveapi\Bus\Character;
 use Seat\Eveapi\Jobs\AbstractAuthCharacterJob;
 use Seat\Eveapi\Mapping\Characters\NotificationMapping;
 use Seat\Eveapi\Models\Character\CharacterNotification;
@@ -74,6 +75,10 @@ class Notifications extends AbstractAuthCharacterJob
         $response = $this->retrieve([
             'character_id' => $this->getCharacterId(),
         ]);
+
+        if ($response->isFromCache() && 
+            CharacterNotification::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
 
         $notifications = collect($response->getBody());
 

--- a/src/Jobs/Character/Notifications.php
+++ b/src/Jobs/Character/Notifications.php
@@ -77,7 +77,7 @@ class Notifications extends AbstractAuthCharacterJob
         ]);
 
         if ($response->isFromCache() && 
-            CharacterNotification::where('character_id', $this->getCharacterId())->count() > 0)
+            CharacterNotification::where('character_id', $this->getCharacterId())->exists())
             return;
 
         $notifications = collect($response->getBody());

--- a/src/Jobs/Character/Roles.php
+++ b/src/Jobs/Character/Roles.php
@@ -73,7 +73,8 @@ class Roles extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        // Not checking if cached here as impact is low and I would rather always update roles.
+        if ($this->shouldUseCache($response) && CharacterRole::where('character_id', $this->getCharacterId())->exists())
+            return;
 
         $roles = $response->getBody();
 

--- a/src/Jobs/Character/Roles.php
+++ b/src/Jobs/Character/Roles.php
@@ -73,6 +73,8 @@ class Roles extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
+        // Not checking if cached here as impact is low and I would rather always update roles.
+
         $roles = $response->getBody();
 
         foreach (['roles', 'roles_at_hq', 'roles_at_base', 'roles_at_other'] as $scope) {

--- a/src/Jobs/Character/Standings.php
+++ b/src/Jobs/Character/Standings.php
@@ -73,6 +73,10 @@ class Standings extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
+        if ($response->isFromCache() && 
+            CharacterStanding::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
+
         $standings = collect($response->getBody());
 
         $standings->each(function ($standing) {

--- a/src/Jobs/Character/Standings.php
+++ b/src/Jobs/Character/Standings.php
@@ -73,7 +73,7 @@ class Standings extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($response->isFromCache() && 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && 
             CharacterStanding::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/Character/Standings.php
+++ b/src/Jobs/Character/Standings.php
@@ -74,7 +74,7 @@ class Standings extends AbstractAuthCharacterJob
         ]);
 
         if ($response->isFromCache() && 
-            CharacterStanding::where('character_id', $this->getCharacterId())->count() > 0)
+            CharacterStanding::where('character_id', $this->getCharacterId())->exists())
             return;
 
         $standings = collect($response->getBody());

--- a/src/Jobs/Character/Standings.php
+++ b/src/Jobs/Character/Standings.php
@@ -73,7 +73,7 @@ class Standings extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CharacterStanding::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/Character/Standings.php
+++ b/src/Jobs/Character/Standings.php
@@ -73,7 +73,7 @@ class Standings extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
             CharacterStanding::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/Clones/Clones.php
+++ b/src/Jobs/Clones/Clones.php
@@ -77,7 +77,7 @@ class Clones extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($response->isFromCache() && 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && 
             CharacterClone::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/Clones/Clones.php
+++ b/src/Jobs/Clones/Clones.php
@@ -78,7 +78,7 @@ class Clones extends AbstractAuthCharacterJob
         ]);
 
         if ($response->isFromCache() && 
-            CharacterClone::where('character_id', $this->getCharacterId())->count() > 0)
+            CharacterClone::where('character_id', $this->getCharacterId())->exists())
             return;
 
 

--- a/src/Jobs/Clones/Clones.php
+++ b/src/Jobs/Clones/Clones.php
@@ -77,10 +77,9 @@ class Clones extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
             CharacterClone::where('character_id', $this->getCharacterId())->exists())
             return;
-
 
         $clone_informations = $response->getBody();
 

--- a/src/Jobs/Clones/Clones.php
+++ b/src/Jobs/Clones/Clones.php
@@ -77,6 +77,11 @@ class Clones extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
+        if ($response->isFromCache() && 
+            CharacterClone::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
+
+
         $clone_informations = $response->getBody();
 
         // Populate current clone information

--- a/src/Jobs/Clones/Clones.php
+++ b/src/Jobs/Clones/Clones.php
@@ -77,7 +77,7 @@ class Clones extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CharacterClone::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/Clones/Implants.php
+++ b/src/Jobs/Clones/Implants.php
@@ -74,7 +74,7 @@ class Implants extends AbstractAuthCharacterJob
         ]);
 
         if ($response->isFromCache() && 
-            CharacterImplant::where('character_id', $this->getCharacterId())->count() > 0)
+            CharacterImplant::where('character_id', $this->getCharacterId())->exists())
             return;
 
         $implants = $response->getBody();

--- a/src/Jobs/Clones/Implants.php
+++ b/src/Jobs/Clones/Implants.php
@@ -73,7 +73,7 @@ class Implants extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
             CharacterImplant::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/Clones/Implants.php
+++ b/src/Jobs/Clones/Implants.php
@@ -73,7 +73,7 @@ class Implants extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CharacterImplant::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/Clones/Implants.php
+++ b/src/Jobs/Clones/Implants.php
@@ -73,7 +73,7 @@ class Implants extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($response->isFromCache() && 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() && 
             CharacterImplant::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/Clones/Implants.php
+++ b/src/Jobs/Clones/Implants.php
@@ -73,6 +73,10 @@ class Implants extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
+        if ($response->isFromCache() && 
+            CharacterImplant::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
+
         $implants = $response->getBody();
 
         collect($implants)->each(function ($implant) {

--- a/src/Jobs/Contacts/Alliance/Contacts.php
+++ b/src/Jobs/Contacts/Alliance/Contacts.php
@@ -101,7 +101,8 @@ class Contacts extends AbstractAuthAllianceJob
             $this->known_contact_ids->push(collect($contacts)
                 ->pluck('contact_id')->flatten()->all());
 
-            if ($response->isFromCache() &&
+            // This wont save network calls, but should save DB writes
+            if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
                 AllianceContact::where('alliance_id', $this->getAllianceId())->exists())
                 continue; // This page has no changes so move onto the next page
 

--- a/src/Jobs/Contacts/Alliance/Contacts.php
+++ b/src/Jobs/Contacts/Alliance/Contacts.php
@@ -90,7 +90,7 @@ class Contacts extends AbstractAuthAllianceJob
      */
     public function handle()
     {
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'alliance_id' => $this->getAllianceId(),
@@ -102,7 +102,7 @@ class Contacts extends AbstractAuthAllianceJob
                 ->pluck('contact_id')->flatten()->all());
 
             // This wont save network calls, but should save DB writes
-            if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+            if ($this->shouldUseCache($response) &&
                 AllianceContact::where('alliance_id', $this->getAllianceId())->exists())
                 continue; // This page has no changes so move onto the next page
 
@@ -118,9 +118,7 @@ class Contacts extends AbstractAuthAllianceJob
                 ])->save();
             });
 
-            if (! $this->nextPage($response->getPagesCount()))
-                break;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
 
         // Cleanup old contacts
         AllianceContact::where('alliance_id', $this->getAllianceId())

--- a/src/Jobs/Contacts/Alliance/Contacts.php
+++ b/src/Jobs/Contacts/Alliance/Contacts.php
@@ -102,7 +102,7 @@ class Contacts extends AbstractAuthAllianceJob
                 ->pluck('contact_id')->flatten()->all());
 
             if ($response->isFromCache() &&
-                AllianceContact::where('alliance_id', $this->getAllianceId())->count() > 0)
+                AllianceContact::where('alliance_id', $this->getAllianceId())->exists())
                 continue; // This page has no changes so move onto the next page
 
             collect($contacts)->each(function ($contact) {

--- a/src/Jobs/Contacts/Alliance/Contacts.php
+++ b/src/Jobs/Contacts/Alliance/Contacts.php
@@ -97,6 +97,13 @@ class Contacts extends AbstractAuthAllianceJob
             ]);
 
             $contacts = $response->getBody();
+            
+            $this->known_contact_ids->push(collect($contacts)
+                ->pluck('contact_id')->flatten()->all());
+
+            if ($response->isFromCache() &&
+                AllianceContact::where('alliance_id', $this->getAllianceId())->count() > 0)
+                continue; // This page has no changes so move onto the next page
 
             collect($contacts)->each(function ($contact) {
 
@@ -109,9 +116,6 @@ class Contacts extends AbstractAuthAllianceJob
                     'label_ids' => $contact->label_ids ?? null,
                 ])->save();
             });
-
-            $this->known_contact_ids->push(collect($contacts)
-                ->pluck('contact_id')->flatten()->all());
 
             if (! $this->nextPage($response->getPagesCount()))
                 break;

--- a/src/Jobs/Contacts/Alliance/Contacts.php
+++ b/src/Jobs/Contacts/Alliance/Contacts.php
@@ -97,7 +97,7 @@ class Contacts extends AbstractAuthAllianceJob
             ]);
 
             $contacts = $response->getBody();
-            
+
             $this->known_contact_ids->push(collect($contacts)
                 ->pluck('contact_id')->flatten()->all());
 

--- a/src/Jobs/Contacts/Alliance/Labels.php
+++ b/src/Jobs/Contacts/Alliance/Labels.php
@@ -70,7 +70,7 @@ class Labels extends AbstractAuthAllianceJob
             'alliance_id' => $this->getAllianceId(),
         ]);
 
-        if ($this->shouldUseCache($response)  &&
+        if ($this->shouldUseCache($response) &&
             AllianceLabel::where('alliance_id', $this->getAllianceId())->exists())
             return;
 

--- a/src/Jobs/Contacts/Alliance/Labels.php
+++ b/src/Jobs/Contacts/Alliance/Labels.php
@@ -71,7 +71,7 @@ class Labels extends AbstractAuthAllianceJob
         ]);
 
         if ($response->isFromCache() &&
-            AllianceLabel::where('alliance_id', $this->getAllianceId())->count() > 0)
+            AllianceLabel::where('alliance_id', $this->getAllianceId())->exists())
             return;
 
         $labels = $response->getBody();

--- a/src/Jobs/Contacts/Alliance/Labels.php
+++ b/src/Jobs/Contacts/Alliance/Labels.php
@@ -70,6 +70,10 @@ class Labels extends AbstractAuthAllianceJob
             'alliance_id' => $this->getAllianceId(),
         ]);
 
+        if ($response->isFromCache() &&
+            AllianceLabel::where('alliance_id', $this->getAllianceId())->count() > 0)
+            return;
+
         $labels = $response->getBody();
 
         collect($labels)->each(function ($label) {

--- a/src/Jobs/Contacts/Alliance/Labels.php
+++ b/src/Jobs/Contacts/Alliance/Labels.php
@@ -70,7 +70,7 @@ class Labels extends AbstractAuthAllianceJob
             'alliance_id' => $this->getAllianceId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response)  &&
             AllianceLabel::where('alliance_id', $this->getAllianceId())->exists())
             return;
 

--- a/src/Jobs/Contacts/Alliance/Labels.php
+++ b/src/Jobs/Contacts/Alliance/Labels.php
@@ -70,7 +70,7 @@ class Labels extends AbstractAuthAllianceJob
             'alliance_id' => $this->getAllianceId(),
         ]);
 
-        if ($response->isFromCache() &&
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
             AllianceLabel::where('alliance_id', $this->getAllianceId())->exists())
             return;
 

--- a/src/Jobs/Contacts/Character/Contacts.php
+++ b/src/Jobs/Contacts/Character/Contacts.php
@@ -105,7 +105,7 @@ class Contacts extends AbstractAuthCharacterJob
                 ->pluck('contact_id')->flatten()->all());
 
             // This wont save network but should save DB writes
-            if ($this->shouldUseCache($response)  &&
+            if ($this->shouldUseCache($response) &&
                 CharacterContact::where('character_id', $this->getCharacterId())->exists())
                 continue;
 

--- a/src/Jobs/Contacts/Character/Contacts.php
+++ b/src/Jobs/Contacts/Character/Contacts.php
@@ -93,7 +93,7 @@ class Contacts extends AbstractAuthCharacterJob
     {
         parent::handle();
 
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'character_id' => $this->getCharacterId(),
@@ -105,7 +105,7 @@ class Contacts extends AbstractAuthCharacterJob
                 ->pluck('contact_id')->flatten()->all());
 
             // This wont save network but should save DB writes
-            if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+            if ($this->shouldUseCache($response)  &&
                 CharacterContact::where('character_id', $this->getCharacterId())->exists())
                 continue;
 
@@ -123,9 +123,7 @@ class Contacts extends AbstractAuthCharacterJob
                 ])->save();
             });
 
-            if (! $this->nextPage($response->getPagesCount()))
-                break;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
 
         // Cleanup old contacts
         CharacterContact::where('character_id', $this->getCharacterId())

--- a/src/Jobs/Contacts/Character/Contacts.php
+++ b/src/Jobs/Contacts/Character/Contacts.php
@@ -104,7 +104,8 @@ class Contacts extends AbstractAuthCharacterJob
             $this->known_contact_ids->push(collect($contacts)
                 ->pluck('contact_id')->flatten()->all());
 
-            if ($response->isFromCache() &&
+            // This wont save network but should save DB writes
+            if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
                 CharacterContact::where('character_id', $this->getCharacterId())->exists())
                 continue;
             

--- a/src/Jobs/Contacts/Character/Contacts.php
+++ b/src/Jobs/Contacts/Character/Contacts.php
@@ -105,7 +105,7 @@ class Contacts extends AbstractAuthCharacterJob
                 ->pluck('contact_id')->flatten()->all());
 
             if ($response->isFromCache() &&
-                CharacterContact::where('character_id', $this->getCharacterId())->count() > 0)
+                CharacterContact::where('character_id', $this->getCharacterId())->exists())
                 continue;
             
             collect($contacts)->each(function ($contact) {

--- a/src/Jobs/Contacts/Character/Contacts.php
+++ b/src/Jobs/Contacts/Character/Contacts.php
@@ -108,7 +108,7 @@ class Contacts extends AbstractAuthCharacterJob
             if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
                 CharacterContact::where('character_id', $this->getCharacterId())->exists())
                 continue;
-            
+
             collect($contacts)->each(function ($contact) {
 
                 CharacterContact::firstOrNew([
@@ -122,8 +122,6 @@ class Contacts extends AbstractAuthCharacterJob
                     'label_ids' => $contact->label_ids ?? null,
                 ])->save();
             });
-
-
 
             if (! $this->nextPage($response->getPagesCount()))
                 break;

--- a/src/Jobs/Contacts/Character/Contacts.php
+++ b/src/Jobs/Contacts/Character/Contacts.php
@@ -101,6 +101,13 @@ class Contacts extends AbstractAuthCharacterJob
 
             $contacts = $response->getBody();
 
+            $this->known_contact_ids->push(collect($contacts)
+                ->pluck('contact_id')->flatten()->all());
+
+            if ($response->isFromCache() &&
+                CharacterContact::where('character_id', $this->getCharacterId())->count() > 0)
+                continue;
+            
             collect($contacts)->each(function ($contact) {
 
                 CharacterContact::firstOrNew([
@@ -115,8 +122,7 @@ class Contacts extends AbstractAuthCharacterJob
                 ])->save();
             });
 
-            $this->known_contact_ids->push(collect($contacts)
-                ->pluck('contact_id')->flatten()->all());
+
 
             if (! $this->nextPage($response->getPagesCount()))
                 break;

--- a/src/Jobs/Contacts/Character/Labels.php
+++ b/src/Jobs/Contacts/Character/Labels.php
@@ -74,7 +74,7 @@ class Labels extends AbstractAuthCharacterJob
         ]);
 
         if ($response->isFromCache() &&
-            CharacterLabel::where('character_id', $this->getCharacterId())->count() > 0)
+            CharacterLabel::where('character_id', $this->getCharacterId())->exists())
             return;
 
         $labels = $response->getBody();

--- a/src/Jobs/Contacts/Character/Labels.php
+++ b/src/Jobs/Contacts/Character/Labels.php
@@ -73,7 +73,7 @@ class Labels extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if ($response->isFromCache() &&
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
             CharacterLabel::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/Contacts/Character/Labels.php
+++ b/src/Jobs/Contacts/Character/Labels.php
@@ -73,6 +73,10 @@ class Labels extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
+        if ($response->isFromCache() &&
+            CharacterLabel::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
+
         $labels = $response->getBody();
 
         collect($labels)->each(function ($label) {

--- a/src/Jobs/Contacts/Character/Labels.php
+++ b/src/Jobs/Contacts/Character/Labels.php
@@ -73,7 +73,7 @@ class Labels extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CharacterLabel::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/Contacts/Corporation/Contacts.php
+++ b/src/Jobs/Contacts/Corporation/Contacts.php
@@ -100,6 +100,13 @@ class Contacts extends AbstractAuthCorporationJob
 
             $contacts = $response->getBody();
 
+            $this->known_contact_ids->push(collect($contacts)
+                ->pluck('contact_id')->flatten()->all());
+            
+            if ($response->isFromCache() &&
+                CharacterContact::where('character_id', $this->getCharacterId())->count() > 0)
+                continue;
+
             collect($contacts)->each(function ($contact) {
 
                 CorporationContact::firstOrNew([
@@ -113,8 +120,7 @@ class Contacts extends AbstractAuthCorporationJob
                 ])->save();
             });
 
-            $this->known_contact_ids->push(collect($contacts)
-                ->pluck('contact_id')->flatten()->all());
+
 
             if (! $this->nextPage($response->getPagesCount()))
                 break;

--- a/src/Jobs/Contacts/Corporation/Contacts.php
+++ b/src/Jobs/Contacts/Corporation/Contacts.php
@@ -103,8 +103,9 @@ class Contacts extends AbstractAuthCorporationJob
             $this->known_contact_ids->push(collect($contacts)
                 ->pluck('contact_id')->flatten()->all());
             
-            if ($response->isFromCache() &&
-                CharacterContact::where('character_id', $this->getCharacterId())->exists())
+                // In this case, the cache guard here  will not save network ops, but should save the DB
+            if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+                CorporationContact::where('corporation_id', $this->getCorporationId())->exists())
                 continue;
 
             collect($contacts)->each(function ($contact) {

--- a/src/Jobs/Contacts/Corporation/Contacts.php
+++ b/src/Jobs/Contacts/Corporation/Contacts.php
@@ -104,7 +104,7 @@ class Contacts extends AbstractAuthCorporationJob
                 ->pluck('contact_id')->flatten()->all());
             
             if ($response->isFromCache() &&
-                CharacterContact::where('character_id', $this->getCharacterId())->count() > 0)
+                CharacterContact::where('character_id', $this->getCharacterId())->exists())
                 continue;
 
             collect($contacts)->each(function ($contact) {

--- a/src/Jobs/Contacts/Corporation/Contacts.php
+++ b/src/Jobs/Contacts/Corporation/Contacts.php
@@ -92,7 +92,7 @@ class Contacts extends AbstractAuthCorporationJob
     {
         parent::handle();
 
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
@@ -104,7 +104,7 @@ class Contacts extends AbstractAuthCorporationJob
                 ->pluck('contact_id')->flatten()->all());
 
                 // In this case, the cache guard here  will not save network ops, but should save the DB
-            if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+            if ($this->shouldUseCache($response) &&
                 CorporationContact::where('corporation_id', $this->getCorporationId())->exists())
                 continue;
 
@@ -121,9 +121,7 @@ class Contacts extends AbstractAuthCorporationJob
                 ])->save();
             });
 
-            if (! $this->nextPage($response->getPagesCount()))
-                break;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
 
         // Cleanup old contacts
         CorporationContact::where('corporation_id', $this->getCorporationId())

--- a/src/Jobs/Contacts/Corporation/Contacts.php
+++ b/src/Jobs/Contacts/Corporation/Contacts.php
@@ -102,7 +102,7 @@ class Contacts extends AbstractAuthCorporationJob
 
             $this->known_contact_ids->push(collect($contacts)
                 ->pluck('contact_id')->flatten()->all());
-            
+
                 // In this case, the cache guard here  will not save network ops, but should save the DB
             if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
                 CorporationContact::where('corporation_id', $this->getCorporationId())->exists())
@@ -120,8 +120,6 @@ class Contacts extends AbstractAuthCorporationJob
                     'label_ids' => $contact->label_ids ?? null,
                 ])->save();
             });
-
-
 
             if (! $this->nextPage($response->getPagesCount()))
                 break;

--- a/src/Jobs/Contacts/Corporation/Labels.php
+++ b/src/Jobs/Contacts/Corporation/Labels.php
@@ -72,7 +72,7 @@ class Labels extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if ($response->isFromCache() &&
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
         CorporationLabel::where('corporation_id', $this->getCorporationId())->exists())
             return;
 

--- a/src/Jobs/Contacts/Corporation/Labels.php
+++ b/src/Jobs/Contacts/Corporation/Labels.php
@@ -73,7 +73,7 @@ class Labels extends AbstractAuthCorporationJob
         ]);
 
         if ($response->isFromCache() &&
-        CorporationLabel::where('corporation_id', $this->getCorporationId())->count() > 0)
+        CorporationLabel::where('corporation_id', $this->getCorporationId())->exists())
             return;
 
         $labels = $response->getBody();

--- a/src/Jobs/Contacts/Corporation/Labels.php
+++ b/src/Jobs/Contacts/Corporation/Labels.php
@@ -72,6 +72,10 @@ class Labels extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
+        if ($response->isFromCache() &&
+        CorporationLabel::where('corporation_id', $this->getCorporationId())->count() > 0)
+            return;
+
         $labels = $response->getBody();
 
         collect($labels)->each(function ($label) {

--- a/src/Jobs/Contacts/Corporation/Labels.php
+++ b/src/Jobs/Contacts/Corporation/Labels.php
@@ -72,7 +72,7 @@ class Labels extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
         CorporationLabel::where('corporation_id', $this->getCorporationId())->exists())
             return;
 

--- a/src/Jobs/Corporation/AllianceHistory.php
+++ b/src/Jobs/Corporation/AllianceHistory.php
@@ -67,6 +67,10 @@ class AllianceHistory extends AbstractCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        CorporationAllianceHistory::where('corporation_id', $this->getCorporationId())->exists())
+            return;
+
         $history = $response->getBody();
 
         collect($history)->each(function ($alliance) {

--- a/src/Jobs/Corporation/AllianceHistory.php
+++ b/src/Jobs/Corporation/AllianceHistory.php
@@ -67,7 +67,7 @@ class AllianceHistory extends AbstractCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
         CorporationAllianceHistory::where('corporation_id', $this->getCorporationId())->exists())
             return;
 

--- a/src/Jobs/Corporation/ContainerLogs.php
+++ b/src/Jobs/Corporation/ContainerLogs.php
@@ -82,20 +82,15 @@ class ContainerLogs extends AbstractAuthCorporationJob
 
         $structure_batch = new StructureBatch();
 
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
-                CorporationContainerLog::where('corporation_id', $this->getCorporationId())->exists()){
-                    if (! $this->nextPage($response->getPagesCount())){
-                        break;
-                    } else {
-                        continue;
-                    }
-                }
+            if ($this->shouldUseCache($response) &&
+                CorporationContainerLog::where('corporation_id', $this->getCorporationId())->exists())
+                continue;
 
             $logs = $response->getBody();
 
@@ -118,10 +113,7 @@ class ContainerLogs extends AbstractAuthCorporationJob
                 ])->save();
 
             });
-
-            if (! $this->nextPage($response->getPagesCount()))
-                break;
-        }
+        }  while ($this->nextPage($response->getPagesCount()));
 
         $structure_batch->submitJobs($this->getToken());
     }

--- a/src/Jobs/Corporation/ContainerLogs.php
+++ b/src/Jobs/Corporation/ContainerLogs.php
@@ -88,6 +88,15 @@ class ContainerLogs extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
+            if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+                CorporationContainerLog::where('corporation_id', $this->getCorporationId())->exists()){
+                    if (! $this->nextPage($response->getPagesCount())){
+                        break;
+                    } else {
+                        continue;
+                    }
+                }
+
             $logs = $response->getBody();
 
             collect($logs)->each(function ($log) use ($structure_batch) {

--- a/src/Jobs/Corporation/Divisions.php
+++ b/src/Jobs/Corporation/Divisions.php
@@ -77,6 +77,10 @@ class Divisions extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+            CorporationDivision::where('corporation_id', $this->getCorporationId())->exists())
+            return;
+
         $divisions = $response->getBody();
 
         if (property_exists($divisions, 'hangar'))

--- a/src/Jobs/Corporation/Divisions.php
+++ b/src/Jobs/Corporation/Divisions.php
@@ -77,7 +77,7 @@ class Divisions extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CorporationDivision::where('corporation_id', $this->getCorporationId())->exists())
             return;
 

--- a/src/Jobs/Corporation/Facilities.php
+++ b/src/Jobs/Corporation/Facilities.php
@@ -77,7 +77,7 @@ class Facilities extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CorporationFacility::where('corporation_id', $this->getCorporationId())->exists())
             return;
 

--- a/src/Jobs/Corporation/Facilities.php
+++ b/src/Jobs/Corporation/Facilities.php
@@ -77,6 +77,10 @@ class Facilities extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+            CorporationFacility::where('corporation_id', $this->getCorporationId())->exists())
+            return;
+
         $facilities = $response->getBody();
 
         collect($facilities)->each(function ($facility) {

--- a/src/Jobs/Corporation/Info.php
+++ b/src/Jobs/Corporation/Info.php
@@ -68,7 +68,7 @@ class Info extends AbstractCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CorporationInfo::where('corporation_id', $this->getCorporationId())->exists())
             return;
 

--- a/src/Jobs/Corporation/Info.php
+++ b/src/Jobs/Corporation/Info.php
@@ -68,6 +68,10 @@ class Info extends AbstractCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+            CorporationInfo::where('corporation_id', $this->getCorporationId())->exists())
+            return;
+
         $corporation = $response->getBody();
 
         $model = CorporationInfo::firstOrNew([

--- a/src/Jobs/Corporation/IssuedMedals.php
+++ b/src/Jobs/Corporation/IssuedMedals.php
@@ -78,20 +78,15 @@ class IssuedMedals extends AbstractAuthCorporationJob
     {
         parent::handle();
 
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
-            if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
-                CorporationIssuedMedal::where('corporation_id', $this->getCorporationId())->exists()){
-                    if (! $this->nextPage($response->getPagesCount())){
-                        break;
-                    } else {
-                        continue;
-                    }
-                }
+            if ($this->shouldUseCache($response) &&
+                CorporationIssuedMedal::where('corporation_id', $this->getCorporationId())->exists())
+                continue;
 
             $medals = $response->getBody();
 
@@ -109,9 +104,6 @@ class IssuedMedals extends AbstractAuthCorporationJob
                 ])->save();
 
             });
-
-            if (! $this->nextPage($response->getPagesCount()))
-                break;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
     }
 }

--- a/src/Jobs/Corporation/IssuedMedals.php
+++ b/src/Jobs/Corporation/IssuedMedals.php
@@ -84,6 +84,15 @@ class IssuedMedals extends AbstractAuthCorporationJob
                 'corporation_id' => $this->getCorporationId(),
             ]);
 
+            if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+                CorporationIssuedMedal::where('corporation_id', $this->getCorporationId())->exists()){
+                    if (! $this->nextPage($response->getPagesCount())){
+                        break;
+                    } else {
+                        continue;
+                    }
+                }
+
             $medals = $response->getBody();
 
             collect($medals)->each(function ($medal) {

--- a/src/Jobs/Corporation/Medals.php
+++ b/src/Jobs/Corporation/Medals.php
@@ -76,11 +76,15 @@ class Medals extends AbstractAuthCorporationJob
     {
         parent::handle();
 
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
             ]);
+
+            if ($this->shouldUseCache($response) &&
+                CorporationMedal::where('corporation_id', $this->getCorporationId())->exists())
+                continue;
 
             $medals = $response->getBody();
 
@@ -97,9 +101,6 @@ class Medals extends AbstractAuthCorporationJob
                 ])->save();
 
             });
-
-            if (! $this->nextPage($response->getPagesCount()))
-                break;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
     }
 }

--- a/src/Jobs/Corporation/MemberTracking.php
+++ b/src/Jobs/Corporation/MemberTracking.php
@@ -77,6 +77,10 @@ class MemberTracking extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+            CorporationMemberTracking::where('corporation_id', $this->getCorporationId())->exists())
+            return;
+
         $members = $response->getBody();
 
         collect($members)->each(function ($member) {

--- a/src/Jobs/Corporation/MemberTracking.php
+++ b/src/Jobs/Corporation/MemberTracking.php
@@ -77,7 +77,7 @@ class MemberTracking extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CorporationMemberTracking::where('corporation_id', $this->getCorporationId())->exists())
             return;
 

--- a/src/Jobs/Corporation/Members.php
+++ b/src/Jobs/Corporation/Members.php
@@ -72,7 +72,7 @@ class Members extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CorporationMember::where('corporation_id', $this->getCorporationId())->exists())
             return;
 

--- a/src/Jobs/Corporation/Members.php
+++ b/src/Jobs/Corporation/Members.php
@@ -72,6 +72,10 @@ class Members extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+            CorporationMember::where('corporation_id', $this->getCorporationId())->exists())
+            return;
+
         $members = $response->getBody();
 
         collect($members)->each(function ($member_id) {

--- a/src/Jobs/Corporation/MembersLimit.php
+++ b/src/Jobs/Corporation/MembersLimit.php
@@ -77,7 +77,7 @@ class MembersLimit extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CorporationMemberLimits::where('corporation_id', $this->getCorporationId())->exists())
             return;
 

--- a/src/Jobs/Corporation/MembersLimit.php
+++ b/src/Jobs/Corporation/MembersLimit.php
@@ -77,6 +77,10 @@ class MembersLimit extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+            CorporationMemberLimits::where('corporation_id', $this->getCorporationId())->exists())
+            return;
+
         $limit = $response->getBody();
 
         if (! property_exists($limit, 'scalar'))

--- a/src/Jobs/Corporation/MembersTitles.php
+++ b/src/Jobs/Corporation/MembersTitles.php
@@ -77,7 +77,7 @@ class MembersTitles extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CorporationMemberTitle::where('corporation_id', $this->getCorporationId())->exists())
             return;
 

--- a/src/Jobs/Corporation/MembersTitles.php
+++ b/src/Jobs/Corporation/MembersTitles.php
@@ -77,6 +77,10 @@ class MembersTitles extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+            CorporationMemberTitle::where('corporation_id', $this->getCorporationId())->exists())
+            return;
+
         $titles = $response->getBody();
 
         collect($titles)->filter(function ($member) {

--- a/src/Jobs/Corporation/RoleHistories.php
+++ b/src/Jobs/Corporation/RoleHistories.php
@@ -78,11 +78,15 @@ class RoleHistories extends AbstractAuthCorporationJob
     {
         parent::handle();
 
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
             ]);
+
+            if ($this->shouldUseCache($response) &&
+                CorporationRoleHistory::where('corporation_id', $this->getCorporationId())->exists())
+                return;
 
             $roles = $response->getBody();
 
@@ -119,9 +123,6 @@ class RoleHistories extends AbstractAuthCorporationJob
                 });
 
             });
-
-            if (! $this->nextPage($response->getPagesCount()))
-                break;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
     }
 }

--- a/src/Jobs/Corporation/Roles.php
+++ b/src/Jobs/Corporation/Roles.php
@@ -91,7 +91,7 @@ class Roles extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CorporationRole::where('corporation_id', $this->getCorporationId())->exists())
             return;
 

--- a/src/Jobs/Corporation/Roles.php
+++ b/src/Jobs/Corporation/Roles.php
@@ -91,6 +91,10 @@ class Roles extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+            CorporationRole::where('corporation_id', $this->getCorporationId())->exists())
+            return;
+
         $roles = $response->getBody();
 
         $returned_characters_ids = collect();

--- a/src/Jobs/Corporation/Shareholders.php
+++ b/src/Jobs/Corporation/Shareholders.php
@@ -97,7 +97,7 @@ class Shareholders extends AbstractAuthCorporationJob
     {
         parent::handle();
 
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
@@ -120,9 +120,7 @@ class Shareholders extends AbstractAuthCorporationJob
             $this->known_shareholders->push(collect($shareholders)
                 ->pluck(['shareholder_type', 'shareholder_id'])->flatten()->all());
 
-            if (! $this->nextPage($response->getPagesCount()))
-                break;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
 
         CorporationShareholder::where('corporation_id', $this->getCorporationId())
             ->whereNotIn('shareholder_id', $this->known_shareholders->flatten()->all())

--- a/src/Jobs/Corporation/Standings.php
+++ b/src/Jobs/Corporation/Standings.php
@@ -73,7 +73,7 @@ class Standings extends AbstractAuthCorporationJob
     {
         parent::handle();
 
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
@@ -100,8 +100,6 @@ class Standings extends AbstractAuthCorporationJob
                 ]);
             });
 
-            if (! $this->nextPage($response->getPagesCount()))
-                break;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
     }
 }

--- a/src/Jobs/Corporation/StarbaseDetails.php
+++ b/src/Jobs/Corporation/StarbaseDetails.php
@@ -107,6 +107,12 @@ class StarbaseDetails extends AbstractAuthCorporationJob
                     'starbase_id' => $starbase->starbase_id,
                 ]);
 
+                if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+                    CorporationStarbaseDetail::where('starbase_id', $starbase->starbase_id)->exists()){
+                        $this->known_starbases->push($starbase->starbase_id);
+                        return;
+                    }
+
                 $detail = $response->getBody();
 
                 $model = CorporationStarbaseDetail::firstOrNew([

--- a/src/Jobs/Corporation/StarbaseDetails.php
+++ b/src/Jobs/Corporation/StarbaseDetails.php
@@ -110,6 +110,7 @@ class StarbaseDetails extends AbstractAuthCorporationJob
                 if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
                     CorporationStarbaseDetail::where('starbase_id', $starbase->starbase_id)->exists()){
                         $this->known_starbases->push($starbase->starbase_id);
+
                         return;
                     }
 

--- a/src/Jobs/Corporation/StarbaseDetails.php
+++ b/src/Jobs/Corporation/StarbaseDetails.php
@@ -114,6 +114,7 @@ class StarbaseDetails extends AbstractAuthCorporationJob
 
                 if ($this->shouldUseCache($response) && $model->exists){
                         $this->known_starbases->push($starbase->starbase_id);
+
                         return true;
                     }
 

--- a/src/Jobs/Corporation/StarbaseDetails.php
+++ b/src/Jobs/Corporation/StarbaseDetails.php
@@ -107,19 +107,17 @@ class StarbaseDetails extends AbstractAuthCorporationJob
                     'starbase_id' => $starbase->starbase_id,
                 ]);
 
-                if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
-                    CorporationStarbaseDetail::where('starbase_id', $starbase->starbase_id)->exists()){
-                        $this->known_starbases->push($starbase->starbase_id);
-
-                        return;
-                    }
-
-                $detail = $response->getBody();
-
                 $model = CorporationStarbaseDetail::firstOrNew([
                     'corporation_id' => $this->getCorporationId(),
                     'starbase_id' => $starbase->starbase_id,
                 ]);
+
+                if ($this->shouldUseCache($response) && $model->exists){
+                        $this->known_starbases->push($starbase->starbase_id);
+                        return true;
+                    }
+
+                $detail = $response->getBody();
 
                 StarbaseDetailMapping::make($model, $detail, [
                     'corporation_id' => function () {

--- a/src/Jobs/Corporation/Starbases.php
+++ b/src/Jobs/Corporation/Starbases.php
@@ -98,7 +98,7 @@ class Starbases extends AbstractAuthCorporationJob
     {
         parent::handle();
 
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
@@ -123,9 +123,7 @@ class Starbases extends AbstractAuthCorporationJob
 
             });
 
-            if (! $this->nextPage($response->getPagesCount()))
-                break;
-        }
+        } while ( $this->nextPage($response->getPagesCount()));
 
         CorporationStarbase::where('corporation_id', $this->getCorporationId())
             ->whereNotIn('starbase_id', $this->known_starbases->flatten()->all())

--- a/src/Jobs/Corporation/Starbases.php
+++ b/src/Jobs/Corporation/Starbases.php
@@ -123,7 +123,7 @@ class Starbases extends AbstractAuthCorporationJob
 
             });
 
-        } while ( $this->nextPage($response->getPagesCount()));
+        } while ($this->nextPage($response->getPagesCount()));
 
         CorporationStarbase::where('corporation_id', $this->getCorporationId())
             ->whereNotIn('starbase_id', $this->known_starbases->flatten()->all())

--- a/src/Jobs/Corporation/Structures.php
+++ b/src/Jobs/Corporation/Structures.php
@@ -100,7 +100,7 @@ class Structures extends AbstractAuthCorporationJob
     {
         parent::handle();
 
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
@@ -173,9 +173,7 @@ class Structures extends AbstractAuthCorporationJob
                 $this->known_structures->push($structure->structure_id);
             });
 
-            if (! $this->nextPage($response->getPagesCount()))
-                break;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
 
         $outdated_structure = CorporationStructure::where('corporation_id', $this->getCorporationId())
             ->whereNotIn('structure_id', $this->known_structures->flatten()->all())

--- a/src/Jobs/Corporation/Titles.php
+++ b/src/Jobs/Corporation/Titles.php
@@ -111,7 +111,7 @@ class Titles extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
-        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CorporationTitle::where('corporation_id', $this->getCorporationId())->exists())
             return;
 

--- a/src/Jobs/Corporation/Titles.php
+++ b/src/Jobs/Corporation/Titles.php
@@ -111,6 +111,10 @@ class Titles extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
+        if (config('eveapi.cache.respect_cache') && $response->isFromCache() &&
+            CorporationTitle::where('corporation_id', $this->getCorporationId())->exists())
+            return;
+
         $titles = $response->getBody();
 
         collect($titles)->each(function ($title) {

--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -422,6 +422,18 @@ abstract class EsiBase extends AbstractJob
     }
 
     /**
+     * Check if the call should respect the cache
+     * based on the request being cached and settings
+     *
+     * @param  \Seat\Services\Contracts\EsiResponse  $response
+     * @return bool
+     */
+    public function shouldUseCache(EsiResponse $response): bool
+    {
+        return config('eveapi.cache.respect_cache') && $response->isFromCache();
+    }
+
+    /**
      * @param  \Seat\Eseye\Exceptions\RequestFailedException  $exception
      *
      * @throws \Seat\Eseye\Exceptions\RequestFailedException

--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -423,7 +423,7 @@ abstract class EsiBase extends AbstractJob
 
     /**
      * Check if the call should respect the cache
-     * based on the request being cached and settings
+     * based on the request being cached and settings.
      *
      * @param  \Seat\Services\Contracts\EsiResponse  $response
      * @return bool

--- a/src/Jobs/Fittings/Character/Fittings.php
+++ b/src/Jobs/Fittings/Character/Fittings.php
@@ -71,6 +71,10 @@ class Fittings extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
+        if ($this->shouldUseCache($response) &&
+            CharacterFitting::where('character_id', $this->getCharacterId())->exists())
+            return;
+
         $fittings = $response->getBody();
 
         collect($fittings)->each(function ($fitting) {

--- a/src/Jobs/Fittings/Insurances.php
+++ b/src/Jobs/Fittings/Insurances.php
@@ -61,6 +61,9 @@ class Insurances extends EsiBase
     {
         $response = $this->retrieve();
 
+        if ($this->shouldUseCache($response) && Insurance::exists())
+            return;
+
         $insurances = $response->getBody();
 
         collect($insurances)->each(function ($insurance) {

--- a/src/Jobs/Industry/Character/Jobs.php
+++ b/src/Jobs/Industry/Character/Jobs.php
@@ -80,6 +80,10 @@ class Jobs extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
+        if ($this->shouldUseCache($response) &&
+            CharacterIndustryJob::where('character_id', $this->getCharacterId())->exists())
+            return;
+
         $industry_jobs = $response->getBody();
 
         collect($industry_jobs)->each(function ($job) use ($structure_batch) {

--- a/src/Jobs/Industry/Character/Mining.php
+++ b/src/Jobs/Industry/Character/Mining.php
@@ -72,11 +72,15 @@ class Mining extends AbstractAuthCharacterJob
     {
         parent::handle();
 
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'character_id' => $this->getCharacterId(),
             ]);
+
+            if ($this->shouldUseCache($response) &&
+                CharacterMining::where('character_id', $this->getCharacterId())->exists())
+                continue;
 
             $entries = $response->getBody();
 
@@ -117,9 +121,6 @@ class Mining extends AbstractAuthCharacterJob
 
                 }
             });
-
-            if (! $this->nextPage($response->getPagesCount()))
-                break;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
     }
 }

--- a/src/Jobs/Industry/Corporation/Jobs.php
+++ b/src/Jobs/Industry/Corporation/Jobs.php
@@ -89,7 +89,7 @@ class Jobs extends AbstractAuthCorporationJob
 
         $structure_batch = new StructureBatch();
 
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
@@ -105,6 +105,9 @@ class Jobs extends AbstractAuthCorporationJob
                     'job_id' => $job->job_id,
                 ]);
 
+                if ($this->shouldUseCache($response) && $model->exists)
+                    return;
+
                 JobMapping::make($model, $job, [
                     'corporation_id' => function () {
                         return $this->getCorporationId();
@@ -115,9 +118,7 @@ class Jobs extends AbstractAuthCorporationJob
                 ])->save();
             });
 
-            if (! $this->nextPage($response->getPagesCount()))
-                break;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
 
         $structure_batch->submitJobs($this->getToken());
     }

--- a/src/Jobs/Industry/Corporation/Mining/Observers.php
+++ b/src/Jobs/Industry/Corporation/Mining/Observers.php
@@ -84,6 +84,10 @@ class Observers extends AbstractAuthCorporationJob
             'corporation_id' => $this->getCorporationId(),
         ]);
 
+        if ($this->shouldUseCache($response) &&
+            CorporationIndustryMiningObserver::where('corporation_id', $this->getCorporationId())->exists())
+            return;
+
         $observers = $response->getBody();
 
         collect($observers)->each(function ($observer) {

--- a/src/Jobs/Killmails/Character/Recent.php
+++ b/src/Jobs/Killmails/Character/Recent.php
@@ -88,7 +88,7 @@ class Recent extends AbstractAuthCharacterJob
      */
     public function handle()
     {
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'character_id' => $this->getCharacterId(),
@@ -108,9 +108,7 @@ class Recent extends AbstractAuthCharacterJob
                     $this->killmail_jobs->add(new Detail($killmail->killmail_id, $killmail->killmail_hash));
             });
 
-            if (! $this->nextPage($response->getPagesCount()))
-                break;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
 
         if ($this->killmail_jobs->isNotEmpty()) {
             if($this->batchId) {

--- a/src/Jobs/Killmails/Corporation/Recent.php
+++ b/src/Jobs/Killmails/Corporation/Recent.php
@@ -92,7 +92,7 @@ class Recent extends AbstractAuthCorporationJob
      */
     public function handle()
     {
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
@@ -112,9 +112,7 @@ class Recent extends AbstractAuthCorporationJob
                     $this->killmail_jobs->add(new Detail($killmail->killmail_id, $killmail->killmail_hash));
             });
 
-            if (! $this->nextPage($response->getPagesCount()))
-                break;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
 
         if ($this->killmail_jobs->isNotEmpty()) {
             if($this->batchId) {

--- a/src/Jobs/Mail/Labels.php
+++ b/src/Jobs/Mail/Labels.php
@@ -70,6 +70,9 @@ class Labels extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
+        if ($this->shouldUseCache($response) && MailLabel::where('character_id', $this->getCharacterId())->exists())
+            return;
+
         $labels = $response->getBody();
 
         collect($labels->labels)->each(function ($label) {

--- a/src/Jobs/Mail/MailingLists.php
+++ b/src/Jobs/Mail/MailingLists.php
@@ -70,6 +70,9 @@ class MailingLists extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
+        if ($this->shouldUseCache($response) && MailMailingList::where('character_id', $this->getCharacterId())->exists())
+            return;
+
         $lists = $response->getBody();
 
         collect($lists)->each(function ($list) {

--- a/src/Jobs/Market/Character/History.php
+++ b/src/Jobs/Market/Character/History.php
@@ -72,7 +72,7 @@ class History extends AbstractAuthCharacterJob
     {
         parent::handle();
 
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'character_id' => $this->getCharacterId(),
@@ -99,9 +99,6 @@ class History extends AbstractAuthCharacterJob
                     },
                 ])->save();
             });
-
-            if (! $this->nextPage($response->getPagesCount()))
-                return;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
     }
 }

--- a/src/Jobs/Market/Corporation/History.php
+++ b/src/Jobs/Market/Corporation/History.php
@@ -79,7 +79,7 @@ class History extends AbstractAuthCorporationJob
     {
         parent::handle();
 
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
@@ -110,8 +110,6 @@ class History extends AbstractAuthCorporationJob
                 ])->save();
             });
 
-            if (! $this->nextPage($response->getPagesCount()))
-                return;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
     }
 }

--- a/src/Jobs/Market/Corporation/Orders.php
+++ b/src/Jobs/Market/Corporation/Orders.php
@@ -82,7 +82,7 @@ class Orders extends AbstractAuthCorporationJob
 
         $structure_batch = new StructureBatch();
 
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
@@ -111,10 +111,8 @@ class Orders extends AbstractAuthCorporationJob
                 ])->save();
             });
 
-            if (! $this->nextPage($response->getPagesCount()))
-                $structure_batch->submitJobs();
-
-                return;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
+        
+        $structure_batch->submitJobs();
     }
 }

--- a/src/Jobs/Market/Corporation/Orders.php
+++ b/src/Jobs/Market/Corporation/Orders.php
@@ -112,7 +112,7 @@ class Orders extends AbstractAuthCorporationJob
             });
 
         } while ($this->nextPage($response->getPagesCount()));
-        
+
         $structure_batch->submitJobs();
     }
 }

--- a/src/Jobs/Market/DispatchHistoryJobs.php
+++ b/src/Jobs/Market/DispatchHistoryJobs.php
@@ -66,15 +66,14 @@ class DispatchHistoryJobs extends EsiBase
 
         $types = collect();
 
-        while (true) {
+        do {
             $response = $this->retrieve(['region_id' => $region_id]);
             $orders = $response->getBody();
 
             $types = $types->merge($orders);
 
             // if there are more pages with orders, continue loading them
-            if (! $this->nextPage($response->getPagesCount())) break;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
 
         // create history jobs
         $jobs = collect();

--- a/src/Jobs/Market/Orders.php
+++ b/src/Jobs/Market/Orders.php
@@ -69,7 +69,7 @@ class Orders extends EsiBase
         $structure_batch = new StructureBatch();
 
         //load all market data
-        while (true) {
+        do {
             //retrieve one page of market orders
             $response = $this->retrieve(['region_id' => $region_id]);
             $orders = $response->getBody();
@@ -120,8 +120,7 @@ class Orders extends EsiBase
             });
 
             // if there are more pages with orders, continue loading them
-            if (! $this->nextPage($response->getPagesCount())) break;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
 
         // remove old orders
         // if they didn't get updated, we can remove them

--- a/src/Jobs/Market/Prices.php
+++ b/src/Jobs/Market/Prices.php
@@ -70,6 +70,10 @@ class Prices extends EsiBase
 
         $response = $this->retrieve();
 
+        if ($this->shouldUseCache($response) &&
+            Price::exists())
+            return;
+
         $prices = $response->getBody();
 
         collect($prices)->chunk(1000)->each(function ($chunk) {

--- a/src/Jobs/PlanetaryInteraction/Character/PlanetDetail.php
+++ b/src/Jobs/PlanetaryInteraction/Character/PlanetDetail.php
@@ -145,10 +145,9 @@ class PlanetDetail extends AbstractAuthCharacterJob
             'planet_id' => $this->planet_id,
         ]);
 
-        if ($response->isFromCache() && 
+        if ($response->isFromCache() &&
             CharacterPlanetPin::where('character_id', $this->getCharacterId())->exists())
             return;
-
 
         $planet = $response->getBody();
 

--- a/src/Jobs/PlanetaryInteraction/Character/PlanetDetail.php
+++ b/src/Jobs/PlanetaryInteraction/Character/PlanetDetail.php
@@ -145,6 +145,11 @@ class PlanetDetail extends AbstractAuthCharacterJob
             'planet_id' => $this->planet_id,
         ]);
 
+        if ($response->isFromCache() && 
+            CharacterPlanetPin::where('character_id', $this->getCharacterId())->count() > 0)
+            return;
+
+
         $planet = $response->getBody();
 
         // seed database with pins

--- a/src/Jobs/PlanetaryInteraction/Character/PlanetDetail.php
+++ b/src/Jobs/PlanetaryInteraction/Character/PlanetDetail.php
@@ -145,7 +145,7 @@ class PlanetDetail extends AbstractAuthCharacterJob
             'planet_id' => $this->planet_id,
         ]);
 
-        if ($response->isFromCache() &&
+        if ($this->shouldUseCache($response) &&
             CharacterPlanetPin::where('character_id', $this->getCharacterId())->exists())
             return;
 

--- a/src/Jobs/PlanetaryInteraction/Character/PlanetDetail.php
+++ b/src/Jobs/PlanetaryInteraction/Character/PlanetDetail.php
@@ -146,7 +146,7 @@ class PlanetDetail extends AbstractAuthCharacterJob
         ]);
 
         if ($response->isFromCache() && 
-            CharacterPlanetPin::where('character_id', $this->getCharacterId())->count() > 0)
+            CharacterPlanetPin::where('character_id', $this->getCharacterId())->exists())
             return;
 
 

--- a/src/Jobs/PlanetaryInteraction/Corporation/CustomsOffices.php
+++ b/src/Jobs/PlanetaryInteraction/Corporation/CustomsOffices.php
@@ -98,7 +98,7 @@ class CustomsOffices extends AbstractAuthCorporationJob
     {
         parent::handle();
 
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'corporation_id' => $this->getCorporationId(),
@@ -123,9 +123,7 @@ class CustomsOffices extends AbstractAuthCorporationJob
 
             });
 
-            if (! $this->nextPage($response->getPagesCount()))
-                break;
-        }
+        } while ($this->nextPage($response->getPagesCount()));
 
         // Cleanup customs offices that were not in the response.
         CorporationCustomsOffice::where('corporation_id', $this->getCorporationId())

--- a/src/Jobs/Skills/Character/Attributes.php
+++ b/src/Jobs/Skills/Character/Attributes.php
@@ -71,11 +71,14 @@ class Attributes extends AbstractAuthCharacterJob
             'character_id' => $this->getCharacterId(),
         ]);
 
-        $attributes = $response->getBody();
-
         $model = CharacterAttribute::firstOrNew([
             'character_id' => $this->getCharacterId(),
         ]);
+
+        if ($this->shouldUseCache($response) && $model->exists)
+            return;
+
+        $attributes = $response->getBody();
 
         CharacterAttributesMapping::make($model, $attributes, [
             'character_id' => function () {

--- a/src/Jobs/Universe/Structures/Citadel.php
+++ b/src/Jobs/Universe/Structures/Citadel.php
@@ -102,6 +102,9 @@ class Citadel extends AbstractAuthCharacterJob
                 'structure_id' => $this->structure_id,
             ]);
 
+            if ($this->shouldUseCache($response) && $model->exists)
+                return;
+
             $structure = $response->getBody();
 
             UniverseStructureMapping::make($model, $structure, [

--- a/src/Jobs/Wallet/Character/Journal.php
+++ b/src/Jobs/Wallet/Character/Journal.php
@@ -92,7 +92,7 @@ class Journal extends AbstractAuthCharacterJob
         // Perform a journal walk backwards to get all of the
         // entries as far back as possible. When the response from
         // ESI is empty, we can assume we have everything.
-        while (true) {
+        do {
 
             $response = $this->retrieve([
                 'character_id' => $this->getCharacterId(),
@@ -132,8 +132,6 @@ class Journal extends AbstractAuthCharacterJob
             });
 
             // in case the last known entry has been reached or we non longer have pages, terminate the job.
-            if (! $this->nextPage($response->getPagesCount()) || $this->at_last_entry)
-                break;
-        }
+        } while ($this->nextPage($response->getPagesCount()) || $this->at_last_entry);
     }
 }

--- a/src/Jobs/Wallet/Corporation/Journals.php
+++ b/src/Jobs/Wallet/Corporation/Journals.php
@@ -104,7 +104,7 @@ class Journals extends AbstractAuthCorporationJob
                 // Perform a journal walk backwards to get all of the
                 // entries as far back as possible. When the response from
                 // ESI is empty, we can assume we have everything.
-                while (true) {
+                do {
 
                     $response = $this->retrieve([
                         'corporation_id' => $this->getCorporationId(),
@@ -151,9 +151,7 @@ class Journals extends AbstractAuthCorporationJob
                     });
 
                     // in case the last known entry has been reached or we non longer have pages, terminate the job.
-                    if (! $this->nextPage($response->getPagesCount()) || $this->at_last_entry)
-                        break;
-                }
+                } while ($this->nextPage($response->getPagesCount()) || $this->at_last_entry);
 
                 // Reset the page for the next wallet division.
                 $this->page = 1;


### PR DESCRIPTION
This PR adds back some cache functionality as it used to exist within SeAT v4.

The intent is that for most jobs (exclusions based on ETAG reliability and complexity of responses/handling), if the result is cached then do not try and insert it into the DB. In a lot of cases, this should lead to fewer DB writes. 

There is a new ENV var that will be added as part of this change, which is `EVEAPI_RESPECT_CACHE`
It defaults to false, which will not check if an ESI response is cached and always treat it as new data (as has been the case in SeAT v5 until now)enables this behavior. This can be set to `true` in order to trial the v4 style caching. In a future release this default may get changed to true.

Future work on the cache will follow will aim at reducing the size of the cache itself.