### PR TITLE
new citadel access caching strategy: Store access cache in DB

### DIFF
--- a/src/Contracts/CitadelAccessCache.php
+++ b/src/Contracts/CitadelAccessCache.php
@@ -20,23 +20,27 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-namespace Seat\Eveapi\Jobs\Universe\Structures;
+namespace Seat\Eveapi\Contracts;
 
-use Seat\Eveapi\Contracts\CitadelAccessCache;
-
-class CacheCitadelAccessCache implements CitadelAccessCache
+interface CitadelAccessCache
 {
-    private static function getCacheKey(int $character_id, int $citadel_id) {
-        return "citadel.$citadel_id.block.$character_id";
-    }
+    const BLOCK_DURATION_SECONDS = 60 * 60 * 24 * 7 * 4; // 4 weeks
 
-    public static function canAccess(int $character_id, int $citadel_id): bool
-    {
-        return cache()->get(self::getCacheKey($character_id, $citadel_id), true);
-    }
+    /**
+     * Checks whether a character can access a citadel or if esi will return an error 403.
+     *
+     * @param  int  $character_id
+     * @param  int  $citadel_id
+     * @return bool
+     */
+    public static function canAccess(int $character_id, int $citadel_id): bool;
 
-    public static function blockAccess(int $character_id, int $citadel_id)
-    {
-        cache()->set(self::getCacheKey($character_id, $citadel_id), false, now()->addSeconds(self::BLOCK_DURATION_SECONDS));
-    }
+    /**
+     * After having received an error 403, block a character from further accesses.
+     *
+     * @param  int  $character_id
+     * @param  int  $citadel_id
+     * @return mixed
+     */
+    public static function blockAccess(int $character_id, int $citadel_id);
 }

--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -22,6 +22,8 @@
 
 namespace Seat\Eveapi;
 
+use Seat\Eveapi\Contracts\CitadelAccessCache;
+use Seat\Eveapi\Jobs\Universe\Structures\CacheCitadelAccessCache;
 use Seat\Eveapi\Models\Character\CharacterAffiliation;
 use Seat\Eveapi\Models\RefreshToken;
 use Seat\Services\AbstractSeatPlugin;
@@ -71,6 +73,8 @@ class EveapiServiceProvider extends AbstractSeatPlugin
             \Seat\Eveapi\Database\Seeders\ScheduleSeeder::class,
             // \Seat\Eveapi\Database\Seeders\Sde\SdeSeeder::class, -- Disabled until later implemented again in services
         ]);
+
+        $this->app->bindIf(CitadelAccessCache::class, CacheCitadelAccessCache::class);
     }
 
     private function addCommands()

--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -24,6 +24,8 @@ namespace Seat\Eveapi;
 
 use Seat\Eveapi\Contracts\CitadelAccessCache;
 use Seat\Eveapi\Jobs\Universe\Structures\CacheCitadelAccessCache;
+use Seat\Eveapi\Jobs\Universe\Structures\DBCitadelAccessCache;
+use Seat\Eveapi\Jobs\Universe\Structures\StructureBatch;
 use Seat\Eveapi\Models\Character\CharacterAffiliation;
 use Seat\Eveapi\Models\RefreshToken;
 use Seat\Services\AbstractSeatPlugin;
@@ -74,7 +76,11 @@ class EveapiServiceProvider extends AbstractSeatPlugin
             // \Seat\Eveapi\Database\Seeders\Sde\SdeSeeder::class, -- Disabled until later implemented again in services
         ]);
 
-        $this->app->bindIf(CitadelAccessCache::class, CacheCitadelAccessCache::class);
+        if(env("CITADEL_ACCESS_CACHE") === "db"){
+            $this->app->bind(CitadelAccessCache::class, DBCitadelAccessCache::class);
+        } else {
+            $this->app->bind(CitadelAccessCache::class, CacheCitadelAccessCache::class);
+        }
     }
 
     private function addCommands()

--- a/src/EveapiServiceProvider.php
+++ b/src/EveapiServiceProvider.php
@@ -25,7 +25,6 @@ namespace Seat\Eveapi;
 use Seat\Eveapi\Contracts\CitadelAccessCache;
 use Seat\Eveapi\Jobs\Universe\Structures\CacheCitadelAccessCache;
 use Seat\Eveapi\Jobs\Universe\Structures\DBCitadelAccessCache;
