### PR TITLE
citadels: add structure id to job tags

### DIFF
--- a/src/Jobs/Universe/Structures/Citadel.php
+++ b/src/Jobs/Universe/Structures/Citadel.php
@@ -79,6 +79,18 @@ class Citadel extends AbstractAuthCharacterJob
 
     /**
      * {@inheritdoc}
+     */
+    public function tags(): array
+    {
+        $tags = parent::tags();
+
+        $tags[] = $this->structure_id;
+
+        return $tags;
+    }
+
+    /**
+     * {@inheritdoc}
      *
      * @throws RequestFailedException
      */


### PR DESCRIPTION
Another debugging tool. Use-case is for figuring out why some citadels don't load for Kiba. Since citaedl jobs might take a while to appear, being able to monitor job for a particular citadel would be useful.