### PR TITLE
Bye ESI versions, Hello compatibility date - eveapi edition

### DIFF
--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -115,6 +115,13 @@ abstract class EsiBase extends AbstractJob
     protected $version = '';
 
     /**
+     * When this job was written, so ESI can try to serve a response compatible with the behaviour of the endpoint at that time.
+     *
+     * @var string
+     */
+    protected string $compatibility_date = "2025-07-20";
+
+    /**
      * The SSO scope required to make the call.
      *
      * @var string
@@ -301,6 +308,7 @@ abstract class EsiBase extends AbstractJob
     {
         $this->validateCall();
 
+        $this->esi->setCompatibilityDate($this->compatibility_date);
         $this->esi->setBody($this->request_body);
         $this->esi->setQueryString($this->query_string);
 

--- a/src/Jobs/EsiBase.php
+++ b/src/Jobs/EsiBase.php
@@ -108,6 +108,8 @@ abstract class EsiBase extends AbstractJob
      *
      * Eg: v1, v4
      *
+     * @deprecated ESI no longer uses versioned endpoints. Support for this field will be removed in SeAT 6. Until then, setting a version has no effect.
+     *
      * @var int
      */
     protected $version = '';
@@ -299,7 +301,6 @@ abstract class EsiBase extends AbstractJob
     {
         $this->validateCall();
 
-        $this->esi->setVersion($this->version);
         $this->esi->setBody($this->request_body);
         $this->esi->setQueryString($this->query_string);
 
@@ -350,10 +351,6 @@ abstract class EsiBase extends AbstractJob
 
         if (trim($this->endpoint) === '')
             throw new Exception('Empty endpoint used');
-
-        // Enfore a version specification unless this is a 'meta' call.
-        if (trim($this->version) === '' && ! in_array('meta', $this->tags()))
-            throw new Exception('Version is empty');
     }
 
     /**
@@ -374,7 +371,6 @@ abstract class EsiBase extends AbstractJob
             dispatch(new Analytics((new AnalyticsContainer)
                 ->set('type', 'endpoint_warning')
                 ->set('ec', 'unexpected_page')
-                ->set('el', $this->version)
                 ->set('ev', $this->endpoint)))->onQueue('default');
         }
 
@@ -385,7 +381,6 @@ abstract class EsiBase extends AbstractJob
             dispatch(new Analytics((new AnalyticsContainer)
                 ->set('type', 'endpoint_warning')
                 ->set('ec', 'missing_pages')
-                ->set('el', $this->version)
                 ->set('ev', $this->endpoint)))->onQueue('default');
         }
 

--- a/src/Services/EseyeClient.php
+++ b/src/Services/EseyeClient.php
@@ -120,25 +120,6 @@ class EseyeClient implements EsiClient
     }
 
     /**
-     * @return string
-     */
-    public function getVersion(): string
-    {
-        return $this->instance->getVersion();
-    }
-
-    /**
-     * @param  string  $version
-     * @return \Seat\Services\Contracts\EsiClient
-     */
-    public function setVersion(string $version): EsiClient
-    {
-        $this->instance->setVersion($version);
-
-        return $this;
-    }
-
-    /**
      * @return array
      */
     public function getQueryString(): array

--- a/src/Services/EseyeClient.php
+++ b/src/Services/EseyeClient.php
@@ -230,4 +230,21 @@ class EseyeClient implements EsiClient
     {
         return $this->instance->getValidAccessToken()->access_token;
     }
+
+    /**
+     * @param string $date
+     * @return void
+     */
+    public function setCompatibilityDate(string $date): void
+    {
+        $this->instance->setCompatibilityDate($date);
+    }
+
+    /**
+     * @return string
+     */
+    public function getCompatibilityDate(): string
+    {
+        return $this->instance->getCompatibilityDate();
+    }
 }


### PR DESCRIPTION
ESI no longer uses versions in the endpoint URL, and as of right now, they also have no effect. See https://developers.eveonline.com/blog/changing-versions-v42-was-getting-out-of-hand. Instead, there are now compatibility dates.

This PR removes endpoint versions and adds new compatibility dates.

The job classes should stay compatible even if they don't set a compatibility date. This is so esi jobs from e.g. plugins keep working fine. The version property is just deprecated for the same reason.

Todo:
- [ ] remove version constant form jobs
- [ ] add compatibility date to jobs
- [ ] audit middlewares (especially endpoint status) for behavior if version is removed
- [ ] test it a lot

Before merging:
- bump eseye dependency to include https://github.com/eveseat/eseye/pull/103
- bump services version to include https://github.com/eveseat/services/pull/185