### PR TITLE
get latest build version for ccp seeder

### DIFF
--- a/src/Config/eveapi.config.php
+++ b/src/Config/eveapi.config.php
@@ -21,5 +21,7 @@
  */
 
 return [
-    
+    'sde' => [
+        'version' => env('SDE_VERSION')
+    ]
 ];

--- a/src/database/seeders/CcpSdeSeeder.php
+++ b/src/database/seeders/CcpSdeSeeder.php
@@ -80,6 +80,7 @@ class CcpSdeSeeder extends Seeder
     public function run()
     {
         // extract sde file/seeder mapping from config
+        // $sde_seeders = config('seat.sde.seeders', []);
         // configure sde version
         $this->version = config('eveapi.config.sde.version', $this->version);
         $this->command->info('Checking configuration...');

--- a/src/database/seeders/CcpSdeSeeder.php
+++ b/src/database/seeders/CcpSdeSeeder.php
@@ -98,10 +98,7 @@ class CcpSdeSeeder extends Seeder
         $this->call($this->seeders);
     }
 
-    /**
-     * Download the EVE Sde from Fuzzwork and save it
-     * in the storage_path/sde folder.
-     */
+    
     /**
      * Download the EVE Sde from Fuzzwork and save it
      * in the storage_path/sde folder.
@@ -129,7 +126,6 @@ class CcpSdeSeeder extends Seeder
 
     private function getLatestSdeVersion()
     {
-        $destination = $this->storage_path.'latest.jsonl';
         $result = Http::get('https://developers.eveonline.com/static-data/tranquility/latest.jsonl');
         // fallback to const version
         if(!$result->successful()){

--- a/src/database/seeders/CcpSdeSeeder.php
+++ b/src/database/seeders/CcpSdeSeeder.php
@@ -134,11 +134,13 @@ class CcpSdeSeeder extends Seeder
         // fallback to const version
         if(!$result->successful()){
             $this->command->info('Unable to get latest version, using version: '. $this->version);
+            return;
         }
         $firstLine = strtok($result->body(), "\n");
         $data = json_decode($firstLine, true);
         if(!$data['buildNumber']){
             this->command->info('Unable to get latest build version from response. using version: '. $this->version);
+            return;
         }
         
         $this->version = $data['buildNumber'];

--- a/src/database/seeders/CcpSdeSeeder.php
+++ b/src/database/seeders/CcpSdeSeeder.php
@@ -80,16 +80,13 @@ class CcpSdeSeeder extends Seeder
     public function run()
     {
         // extract sde file/seeder mapping from config
-        // $sde_seeders = config('seat.sde.seeders', []);
-
+        // configure sde version
+        $this->version = config('eveapi.config.sde.version', $this->version);
         $this->command->info('Checking configuration...');
         if (! $this->isStorageOk())
             throw new DirectoryNotFoundException('Storage path is not OK. Please check permissions.');
 
-        $this->command->info('Getting latest SDE Version');
-        $this->getLatestSdeVersion();
-
-        $this->command->info('Authorised Version Found as: ' . $this->version);
+        $this->command->info('Using SDE Version: ' . $this->version);
 
         $this->command->info('Downloading static files...');
         $this->downloadStaticFiles();
@@ -122,24 +119,6 @@ class CcpSdeSeeder extends Seeder
             unlink($destination);
             $this->command->info("Deleted ZIP file: $destination");
         }
-    }
-
-    private function getLatestSdeVersion()
-    {
-        $result = Http::get('https://developers.eveonline.com/static-data/tranquility/latest.jsonl');
-        // fallback to const version
-        if(!$result->successful()){
-            $this->command->info('Unable to get latest version, using version: '. $this->version);
-            return;
-        }
-        $firstLine = strtok($result->body(), "\n");
-        $data = json_decode($firstLine, true);
-        if(!$data['buildNumber']){
-            this->command->info('Unable to get latest build version from response. using version: '. $this->version);
-            return;
-        }
-        
-        $this->version = $data['buildNumber'];
     }
 
     private function extractZipWithProgress(string $zipPath, string $destination): void

--- a/src/database/seeders/CcpSdeSeeder.php
+++ b/src/database/seeders/CcpSdeSeeder.php
@@ -48,7 +48,7 @@ class CcpSdeSeeder extends Seeder
     /**
      * @var string
      */
-    private const VERSION = '3118350';
+    private $version = '3118350';
 
     /**
      * The SDE file storage path.
@@ -86,8 +86,10 @@ class CcpSdeSeeder extends Seeder
         if (! $this->isStorageOk())
             throw new DirectoryNotFoundException('Storage path is not OK. Please check permissions.');
 
-        $this->command->info('Authorised Version Found as: ' . self::VERSION);
+        $this->command->info('Getting latest SDE Version');
+        $this->getLatestSdeVersion();
 
+        $this->command->info('Authorised Version Found as: ' . $this->version);
 
         $this->command->info('Downloading static files...');
         $this->downloadStaticFiles();
@@ -100,10 +102,13 @@ class CcpSdeSeeder extends Seeder
      * Download the EVE Sde from Fuzzwork and save it
      * in the storage_path/sde folder.
      */
+    /**
+     * Download the EVE Sde from Fuzzwork and save it
+     * in the storage_path/sde folder.
+     */
     private function downloadStaticFiles()
     {
-
-        $sde = sprintf('eve-online-static-data-%d-jsonl.zip', self::VERSION);
+        $sde = sprintf('eve-online-static-data-%d-jsonl.zip', $this->version);
 
         $url = sprintf('https://developers.eveonline.com/static-data/tranquility/%s', $sde);
         $destination = $this->storage_path . $sde;
@@ -120,6 +125,23 @@ class CcpSdeSeeder extends Seeder
             unlink($destination);
             $this->command->info("Deleted ZIP file: $destination");
         }
+    }
+
+    private function getLatestSdeVersion()
+    {
+        $destination = $this->storage_path.'latest.jsonl';
+        $result = Http::get('https://developers.eveonline.com/static-data/tranquility/latest.jsonl');
+        // fallback to const version
+        if(!$result->successful()){
+            $this->command->info('Unable to get latest version, using version: '. $this->version);
+        }
+        $firstLine = strtok($result->body(), "\n");
+        $data = json_decode($firstLine, true);
+        if(!$data['buildNumber']){
+            this->command->info('Unable to get latest build version from response. using version: '. $this->version);
+        }
+        
+        $this->version = $data['buildNumber'];
     }
 
     private function extractZipWithProgress(string $zipPath, string $destination): void

--- a/src/database/seeders/Sde/Ccp/InvTypesSeeder.php
+++ b/src/database/seeders/Sde/Ccp/InvTypesSeeder.php
@@ -43,7 +43,7 @@ class InvTypesSeeder extends AbstractSdeSeeder
     {
         $table->integer('typeID')->primary();
         $table->integer('groupID');
-        $table->string('typeName', 100);
+        $table->string('typeName', 150);
         $table->text('description')->nullable();
         $table->double('mass')->nullable();
         $table->double('volume')->nullable();


### PR DESCRIPTION

- Gets latest SDE Build number from [https://developers.eveonline.com/static-data/tranquility/latest.jsonl](https://developers.eveonline.com/static-data/tranquility/latest.jsonl)
- in case of failure, falls back to currently set build number. 
- Updated invTypes.typeName length for larger names in latest SDE.