### PR TITLE
fix: trigger corporation info job on corp change

### DIFF
--- a/src/Observers/CharacterAffiliationObserver.php
+++ b/src/Observers/CharacterAffiliationObserver.php
@@ -39,7 +39,21 @@ class CharacterAffiliationObserver
     /**
      * @param  \Seat\Eveapi\Models\Character\CharacterAffiliation  $affiliation
      */
-    public function created(CharacterAffiliation $affiliation)
+    public function created(CharacterAffiliation $affiliation){
+        $this->handle($affiliation);
+    }
+
+    /**
+     * @param  \Seat\Eveapi\Models\Character\CharacterAffiliation  $affiliation
+     */
+    public function updated(CharacterAffiliation $affiliation){
+        $this->handle($affiliation);
+    }
+
+    /**
+     * @param  \Seat\Eveapi\Models\Character\CharacterAffiliation  $affiliation
+     */
+    public function handle(CharacterAffiliation $affiliation)
     {
         if (! CorporationInfo::find($affiliation->corporation_id) && RefreshToken::withTrashed()->find($affiliation->character_id))
             dispatch(new CorporationInfoJob($affiliation->corporation_id))->onQueue('high');


### PR DESCRIPTION
I've recently changed my corporation. Afterwards, I noticed that the SeAT of my old corp didn't pull the corporation_info for the new corp, meaning that for example seat-connector failed to display my new ticker.

This PR changes this so that we pull corporation_infos for character also when they change corporations and not just when they first log into seat.