-use Seat\Eveapi\Jobs\Universe\Structures\StructureBatch;
 use Seat\Eveapi\Models\Character\CharacterAffiliation;
 use Seat\Eveapi\Models\RefreshToken;
 use Seat\Services\AbstractSeatPlugin;
@@ -76,7 +75,7 @@ class EveapiServiceProvider extends AbstractSeatPlugin
             // \Seat\Eveapi\Database\Seeders\Sde\SdeSeeder::class, -- Disabled until later implemented again in services
         ]);
 
-        if(env("CITADEL_ACCESS_CACHE") === "db"){
+        if(env('CITADEL_ACCESS_CACHE') === 'db'){
             $this->app->bind(CitadelAccessCache::class, DBCitadelAccessCache::class);
         } else {
             $this->app->bind(CitadelAccessCache::class, CacheCitadelAccessCache::class);

--- a/src/Jobs/Universe/Structures/DBCitadelAccessCache.php
+++ b/src/Jobs/Universe/Structures/DBCitadelAccessCache.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Jobs\Universe\Structures;
 
 use Seat\Eveapi\Contracts\CitadelAccessCache;
@@ -14,7 +34,7 @@ class DBCitadelAccessCache implements CitadelAccessCache
     {
         $entry = CitadelAccessCacheModel::where('character_id', $character_id)
             ->where('citadel_id', $citadel_id)
-            ->where('last_failed_access','>=',now()->subSeconds(self::BLOCK_DURATION_SECONDS))
+            ->where('last_failed_access', '>=', now()->subSeconds(self::BLOCK_DURATION_SECONDS))
             ->first();
 
         if($entry === null) return true;

--- a/src/Jobs/Universe/Structures/DBCitadelAccessCache.php
+++ b/src/Jobs/Universe/Structures/DBCitadelAccessCache.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Seat\Eveapi\Jobs\Universe\Structures;
+
+use Seat\Eveapi\Contracts\CitadelAccessCache;
+use Seat\Eveapi\Models\Universe\CitadelAccessCache as CitadelAccessCacheModel;
+
+class DBCitadelAccessCache implements CitadelAccessCache
+{
+    /**
+     * @inheritDoc
+     */
+    public static function canAccess(int $character_id, int $citadel_id): bool
+    {
+        $entry = CitadelAccessCacheModel::where('character_id', $character_id)
+            ->where('citadel_id', $citadel_id)
+            ->where('last_failed_access','>=',now()->subSeconds(self::BLOCK_DURATION_SECONDS))
+            ->first();
+
+        if($entry === null) return true;
+
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function blockAccess(int $character_id, int $citadel_id)
+    {
+        $entry = CitadelAccessCacheModel::where('character_id', $character_id)
+            ->where('citadel_id', $citadel_id)
+            ->first();
+
+        if($entry === null) {
+            $entry = new CitadelAccessCacheModel();
+            $entry->character_id = $character_id;
+            $entry->citadel_id = $citadel_id;
+        }
+
+        $entry->last_failed_access = now();
+        $entry->save();
+    }
+}

--- a/src/Jobs/Universe/Structures/StructureBatch.php
+++ b/src/Jobs/Universe/Structures/StructureBatch.php
@@ -26,10 +26,10 @@ use Illuminate\Support\Facades\Bus;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Psr\SimpleCache\InvalidArgumentException;
+use Seat\Eveapi\Contracts\CitadelAccessCache;
 use Seat\Eveapi\Models\RefreshToken;
 use Seat\Eveapi\Models\Universe\UniverseStation;
 use Seat\Eveapi\Models\Universe\UniverseStructure;
-use Seat\Eveapi\Contracts\CitadelAccessCache;
 
 class StructureBatch
 {
@@ -98,8 +98,9 @@ class StructureBatch
      * Returns whether a job for this citadel has already been scheduled.
      * This logic doesn't need to be 100% race-condition proof, as soon as it catches 99% it does its job.
      *
-     * @param int $structure_id
+     * @param  int  $structure_id
      * @return bool
+     *
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */
@@ -111,8 +112,9 @@ class StructureBatch
      * Set a structure as already processing.
      * This logic doesn't need to be 100% race-condition proof, as soon as it catches 99% it does its job.
      *
-     * @param int $structure_id
+     * @param  int  $structure_id
      * @return void
+     *
      * @throws InvalidArgumentException
      */
     private function setStructureCurrentlyProcessing(int $structure_id): void {

--- a/src/Models/Universe/CitadelAccessCache.php
+++ b/src/Models/Universe/CitadelAccessCache.php
@@ -20,23 +20,40 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-namespace Seat\Eveapi\Jobs\Universe\Structures;
+namespace Seat\Eveapi\Models\Universe;
 
-use Seat\Eveapi\Contracts\CitadelAccessCache;
+use Carbon\Carbon;
+use Seat\Eveapi\Traits\HasCompositePrimaryKey;
+use Seat\Services\Models\ExtensibleModel;
 
-class CacheCitadelAccessCache implements CitadelAccessCache
+/**
+ * A citadel access cache that is stored in the database
+ *
+ * @property int citadel_id
+ * @property int character_id
+ * @property Carbon last_failed_access
+ */
+class CitadelAccessCache extends ExtensibleModel
 {
-    private static function getCacheKey(int $character_id, int $citadel_id) {
-        return "citadel.$citadel_id.block.$character_id";
-    }
+    use HasCompositePrimaryKey;
 
-    public static function canAccess(int $character_id, int $citadel_id): bool
-    {
-        return cache()->get(self::getCacheKey($character_id, $citadel_id), true);
-    }
+    /**
+     * @var string
+     */
+    protected $primaryKey = ['citadel_id', 'character_id'];
 
-    public static function blockAccess(int $character_id, int $citadel_id)
-    {
-        cache()->set(self::getCacheKey($character_id, $citadel_id), false, now()->addSeconds(self::BLOCK_DURATION_SECONDS));
-    }
+    /**
+     * @var bool
+     */
+    public $incrementing = true;
+
+    /**
+     * @var bool
+     */
+    public $timestamps = false;
+
+    /**
+     * @var string
+     */
+    protected $table = 'citadel_access_cache';
 }

--- a/src/Models/Universe/CitadelAccessCache.php
+++ b/src/Models/Universe/CitadelAccessCache.php
@@ -27,7 +27,7 @@ use Seat\Eveapi\Traits\HasCompositePrimaryKey;
 use Seat\Services\Models\ExtensibleModel;
 
 /**
- * A citadel access cache that is stored in the database
+ * A citadel access cache that is stored in the database.
  *
  * @property int citadel_id
  * @property int character_id

--- a/src/database/migrations/2025_01_31_210832_add_db_citadel_access_cache.php
+++ b/src/database/migrations/2025_01_31_210832_add_db_citadel_access_cache.php
@@ -20,27 +20,35 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-namespace Seat\Eveapi\Jobs\Universe\Structures;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
-interface CitadelAccessCache
+return new class extends Migration
 {
-    const BLOCK_DURATION_SECONDS = 60 * 60 * 24 * 7 * 4; // 4 weeks
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('citadel_access_cache', function (Blueprint $table) {
+            $table->bigInteger('citadel_id');
+            $table->bigInteger('character_id');
+            $table->timestamp('last_failed_access')->nullable();
+
+            $table->primary(['citadel_id','character_id']);
+        });
+    }
 
     /**
-     * Checks whether a character can access a citadel or if esi will return an error 403.
+     * Reverse the migrations.
      *
-     * @param  int  $character_id
-     * @param  int  $citadel_id
-     * @return bool
+     * @return void
      */
-    public static function canAccess(int $character_id, int $citadel_id): bool;
-
-    /**
-     * After having received an error 403, block a character from further accesses.
-     *
-     * @param  int  $character_id
-     * @param  int  $citadel_id
-     * @return mixed
-     */
-    public static function blockAccess(int $character_id, int $citadel_id);
-}
+    public function down()
+    {
+        Schema::drop('citadel_access_cache');
+    }
+};

--- a/src/database/migrations/2025_01_31_210832_add_db_citadel_access_cache.php
+++ b/src/database/migrations/2025_01_31_210832_add_db_citadel_access_cache.php
@@ -24,8 +24,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      *
@@ -38,7 +37,7 @@ return new class extends Migration
             $table->bigInteger('character_id');
             $table->timestamp('last_failed_access')->nullable();
 
-            $table->primary(['citadel_id','character_id']);
+            $table->primary(['citadel_id', 'character_id']);
         });
     }
 


### PR DESCRIPTION
This PR adds an (experimental) option to store the citadel access cache in the database instead of redis to reduce load when frequently restarting the stack on large installs.

It can be enabled by setting `CITADEL_ACCESS_CACHE=db` in your .env

The goal is also to eventually remove the limit of 1 character per citadel per hour that potentially prevents loading citadels when only a few characters can access a citadel.