### PR TITLE
fix's version assignment if environment variable not set

### DIFF
--- a/src/database/seeders/CcpSdeSeeder.php
+++ b/src/database/seeders/CcpSdeSeeder.php
@@ -82,7 +82,7 @@ class CcpSdeSeeder extends Seeder
         // extract sde file/seeder mapping from config
         // $sde_seeders = config('seat.sde.seeders', []);
         // configure sde version
-        $this->version = config('eveapi.config.sde.version', $this->version);
+        $this->version = config('eveapi.config.sde.version') ?? $this->version;
         $this->command->info('Checking configuration...');
         if (! $this->isStorageOk())
             throw new DirectoryNotFoundException('Storage path is not OK. Please check permissions.');


### PR DESCRIPTION
fix's issue when the CCP_SDE_VERSION environment is not set. 

`config('eveapi.config.sde.version', $this->version);` is tecnically set as null, and does not return the fallback version.