### PR TITLE
Performance: randomize citadel access ban durations

### DIFF
--- a/src/Jobs/Universe/Structures/AbstractCitadelAccessCache.php
+++ b/src/Jobs/Universe/Structures/AbstractCitadelAccessCache.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eveapi\Jobs\Universe\Structures;
 
 use Seat\Eveapi\Contracts\CitadelAccessCache;
@@ -7,11 +27,12 @@ use Seat\Eveapi\Contracts\CitadelAccessCache;
 abstract class AbstractCitadelAccessCache implements CitadelAccessCache
 {
     /**
-     * Returns a randomized block duration on the order of self::BLOCK_DURATION_SECONDS
+     * Returns a randomized block duration on the order of self::BLOCK_DURATION_SECONDS.
+     *
      * @return int
      */
     protected static function getRandomizedBlockDuration(): int
     {
-        return rand((int)(self::BLOCK_DURATION_SECONDS*0.5),(int)(self::BLOCK_DURATION_SECONDS*1.5));
+        return rand((int) (self::BLOCK_DURATION_SECONDS * 0.5), (int) (self::BLOCK_DURATION_SECONDS * 1.5));
     }
 }

--- a/src/Jobs/Universe/Structures/AbstractCitadelAccessCache.php
+++ b/src/Jobs/Universe/Structures/AbstractCitadelAccessCache.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Seat\Eveapi\Jobs\Universe\Structures;
+
+use Seat\Eveapi\Contracts\CitadelAccessCache;
+
+abstract class AbstractCitadelAccessCache implements CitadelAccessCache
+{
+    /**
+     * Returns a randomized block duration on the order of self::BLOCK_DURATION_SECONDS
+     * @return int
+     */
+    protected static function getRandomizedBlockDuration(): int
+    {
+        return rand((int)(self::BLOCK_DURATION_SECONDS*0.5),(int)(self::BLOCK_DURATION_SECONDS*1.5));
+    }
+}

--- a/src/Jobs/Universe/Structures/CacheCitadelAccessCache.php
+++ b/src/Jobs/Universe/Structures/CacheCitadelAccessCache.php
@@ -22,8 +22,6 @@
 
 namespace Seat\Eveapi\Jobs\Universe\Structures;
 
-use Seat\Eveapi\Contracts\CitadelAccessCache;
-
 class CacheCitadelAccessCache extends AbstractCitadelAccessCache
 {
     private static function getCacheKey(int $character_id, int $citadel_id) {

--- a/src/Jobs/Universe/Structures/DBCitadelAccessCache.php
+++ b/src/Jobs/Universe/Structures/DBCitadelAccessCache.php
@@ -22,7 +22,6 @@
 
 namespace Seat\Eveapi\Jobs\Universe\Structures;
 
-use Seat\Eveapi\Contracts\CitadelAccessCache;
 use Seat\Eveapi\Models\Universe\CitadelAccessCache as CitadelAccessCacheModel;
 
 class DBCitadelAccessCache extends AbstractCitadelAccessCache

--- a/src/Jobs/Universe/Structures/DBCitadelAccessCache.php
+++ b/src/Jobs/Universe/Structures/DBCitadelAccessCache.php
@@ -25,7 +25,7 @@ namespace Seat\Eveapi\Jobs\Universe\Structures;
 use Seat\Eveapi\Contracts\CitadelAccessCache;
 use Seat\Eveapi\Models\Universe\CitadelAccessCache as CitadelAccessCacheModel;
 
-class DBCitadelAccessCache implements CitadelAccessCache
+class DBCitadelAccessCache extends AbstractCitadelAccessCache
 {
     /**
      * @inheritDoc
@@ -34,7 +34,7 @@ class DBCitadelAccessCache implements CitadelAccessCache
     {
         $entry = CitadelAccessCacheModel::where('character_id', $character_id)
             ->where('citadel_id', $citadel_id)
-            ->where('last_failed_access', '>=', now()->subSeconds(self::BLOCK_DURATION_SECONDS))
+            ->where('next_allowed_access', '>=', now())
             ->first();
 
         if($entry === null) return true;
@@ -57,7 +57,7 @@ class DBCitadelAccessCache implements CitadelAccessCache
             $entry->citadel_id = $citadel_id;
         }
 
-        $entry->last_failed_access = now();
+        $entry->next_allowed_access = now()->addSeconds(self::getRandomizedBlockDuration());
         $entry->save();
     }
 }

--- a/src/database/migrations/2025_04_15_000000_refactor_db_citadel_access_cache.php
+++ b/src/database/migrations/2025_04_15_000000_refactor_db_citadel_access_cache.php
@@ -20,23 +20,33 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-namespace Seat\Eveapi\Jobs\Universe\Structures;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
-use Seat\Eveapi\Contracts\CitadelAccessCache;
-
-class CacheCitadelAccessCache extends AbstractCitadelAccessCache
+return new class extends Migration
 {
-    private static function getCacheKey(int $character_id, int $citadel_id) {
-        return "citadel.$citadel_id.block.$character_id";
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('citadel_access_cache', function (Blueprint $table) {
+            $table->renameColumn('last_failed_access','next_allowed_access');
+        });
     }
 
-    public static function canAccess(int $character_id, int $citadel_id): bool
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
     {
-        return cache()->get(self::getCacheKey($character_id, $citadel_id), true);
+        Schema::table('citadel_access_cache', function (Blueprint $table) {
+            $table->renameColumn('next_allowed_access','last_failed_access');
+        });
     }
-
-    public static function blockAccess(int $character_id, int $citadel_id)
-    {
-        cache()->set(self::getCacheKey($character_id, $citadel_id), false, now()->addSeconds(self::getRandomizedBlockDuration()));
-    }
-}
+};

--- a/src/database/migrations/2025_04_15_000000_refactor_db_citadel_access_cache.php
+++ b/src/database/migrations/2025_04_15_000000_refactor_db_citadel_access_cache.php
@@ -24,8 +24,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      *
@@ -34,7 +33,7 @@ return new class extends Migration
     public function up()
     {
         Schema::table('citadel_access_cache', function (Blueprint $table) {
-            $table->renameColumn('last_failed_access','next_allowed_access');
+            $table->renameColumn('last_failed_access', 'next_allowed_access');
         });
     }
 
@@ -46,7 +45,7 @@ return new class extends Migration
     public function down()
     {
         Schema::table('citadel_access_cache', function (Blueprint $table) {
-            $table->renameColumn('next_allowed_access','last_failed_access');
+            $table->renameColumn('next_allowed_access', 'last_failed_access');
         });
     }
 };


### PR DESCRIPTION
Randomizing citadel access ban durations should hopefully help wibla solve the issue where there are citadel load spikes every 4 weeks. For more details, see the discussion on discord.

This changes requires refactoring how the database citadel access cache works. Before, we stored the time of the last failed attempt. This presents issues when determining if a random timespan has passed. We'd have to generate and store the timespan at the time of job failure so it is not "random" again every time we check. Instead, we now store the time where a next attempt can be made in the DB.

Since `CitadelAccessCache` is an interface, I couldn't add a default method for the randomization. Instead, I've opted to create an intermediary abstract class.