### PR TITLE
fix: ensure corporation id from factory is unique

### DIFF
--- a/tests/database/factories/CorporationInfoFactory.php
+++ b/tests/database/factories/CorporationInfoFactory.php
@@ -39,7 +39,7 @@ class CorporationInfoFactory extends Factory
     public function definition(): array
     {
         return [
-            'corporation_id' => fake()->numberBetween(98000000, 98001794),
+            'corporation_id' => fake()->unique()->numberBetween(98000000, 98001794),
             'name' => fake()->company,
             'ticker' => fake()->currencyCode,
             'member_count' => fake()->numberBetween(5, 200),


### PR DESCRIPTION
While fixing https://github.com/eveseat/web/pull/702, I got a failure because the corporation_info factory tried to generate two corporations with the same id, violating a database unique constraint.