### PR TITLE
Allow resolving specific universe names

### DIFF
--- a/src/Jobs/Universe/Names.php
+++ b/src/Jobs/Universe/Names.php
@@ -72,10 +72,11 @@ class Names extends EsiBase
     protected $existing_entity_ids;
 
     /**
-     * @param \Illuminate\Support\Collection|null $entity_ids
+     * @param \Illuminate\Support\Collection|null  $entity_ids
+     *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    public function __construct (?Collection $entity_ids = null)
+    public function __construct(?Collection $entity_ids = null)
     {
         parent::__construct();
 
@@ -93,7 +94,7 @@ class Names extends EsiBase
     {
 
         // if no entity IDs were specified, try to resolve all unresolved universe names
-        if (!isset($this->entity_ids)) {
+        if (! isset($this->entity_ids)) {
             $this->entity_ids->push(CharacterWalletJournal::select('first_party_id')
                 ->whereNotNull('first_party_id')
                 ->distinct()

--- a/src/Jobs/Universe/Names.php
+++ b/src/Jobs/Universe/Names.php
@@ -72,7 +72,7 @@ class Names extends EsiBase
     protected $existing_entity_ids;
 
     /**
-     * @param \Illuminate\Support\Collection|null  $entity_ids
+     * @param  \Illuminate\Support\Collection|null  $entity_ids
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */

--- a/src/Jobs/Universe/Names.php
+++ b/src/Jobs/Universe/Names.php
@@ -92,11 +92,6 @@ class Names extends EsiBase
     public function handle()
     {
 
-        $this->existing_entity_ids = UniverseName::select('entity_id')
-            ->distinct()
-            ->get()
-            ->pluck('entity_id');
-
         // if no entity IDs were specified, try to resolve all unresolved universe names
         if (!isset($this->entity_ids)) {
             $this->entity_ids->push(CharacterWalletJournal::select('first_party_id')
@@ -120,6 +115,15 @@ class Names extends EsiBase
                 ->pluck('client_id')
                 ->toArray());
         }
+
+        if ($this->entity_ids->isEmpty()) {
+            return;
+        }
+
+        $this->existing_entity_ids = UniverseName::select('entity_id')
+            ->distinct()
+            ->get()
+            ->pluck('entity_id');
 
         $this->entity_ids->flatten()->diff($this->existing_entity_ids)->values()->chunk($this->items_id_limit)->each(function ($chunk) {
 


### PR DESCRIPTION
Related to [https://github.com/eveseat/notifications/pull/110](https://github.com/eveseat/notifications/pull/110)

Allows querying ESI for a specific list of entity IDs instead of querying for all known unresolved entity IDs. I plan to use this to ensure that the victim and attacker data for a killmail has been loaded before sending kill mail notifications.