### PR TITLE
Fix planet content cleanup.

### DIFF
--- a/src/Jobs/PlanetaryInteraction/Character/PlanetDetail.php
+++ b/src/Jobs/PlanetaryInteraction/Character/PlanetDetail.php
@@ -402,6 +402,7 @@ class PlanetDetail extends AbstractAuthCharacterJob
             $type = $pins->first();
 
             CharacterPlanetContent::where('character_id', $this->getCharacterId())
+                ->where('planet_id', $this->planet_id)
                 ->where('type_id', $type['type_id'])
                 ->whereNotIn('pin_id', $pins->pluck('pin_id'))
                 ->delete();


### PR DESCRIPTION
If multiple characters have different `planet_ids` but share the same `type_id`, this query deletes valid records because it only filters by `character_id` and `type_id` without considering `planet_id`.

This should resolve https://github.com/eveseat/seat/issues/922

The results look promising and align with my expectations, but please let me know if I've overlooked anything or made an error in my reasoning.