### PR TITLE
Fix Character.php for new characters joining seat

### DIFF
--- a/src/Bus/Character.php
+++ b/src/Bus/Character.php
@@ -112,7 +112,7 @@ class Character extends Bus
         );
 
         // integrity check: ensure we have corporation_info for every character
-        if($character->affiliation !== null && $character->affiliation->corporationInfo === null) {
+        if($character->affiliation !== null && $character->affiliation->corporationInfo === null && $character->affiliation->corporation_id !== null) {
             $this->addPublicJob(new CorporationInfoJob($character->affiliation->corporation_id));
         }
 


### PR DESCRIPTION
Corporation ID isn't pulled yet for brand new characters, so the job fails when a new character joins.  This change takes that into account. and fixes https://github.com/eveseat/seat/issues/928